### PR TITLE
Switch time representation to java.time

### DIFF
--- a/src/main/kotlin/io/hemin/wien/WienParser.kt
+++ b/src/main/kotlin/io/hemin/wien/WienParser.kt
@@ -114,7 +114,7 @@ object WienParser {
                 }
                 else -> {
                     for (parser in parsers) {
-                        parser.parse(builder, element)
+                        parser.tryParsingChannelChildNode(builder, element)
                     }
                 }
             }
@@ -126,7 +126,7 @@ object WienParser {
         val builder: EpisodeBuilder = ValidatingEpisodeBuilder()
         for (element in childNodes.asListOfNodes()) {
             for (parser in parsers) {
-                parser.parse(builder, element)
+                parser.tryParsingItemChildNode(builder, element)
             }
         }
         builder

--- a/src/main/kotlin/io/hemin/wien/builder/episode/EpisodeBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/episode/EpisodeBuilder.kt
@@ -5,7 +5,7 @@ import io.hemin.wien.builder.ImageBuilder
 import io.hemin.wien.builder.LinkBuilder
 import io.hemin.wien.builder.PersonBuilder
 import io.hemin.wien.model.Episode
-import java.util.Date
+import java.time.temporal.TemporalAccessor
 
 internal interface EpisodeBuilder : Builder<Episode> {
 
@@ -66,7 +66,7 @@ internal interface EpisodeBuilder : Builder<Episode> {
     fun guidBuilder(guidBuilder: EpisodeGuidBuilder?): EpisodeBuilder
 
     /** Set the pubDate value. */
-    fun pubDate(pubDate: Date?): EpisodeBuilder
+    fun pubDate(pubDate: TemporalAccessor?): EpisodeBuilder
 
     /** Set the source value. */
     fun source(source: String?): EpisodeBuilder

--- a/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastBuilder.kt
@@ -6,7 +6,7 @@ import io.hemin.wien.builder.LinkBuilder
 import io.hemin.wien.builder.PersonBuilder
 import io.hemin.wien.builder.episode.EpisodeBuilder
 import io.hemin.wien.model.Podcast
-import java.util.Date
+import java.time.temporal.TemporalAccessor
 
 internal interface PodcastBuilder : Builder<Podcast> {
 
@@ -35,10 +35,10 @@ internal interface PodcastBuilder : Builder<Podcast> {
     fun description(description: String): PodcastBuilder
 
     /** Set the pubDate value. */
-    fun pubDate(pubDate: Date?): PodcastBuilder
+    fun pubDate(pubDate: TemporalAccessor?): PodcastBuilder
 
     /** Set the lastBuildDate value. */
-    fun lastBuildDate(lastBuildDate: Date?): PodcastBuilder
+    fun lastBuildDate(lastBuildDate: TemporalAccessor?): PodcastBuilder
 
     /** Set the language value. */
     fun language(language: String): PodcastBuilder

--- a/src/main/kotlin/io/hemin/wien/builder/validating/episode/ValidatingEpisodeBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/validating/episode/ValidatingEpisodeBuilder.kt
@@ -17,7 +17,7 @@ import io.hemin.wien.builder.validating.ValidatingImageBuilder
 import io.hemin.wien.builder.validating.ValidatingLinkBuilder
 import io.hemin.wien.builder.validating.ValidatingPersonBuilder
 import io.hemin.wien.model.Episode
-import java.util.Date
+import java.time.temporal.TemporalAccessor
 
 internal class ValidatingEpisodeBuilder : EpisodeBuilder {
 
@@ -30,7 +30,7 @@ internal class ValidatingEpisodeBuilder : EpisodeBuilder {
     private val categories: MutableList<String> = mutableListOf()
     private var comments: String? = null
     private var guidBuilder: EpisodeGuidBuilder? = null
-    private var pubDate: Date? = null
+    private var pubDate: TemporalAccessor? = null
     private var source: String? = null
 
     override val content: EpisodeContentBuilder = ValidatingEpisodeContentBuilder()
@@ -65,7 +65,7 @@ internal class ValidatingEpisodeBuilder : EpisodeBuilder {
 
     override fun guidBuilder(guidBuilder: EpisodeGuidBuilder?): EpisodeBuilder = apply { this.guidBuilder = guidBuilder }
 
-    override fun pubDate(pubDate: Date?): EpisodeBuilder = apply { this.pubDate = pubDate }
+    override fun pubDate(pubDate: TemporalAccessor?): EpisodeBuilder = apply { this.pubDate = pubDate }
 
     override fun source(source: String?): EpisodeBuilder = apply { this.source = source }
 

--- a/src/main/kotlin/io/hemin/wien/builder/validating/podcast/ValidatingPodcastBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/validating/podcast/ValidatingPodcastBuilder.kt
@@ -14,7 +14,7 @@ import io.hemin.wien.builder.validating.ValidatingImageBuilder
 import io.hemin.wien.builder.validating.ValidatingLinkBuilder
 import io.hemin.wien.builder.validating.ValidatingPersonBuilder
 import io.hemin.wien.model.Podcast
-import java.util.Date
+import java.time.temporal.TemporalAccessor
 
 internal class ValidatingPodcastBuilder : PodcastBuilder {
 
@@ -23,8 +23,8 @@ internal class ValidatingPodcastBuilder : PodcastBuilder {
     private lateinit var descriptionValue: String
     private lateinit var languageValue: String
 
-    private var pubDate: Date? = null
-    private var lastBuildDate: Date? = null
+    private var pubDate: TemporalAccessor? = null
+    private var lastBuildDate: TemporalAccessor? = null
     private var generator: String? = null
     private var copyright: String? = null
     private var docs: String? = null
@@ -50,9 +50,9 @@ internal class ValidatingPodcastBuilder : PodcastBuilder {
 
     override fun description(description: String): PodcastBuilder = apply { this.descriptionValue = description }
 
-    override fun pubDate(pubDate: Date?): PodcastBuilder = apply { this.pubDate = pubDate }
+    override fun pubDate(pubDate: TemporalAccessor?): PodcastBuilder = apply { this.pubDate = pubDate }
 
-    override fun lastBuildDate(lastBuildDate: Date?): PodcastBuilder = apply { this.lastBuildDate = lastBuildDate }
+    override fun lastBuildDate(lastBuildDate: TemporalAccessor?): PodcastBuilder = apply { this.lastBuildDate = lastBuildDate }
 
     override fun language(language: String): PodcastBuilder = apply { this.languageValue = language }
 

--- a/src/main/kotlin/io/hemin/wien/model/Episode.kt
+++ b/src/main/kotlin/io/hemin/wien/model/Episode.kt
@@ -1,7 +1,7 @@
 package io.hemin.wien.model
 
 import io.hemin.wien.model.Episode.Podlove.SimpleChapter
-import java.util.Date
+import java.time.temporal.TemporalAccessor
 
 /**
  * Model class for all the properties extracted by parser implementations from RSS `<item>` elements.
@@ -23,6 +23,7 @@ import java.util.Date
  * @property googlePlay The data from the Google Play namespace, or null if no data from this namespace was found.
  * @property bitlove The data from the Bitlove namespace, or null if no data from this namespace was found.
  */
+@Suppress("unused")
 data class Episode(
     val title: String,
     val link: String? = null,
@@ -32,7 +33,7 @@ data class Episode(
     val comments: String? = null,
     val enclosure: Enclosure,
     val guid: Guid? = null,
-    val pubDate: Date? = null,
+    val pubDate: TemporalAccessor? = null,
     val source: String? = null,
     val content: Content? = null,
     val iTunes: ITunes? = null,
@@ -100,6 +101,7 @@ data class Episode(
         override val subtitle: String? = null,
         override val summary: String? = null
     ) : ITunesBase {
+
         /**
          * Enum model for the defined values encountered within the
          * `<itunes:episodeType>` element within a `<item>` element.

--- a/src/main/kotlin/io/hemin/wien/model/Podcast.kt
+++ b/src/main/kotlin/io/hemin/wien/model/Podcast.kt
@@ -1,6 +1,6 @@
 package io.hemin.wien.model
 
-import java.util.Date
+import java.time.temporal.TemporalAccessor
 
 /**
  * Model class for all the properties extracted by parser implementations from RSS `<channel>` elements.
@@ -28,8 +28,8 @@ data class Podcast(
     val title: String,
     val link: String,
     val description: String,
-    val pubDate: Date? = null,
-    val lastBuildDate: Date? = null,
+    val pubDate: TemporalAccessor? = null,
+    val lastBuildDate: TemporalAccessor? = null,
     val language: String,
     val generator: String? = null,
     val copyright: String? = null,

--- a/src/main/kotlin/io/hemin/wien/parser/DateParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/DateParser.kt
@@ -80,7 +80,7 @@ internal object DateParser {
             .optionalEnd() // End [ [x]]
             .toFormatter(),
 
-        DateTimeFormatter.ISO_DATE_TIME // ISO-8601: 2011-12-03T10:15{:30{.100}}{+01:00{[Europe/Paris]}}
+        DateTimeFormatter.ISO_DATE_TIME // ISO-8601: 2011-12-03T10:15[:30[.100]][+01:00'['Europe/Paris']']
     )
 
     /**
@@ -95,9 +95,8 @@ internal object DateParser {
 
         for (formatter in formatters) {
             return try {
-                val parsed = formatter.withLocale(locale)
+                formatter.withLocale(locale)
                     .parseBest(trimmedValue, ZonedDateTime::from, LocalDateTime::from)
-                parsed
             } catch (ignored: DateTimeParseException) {
                 continue
             }

--- a/src/main/kotlin/io/hemin/wien/parser/DateParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/DateParser.kt
@@ -1,8 +1,13 @@
 package io.hemin.wien.parser
 
-import java.text.ParsePosition
-import java.text.SimpleDateFormat
-import java.util.Date
+import java.time.LocalDateTime
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatterBuilder
+import java.time.format.DateTimeParseException
+import java.time.format.SignStyle
+import java.time.temporal.ChronoField
+import java.time.temporal.TemporalAccessor
 import java.util.Locale
 
 /**
@@ -10,74 +15,94 @@ import java.util.Locale
  * Various formats are supported. This class attempts to find the correct
  * format to produce the intended date object.
  */
-internal class DateParser {
+internal object DateParser {
 
-    companion object {
+    private val dayOfWeek = mapOf(
+        1L to "Mon",
+        2L to "Tue",
+        3L to "Wed",
+        4L to "Thu",
+        5L to "Fri",
+        6L to "Sat",
+        7L to "Sun"
+    )
 
-        private val masks = arrayOf(
-            "EEE, dd MMM yy HH:mm:ss z",
-            "EEE, dd MMM yy HH:mm z",
-            "dd MMM yy HH:mm:ss z",
-            "dd MMM yy HH:mm z",
-            "yyyy-MM-dd'T'HH:mm:ss.SSSz",
-            "yyyy-MM-dd't'HH:mm:ss.SSSz",
-            "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
-            "yyyy-MM-dd't'HH:mm:ss.SSS'z'",
-            "yyyy-MM-dd'T'HH:mm:ssz",
-            "yyyy-MM-dd't'HH:mm:ssz",
-            "yyyy-MM-dd'T'HH:mm:ssZ",
-            "yyyy-MM-dd't'HH:mm:ssZ",
-            "yyyy-MM-dd'T'HH:mm:ss'Z'",
-            "yyyy-MM-dd't'HH:mm:ss'z'",
-            "yyyy-MM-dd'T'HH:mmz",
-            "yyyy-MM'T'HH:mmz",
-            "yyyy'T'HH:mmz",
-            "yyyy-MM-dd't'HH:mmz",
-            "yyyy-MM-dd'T'HH:mm'Z'",
-            "yyyy-MM-dd't'HH:mm'z'",
-            "yyyy-MM-dd",
-            "yyyy-MM",
-            "yyyy"
-        )
+    private val monthOfYear = mapOf(
+        1L to "Jan",
+        2L to "Feb",
+        3L to "Mar",
+        4L to "Apr",
+        5L to "May",
+        6L to "Jun",
+        7L to "Jul",
+        8L to "Aug",
+        9L to "Sep",
+        10L to "Oct",
+        11L to "Nov",
+        12L to "Dec"
+    )
 
-        /**
-         * Parses a string into a date object, if the string represents a valid date format.
-         * Uses `en-US` as the locale.
-         *
-         * @param value The string representation of a date.
-         * @return The date object defined by the string, or null of parsing was unsuccessful.
-         */
-        fun parse(value: String?): Date? = parse(value, Locale.forLanguageTag("en-US"))
+    // Attempt to parse RFC-(2)822/RFC-1123 first, fallback on ISO-8601.
+    // Our RFC parser is based on DateTimeFormatter#RFC_1123_DATE_TIME, but is much more
+    // lenient in parsing weird stuff. Because as y'all know time is bloody hard to do right.
+    // Note: brackets indicate optional parts in the pattern
+    private val formatters = listOf(
+        DateTimeFormatterBuilder().parseCaseInsensitive() // RFC-(2)822/RFC-1123 (-ish): [Tue, ]3 Dec 2011 10:15[:30[.123]][ +0100]
+            .parseLenient()
+            // Start of date section
+            // Optional EEE: day of week (in English, 3 letters)
+            .optionalStart()
+            .appendText(ChronoField.DAY_OF_WEEK, dayOfWeek)
+            .appendLiteral(", ")
+            .optionalEnd()
+            // [d]d MMM yy: day number (1 or 2 digits), month name (in English, 3 letters), year (4 digits)
+            .appendValue(ChronoField.DAY_OF_MONTH, 1, 2, SignStyle.NOT_NEGATIVE)
+            .appendLiteral(' ')
+            .appendText(ChronoField.MONTH_OF_YEAR, monthOfYear)
+            .appendLiteral(' ')
+            .appendValue(ChronoField.YEAR, 4)
+            .appendLiteral(' ')
+            // Start of time section
+            .appendValue(ChronoField.HOUR_OF_DAY, 2)
+            .appendLiteral(':')
+            .appendValue(ChronoField.MINUTE_OF_HOUR, 2)
+            .optionalStart() // Start [:ss[.SSS]]
+            .appendLiteral(':')
+            .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
+            .optionalStart() // Start [.SSS]
+            .appendLiteral('.')
+            .appendValue(ChronoField.MILLI_OF_SECOND, 3)
+            .optionalEnd() // End [.SSS]
+            .optionalEnd() // End [:ss[.SSS]]
+            .optionalStart() // Start [ [x]]
+            .appendLiteral(' ')
+            .appendOffset("+HHMM", "GMT") // (fallback to GMT when missing)
+            .optionalEnd() // End [ [x]]
+            .toFormatter(),
 
-        /**
-         * Parses a string into a date object, if the string represents a valid date format.
-         *
-         * @param value The string representation of a date.
-         * @return The date object defined by the string, or null of parsing was unsuccessful.
-         */
-        fun parse(value: String?, locale: Locale): Date? {
-            var d: Date? = null
-            value?.let {
-                val sDate = it.trim()
-                var pp: ParsePosition?
-                var i = 0
-                while (d == null && i < masks.size) {
-                    val df = SimpleDateFormat(masks[i], locale)
-                    df.isLenient = true
-                    try {
-                        pp = ParsePosition(0)
-                        d = df.parse(sDate, pp)
-                        if (pp.index != sDate.length) {
-                            d = null
-                        }
-                    } catch (ex: NullPointerException) {
-                        d = null
-                    }
+        DateTimeFormatter.ISO_DATE_TIME // ISO-8601: 2011-12-03T10:15{:30{.100}}{+01:00{[Europe/Paris]}}
+    )
 
-                    i++
-                }
+    /**
+     * Parses a string into a date object, if the string represents a valid date format.
+     *
+     * @param value The string representation of a date.
+     * @return The date object defined by the string, or null of parsing was unsuccessful.
+     */
+    fun parse(value: String?, locale: Locale = Locale.US): TemporalAccessor? {
+        if (value.isNullOrBlank()) return null
+        val trimmedValue = value.trim()
+
+        for (formatter in formatters) {
+            return try {
+                val parsed = formatter.withLocale(locale)
+                    .parseBest(trimmedValue, ZonedDateTime::from, LocalDateTime::from)
+                parsed
+            } catch (ignored: DateTimeParseException) {
+                continue
             }
-            return d
         }
+
+        return null
     }
 }

--- a/src/main/kotlin/io/hemin/wien/parser/NamespaceParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/NamespaceParser.kt
@@ -78,7 +78,7 @@ internal abstract class NamespaceParser {
      *
      * @return The content of the DOM node in string representation, or null.
      */
-    protected fun textOrNull(node: Node): String? = ifMatchesNamespace(node) {
+    protected fun Node.textOrNull(): String? = this.ifMatchesNamespace() {
         it.textContent.trimmedOrNullIfBlank()
     }
 
@@ -89,8 +89,8 @@ internal abstract class NamespaceParser {
      * @see parseAsBooleanOrNull
      * @return The logical interpretation of the DOM node's text content as boolean, or `null`.
      */
-    protected fun textAsBooleanOrNull(node: Node): Boolean? = ifMatchesNamespace(node) {
-        textOrNull(it).parseAsBooleanOrNull()
+    protected fun Node.textAsBooleanOrNull(): Boolean? = this.ifMatchesNamespace() {
+        it.textOrNull().parseAsBooleanOrNull()
     }
 
     /**
@@ -110,8 +110,8 @@ internal abstract class NamespaceParser {
      *
      * @return The DOM nodes content as an Int, or null if conversion failed.
      */
-    protected fun toInt(node: Node): Int? = ifMatchesNamespace(node) {
-        textOrNull(it)?.toIntOrNull()
+    protected fun Node.toInt(): Int? = this.ifMatchesNamespace() {
+        it.textOrNull()?.toIntOrNull()
     }
 
     /**
@@ -120,29 +120,28 @@ internal abstract class NamespaceParser {
      *
      * @return The DOM nodes content as an Int, or null if parsing failed.
      */
-    protected fun toDate(node: Node): TemporalAccessor? = ifMatchesNamespace(node) {
-        DateParser.parse(textOrNull(it))
+    protected fun Node.toDate(): TemporalAccessor? = this.ifMatchesNamespace() {
+        DateParser.parse(it.textOrNull())
     }
 
     /**
      * Extract the textContent of a DOM node attribute identified by name.
      *
-     * @param node The DOM node with the attribute.
      * @param attributeName The name of the node's attribute.
      * @return The textContent of the node's attribute.
      */
-    protected fun attributeValueByName(node: Node, attributeName: String): String? =
-        node.attributes?.getNamedItem(attributeName)?.textContent?.trim()
+    protected fun Node.attributeValueByName(attributeName: String): String? =
+        attributes?.getNamedItem(attributeName)?.textContent?.trim()
 
     /**
      * Executes a block of code on a DOM node if the node has the same [namespaceURI] of this parser.
      *
-     * @param node The DOM node to execute the [block] of code on.
-     * @param block The block of code to execute on the [node] when the namespace matches the parser's.
+     * @param this@ifMatchesNamespace The DOM node to execute the [block] of code on.
+     * @param block The block of code to execute on the [this@ifMatchesNamespace] when the namespace matches the parser's.
      */
-    protected fun <T> ifMatchesNamespace(node: Node, block: (Node) -> T?) =
-        if (node.canParseNode()) {
-            block(node)
+    protected fun <T> Node.ifMatchesNamespace(block: (Node) -> T?) =
+        if (canParseNode()) {
+            block(this)
         } else {
             null
         }

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/AtomParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/AtomParser.kt
@@ -53,28 +53,28 @@ internal class AtomParser : NamespaceParser() {
         }
     }
 
-    private fun toLinkBuilder(node: Node, linkBuilder: LinkBuilder): LinkBuilder? = ifMatchesNamespace(node) {
-        val href = attributeValueByName(it, "href") ?: return@ifMatchesNamespace null
+    private fun toLinkBuilder(node: Node, linkBuilder: LinkBuilder): LinkBuilder? = node.ifMatchesNamespace() {
+        val href = it.attributeValueByName("href") ?: return@ifMatchesNamespace null
 
         linkBuilder
             .href(href)
-            .hrefLang(attributeValueByName(it, "hrefLang"))
-            .hrefResolved(attributeValueByName(it, "hrefResolved"))
-            .length(attributeValueByName(it, "length"))
-            .rel(attributeValueByName(it, "rel"))
-            .title(attributeValueByName(it, "title"))
-            .type(attributeValueByName(it, "type"))
+            .hrefLang(it.attributeValueByName("hrefLang"))
+            .hrefResolved(it.attributeValueByName("hrefResolved"))
+            .length(it.attributeValueByName("length"))
+            .rel(it.attributeValueByName("rel"))
+            .title(it.attributeValueByName("title"))
+            .type(it.attributeValueByName("type"))
     }
 
-    private fun toPersonBuilder(node: Node, personBuilder: PersonBuilder): PersonBuilder? = ifMatchesNamespace(node) {
+    private fun toPersonBuilder(node: Node, personBuilder: PersonBuilder): PersonBuilder? = node.ifMatchesNamespace() {
         for (child in node.childNodes.asListOfNodes()) {
             when (child.localName) {
                 "name" -> {
-                    val name = textOrNull(child)
+                    val name = child.textOrNull()
                     if (name != null) personBuilder.name(name)
                 }
-                "email" -> personBuilder.email(textOrNull(child))
-                "uri" -> personBuilder.uri(textOrNull(child))
+                "email" -> personBuilder.email(child.textOrNull())
+                "uri" -> personBuilder.uri(child.textOrNull())
             }
         }
         personBuilder

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/AtomParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/AtomParser.kt
@@ -17,44 +17,44 @@ internal class AtomParser : NamespaceParser() {
 
     override val namespaceURI: String = "http://www.w3.org/2005/Atom"
 
-    override fun parse(builder: PodcastBuilder, node: Node) = valid(node) {
+    override fun parseChannelNode(builder: PodcastBuilder, node: Node) {
         when (node.localName) {
             "contributor" -> {
-                val personBuilder = toPersonBuilder(node, builder.createPersonBuilder()) ?: return@valid
+                val personBuilder = toPersonBuilder(node, builder.createPersonBuilder()) ?: return
                 builder.atom.addContributorBuilder(personBuilder)
             }
             "author" -> {
-                val personBuilder = toPersonBuilder(node, builder.createPersonBuilder()) ?: return@valid
+                val personBuilder = toPersonBuilder(node, builder.createPersonBuilder()) ?: return
                 builder.atom.addAuthorBuilder(personBuilder)
             }
             "link" -> {
-                val linkBuilder = toLinkBuilder(node, builder.createLinkBuilder()) ?: return@valid
+                val linkBuilder = toLinkBuilder(node, builder.createLinkBuilder()) ?: return
                 builder.atom.addLinkBuilder(linkBuilder)
             }
             else -> pass
         }
     }
 
-    override fun parse(builder: EpisodeBuilder, node: Node) = valid(node) {
+    override fun parseItemNode(builder: EpisodeBuilder, node: Node) {
         when (node.localName) {
             "contributor" -> {
-                val person = toPersonBuilder(node, builder.createPersonBuilder()) ?: return@valid
+                val person = toPersonBuilder(node, builder.createPersonBuilder()) ?: return
                 builder.atom.addContributorBuilder(person)
             }
             "author" -> {
-                val person = toPersonBuilder(node, builder.createPersonBuilder()) ?: return@valid
+                val person = toPersonBuilder(node, builder.createPersonBuilder()) ?: return
                 builder.atom.addAuthorBuilder(person)
             }
             "link" -> {
-                val link = toLinkBuilder(node, builder.createLinkBuilder()) ?: return@valid
+                val link = toLinkBuilder(node, builder.createLinkBuilder()) ?: return
                 builder.atom.addLinkBuilder(link)
             }
             else -> pass
         }
     }
 
-    private fun toLinkBuilder(node: Node, linkBuilder: LinkBuilder): LinkBuilder? = valid(node) {
-        val href = attributeValueByName(it, "href") ?: return@valid null
+    private fun toLinkBuilder(node: Node, linkBuilder: LinkBuilder): LinkBuilder? = ifMatchesNamespace(node) {
+        val href = attributeValueByName(it, "href") ?: return@ifMatchesNamespace null
 
         linkBuilder
             .href(href)
@@ -66,15 +66,15 @@ internal class AtomParser : NamespaceParser() {
             .type(attributeValueByName(it, "type"))
     }
 
-    private fun toPersonBuilder(node: Node, personBuilder: PersonBuilder): PersonBuilder? = valid(node) {
+    private fun toPersonBuilder(node: Node, personBuilder: PersonBuilder): PersonBuilder? = ifMatchesNamespace(node) {
         for (child in node.childNodes.asListOfNodes()) {
             when (child.localName) {
                 "name" -> {
-                    val name = toText(child)
+                    val name = textOrNull(child)
                     if (name != null) personBuilder.name(name)
                 }
-                "email" -> personBuilder.email(toText(child))
-                "uri" -> personBuilder.uri(toText(child))
+                "email" -> personBuilder.email(textOrNull(child))
+                "uri" -> personBuilder.uri(textOrNull(child))
             }
         }
         personBuilder

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/BitloveParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/BitloveParser.kt
@@ -14,20 +14,17 @@ internal class BitloveParser : NamespaceParser() {
 
     override val namespaceURI: String = "http://bitlove.org"
 
-    override fun parse(builder: PodcastBuilder, node: Node) {}
-
-    override fun parse(builder: EpisodeBuilder, node: Node) {
-        if (node.namespaceURI == null && node.localName == "enclosure") {
-            val guid = toGuid(node) ?: return
-            builder.bitlove.guid(guid)
-        }
+    override fun parseChannelNode(builder: PodcastBuilder, node: Node) {
+        // No-op
     }
 
-    /**
-     * Extracts the Bitlove GUID attribute from the DOM node.
-     *
-     * @return The DOM nodes GUID attribute value from the Bitlove namespace, if present.
-     */
+    override fun parseItemNode(builder: EpisodeBuilder, node: Node) {
+        val guid = toGuid(node) ?: return
+        builder.bitlove.guid(guid)
+    }
+
+    override fun Node.canParseNode() = namespaceURI == null && localName == "enclosure" && isDirectChildOf("item")
+
     private fun toGuid(node: Node): String? =
         node.attributes?.getNamedItemNS(namespaceURI, "guid")?.textContent?.trim()
 }

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/ContentParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/ContentParser.kt
@@ -12,20 +12,16 @@ import org.w3c.dom.Node
  */
 internal class ContentParser : NamespaceParser() {
 
-    /**
-     * The URI of the namespace processed by this parser.
-     *
-     * URI: `http://purl.org/rss/1.0/modules/content/`
-     */
     override val namespaceURI: String = "http://purl.org/rss/1.0/modules/content/"
 
-    /** This module does not set any data in the [PodcastBuilder]. */
-    override fun parse(builder: PodcastBuilder, node: Node) {}
+    override fun parseChannelNode(builder: PodcastBuilder, node: Node) {
+        // No-op
+    }
 
-    override fun parse(builder: EpisodeBuilder, node: Node) = valid(node) {
+    override fun parseItemNode(builder: EpisodeBuilder, node: Node) {
         when (node.localName) {
             "encoded" -> {
-                val encoded = toText(node)
+                val encoded = textOrNull(node)
                 if (encoded != null) builder.content.encoded(encoded)
             }
             else -> pass

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/ContentParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/ContentParser.kt
@@ -21,7 +21,7 @@ internal class ContentParser : NamespaceParser() {
     override fun parseItemNode(builder: EpisodeBuilder, node: Node) {
         when (node.localName) {
             "encoded" -> {
-                val encoded = textOrNull(node)
+                val encoded = node.textOrNull()
                 if (encoded != null) builder.content.encoded(encoded)
             }
             else -> pass

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/FeedpressParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/FeedpressParser.kt
@@ -16,11 +16,11 @@ internal class FeedpressParser : NamespaceParser() {
 
     override fun parseChannelNode(builder: PodcastBuilder, node: Node) {
         when (node.localName) {
-            "newsletterId" -> builder.feedpress.newsletterId(textOrNull(node))
-            "locale" -> builder.feedpress.locale(textOrNull(node))
-            "podcastId" -> builder.feedpress.podcastId(textOrNull(node))
-            "cssFile" -> builder.feedpress.cssFile(textOrNull(node))
-            "link" -> builder.feedpress.link(textOrNull(node))
+            "newsletterId" -> builder.feedpress.newsletterId(node.textOrNull())
+            "locale" -> builder.feedpress.locale(node.textOrNull())
+            "podcastId" -> builder.feedpress.podcastId(node.textOrNull())
+            "cssFile" -> builder.feedpress.cssFile(node.textOrNull())
+            "link" -> builder.feedpress.link(node.textOrNull())
             else -> pass
         }
     }

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/FeedpressParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/FeedpressParser.kt
@@ -14,17 +14,18 @@ internal class FeedpressParser : NamespaceParser() {
 
     override val namespaceURI: String = "https://feed.press/xmlns"
 
-    override fun parse(builder: PodcastBuilder, node: Node) = valid(node) {
+    override fun parseChannelNode(builder: PodcastBuilder, node: Node) {
         when (node.localName) {
-            "newsletterId" -> builder.feedpress.newsletterId(toText(node))
-            "locale" -> builder.feedpress.locale(toText(node))
-            "podcastId" -> builder.feedpress.podcastId(toText(node))
-            "cssFile" -> builder.feedpress.cssFile(toText(node))
-            "link" -> builder.feedpress.link(toText(node))
+            "newsletterId" -> builder.feedpress.newsletterId(textOrNull(node))
+            "locale" -> builder.feedpress.locale(textOrNull(node))
+            "podcastId" -> builder.feedpress.podcastId(textOrNull(node))
+            "cssFile" -> builder.feedpress.cssFile(textOrNull(node))
+            "link" -> builder.feedpress.link(textOrNull(node))
             else -> pass
         }
     }
 
-    /** This module does not set any data in the [EpisodeBuilder]. */
-    override fun parse(builder: EpisodeBuilder, node: Node) {}
+    override fun parseItemNode(builder: EpisodeBuilder, node: Node) {
+        // No-op
+    }
 }

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/FyydParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/FyydParser.kt
@@ -17,7 +17,7 @@ internal class FyydParser : NamespaceParser() {
     override fun parseChannelNode(builder: PodcastBuilder, node: Node) {
         when (node.localName) {
             "verify" -> {
-                val verify = textOrNull(node) ?: return
+                val verify = node.textOrNull() ?: return
                 builder.fyyd.verify(verify)
             }
             else -> pass

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/FyydParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/FyydParser.kt
@@ -14,16 +14,17 @@ internal class FyydParser : NamespaceParser() {
 
     override val namespaceURI: String = "https://fyyd.de/fyyd-ns/"
 
-    override fun parse(builder: PodcastBuilder, node: Node) = valid(node) {
+    override fun parseChannelNode(builder: PodcastBuilder, node: Node) {
         when (node.localName) {
             "verify" -> {
-                val verify = toText(node) ?: return@valid
+                val verify = textOrNull(node) ?: return
                 builder.fyyd.verify(verify)
             }
             else -> pass
         }
     }
 
-    /** This module does not set any data in the [EpisodeBuilder]. */
-    override fun parse(builder: EpisodeBuilder, node: Node) {}
+    override fun parseItemNode(builder: EpisodeBuilder, node: Node) {
+        // No-op
+    }
 }

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/GooglePlayParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/GooglePlayParser.kt
@@ -17,15 +17,15 @@ internal class GooglePlayParser : NamespaceParser() {
 
     override fun parseChannelNode(builder: PodcastBuilder, node: Node) {
         when (node.localName) {
-            "author" -> builder.googlePlay.author(textOrNull(node))
-            "owner" -> builder.googlePlay.owner(textOrNull(node))
+            "author" -> builder.googlePlay.author(node.textOrNull())
+            "owner" -> builder.googlePlay.owner(node.textOrNull())
             "category" -> {
                 val category = node.attributes.getNamedItem("text").textContent ?: return
                 builder.googlePlay.addCategory(category)
             }
-            "description" -> builder.googlePlay.description(textOrNull(node))
-            "explicit" -> builder.googlePlay.explicit(textAsBooleanOrNull(node))
-            "block" -> builder.googlePlay.block(textAsBooleanOrNull(node))
+            "description" -> builder.googlePlay.description(node.textOrNull())
+            "explicit" -> builder.googlePlay.explicit(node.textAsBooleanOrNull())
+            "block" -> builder.googlePlay.block(node.textAsBooleanOrNull())
             "image" -> builder.googlePlay.imageBuilder(toImageBuilder(node, builder.createImageBuilder()))
             else -> pass
         }
@@ -33,16 +33,16 @@ internal class GooglePlayParser : NamespaceParser() {
 
     override fun parseItemNode(builder: EpisodeBuilder, node: Node) {
         when (node.localName) {
-            "description" -> builder.googlePlay.description(textOrNull(node))
-            "explicit" -> builder.googlePlay.explicit(textAsBooleanOrNull(node))
-            "block" -> builder.googlePlay.block(textAsBooleanOrNull(node))
+            "description" -> builder.googlePlay.description(node.textOrNull())
+            "explicit" -> builder.googlePlay.explicit(node.textAsBooleanOrNull())
+            "block" -> builder.googlePlay.block(node.textAsBooleanOrNull())
             "image" -> builder.googlePlay.imageBuilder(toImageBuilder(node, builder.createImageBuilder()))
             else -> pass
         }
     }
 
-    private fun toImageBuilder(node: Node, imageBuilder: ImageBuilder): ImageBuilder? = ifMatchesNamespace(node) {
-        val url: String? = attributeValueByName(node, "href")
+    private fun toImageBuilder(node: Node, imageBuilder: ImageBuilder): ImageBuilder? = node.ifMatchesNamespace() {
+        val url: String? = node.attributeValueByName("href")
         if (url.isNullOrBlank()) {
             null
         } else {

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/GooglePlayParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/GooglePlayParser.kt
@@ -13,40 +13,35 @@ import org.w3c.dom.Node
  */
 internal class GooglePlayParser : NamespaceParser() {
 
-    /**
-     * The URI of the namespace processed by this parser.
-     *
-     * URI: `http://www.google.com/schemas/play-podcasts/1.0`
-     */
     override val namespaceURI: String = "http://www.google.com/schemas/play-podcasts/1.0"
 
-    override fun parse(builder: PodcastBuilder, node: Node) = valid(node) {
+    override fun parseChannelNode(builder: PodcastBuilder, node: Node) {
         when (node.localName) {
-            "author" -> builder.googlePlay.author(toText(node))
-            "owner" -> builder.googlePlay.owner(toText(node))
+            "author" -> builder.googlePlay.author(textOrNull(node))
+            "owner" -> builder.googlePlay.owner(textOrNull(node))
             "category" -> {
-                val category = node.attributes.getNamedItem("text").textContent ?: return@valid
+                val category = node.attributes.getNamedItem("text").textContent ?: return
                 builder.googlePlay.addCategory(category)
             }
-            "description" -> builder.googlePlay.description(toText(node))
-            "explicit" -> builder.googlePlay.explicit(toBoolean(node))
-            "block" -> builder.googlePlay.block(toBoolean(node))
+            "description" -> builder.googlePlay.description(textOrNull(node))
+            "explicit" -> builder.googlePlay.explicit(textAsBooleanOrNull(node))
+            "block" -> builder.googlePlay.block(textAsBooleanOrNull(node))
             "image" -> builder.googlePlay.imageBuilder(toImageBuilder(node, builder.createImageBuilder()))
             else -> pass
         }
     }
 
-    override fun parse(builder: EpisodeBuilder, node: Node) = valid(node) {
+    override fun parseItemNode(builder: EpisodeBuilder, node: Node) {
         when (node.localName) {
-            "description" -> builder.googlePlay.description(toText(node))
-            "explicit" -> builder.googlePlay.explicit(toBoolean(node))
-            "block" -> builder.googlePlay.block(toBoolean(node))
+            "description" -> builder.googlePlay.description(textOrNull(node))
+            "explicit" -> builder.googlePlay.explicit(textAsBooleanOrNull(node))
+            "block" -> builder.googlePlay.block(textAsBooleanOrNull(node))
             "image" -> builder.googlePlay.imageBuilder(toImageBuilder(node, builder.createImageBuilder()))
             else -> pass
         }
     }
 
-    private fun toImageBuilder(node: Node, imageBuilder: ImageBuilder): ImageBuilder? = valid(node) {
+    private fun toImageBuilder(node: Node, imageBuilder: ImageBuilder): ImageBuilder? = ifMatchesNamespace(node) {
         val url: String? = attributeValueByName(node, "href")
         if (url.isNullOrBlank()) {
             null

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/ITunesParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/ITunesParser.kt
@@ -15,71 +15,65 @@ import org.w3c.dom.Node
  */
 internal class ITunesParser : NamespaceParser() {
 
-    /**
-     * The URI of the namespace processed by this parser.
-     *
-     * URI: `http://www.itunes.com/dtds/podcast-1.0.dtd`
-     */
     override val namespaceURI: String = "http://www.itunes.com/dtds/podcast-1.0.dtd"
 
-    override fun parse(builder: PodcastBuilder, node: Node) = valid(node) {
+    override fun parseChannelNode(builder: PodcastBuilder, node: Node) {
         when (node.localName) {
-            "author" -> builder.iTunes.author(toText(node))
-            "block" -> builder.iTunes.block(toBoolean(node))
+            "author" -> builder.iTunes.author(textOrNull(node))
+            "block" -> builder.iTunes.block(textAsBooleanOrNull(node))
             "category" -> {
-                val category = node.attributes.getNamedItem("text").textContent ?: return@valid
+                val category = node.attributes.getNamedItem("text").textContent ?: return
                 builder.iTunes.addCategory(category)
             }
-            "complete" -> builder.iTunes.complete(toBoolean(node))
+            "complete" -> builder.iTunes.complete(textAsBooleanOrNull(node))
             "explicit" -> {
-                val explicit = toBoolean(node) ?: return@valid
+                val explicit = textAsBooleanOrNull(node) ?: return
                 builder.iTunes.explicit(explicit)
             }
             "image" -> {
-                val image = toImageBuilder(node, builder.createImageBuilder()) ?: return@valid
+                val image = toImageBuilder(node, builder.createImageBuilder()) ?: return
                 builder.iTunes.imageBuilder(image)
             }
-            "keywords" -> builder.iTunes.keywords(toText(node))
+            "keywords" -> builder.iTunes.keywords(textOrNull(node))
             "owner" -> builder.iTunes.ownerBuilder(toPersonBuilder(node, builder.createPersonBuilder()))
-            "subtitle" -> builder.iTunes.subtitle(toText(node))
-            "summary" -> builder.iTunes.summary(toText(node))
-            "type" -> builder.iTunes.type(toText(node))
-            "title" -> builder.iTunes.title(toText(node))
-            "new-feed-url" -> builder.iTunes.newFeedUrl(toText(node))
+            "subtitle" -> builder.iTunes.subtitle(textOrNull(node))
+            "summary" -> builder.iTunes.summary(textOrNull(node))
+            "type" -> builder.iTunes.type(textOrNull(node))
+            "title" -> builder.iTunes.title(textOrNull(node))
+            "new-feed-url" -> builder.iTunes.newFeedUrl(textOrNull(node))
             else -> pass
         }
     }
 
-    override fun parse(builder: EpisodeBuilder, node: Node) = valid(node) {
+    override fun parseItemNode(builder: EpisodeBuilder, node: Node) {
         when (node.localName) {
-            "block" -> builder.iTunes.block(toBoolean(node))
-            "duration" -> builder.iTunes.duration(toText(node))
+            "block" -> builder.iTunes.block(textAsBooleanOrNull(node))
+            "duration" -> builder.iTunes.duration(textOrNull(node))
             "episode" -> builder.iTunes.episode(toInt(node))
-            "episodeType" -> builder.iTunes.episodeType(toText(node))
-            "explicit" -> builder.iTunes.explicit(toBoolean(node))
+            "episodeType" -> builder.iTunes.episodeType(textOrNull(node))
+            "explicit" -> builder.iTunes.explicit(textAsBooleanOrNull(node))
             "image" -> builder.iTunes.imageBuilder(toImageBuilder(node, builder.createImageBuilder()))
             "season" -> builder.iTunes.season(toInt(node))
-            "title" -> builder.iTunes.title(toText(node))
-            "author" -> builder.iTunes.author(toText(node))
-            "subtitle" -> builder.iTunes.subtitle(toText(node))
-            "summary" -> builder.iTunes.summary(toText(node))
+            "title" -> builder.iTunes.title(textOrNull(node))
+            "author" -> builder.iTunes.author(textOrNull(node))
+            "subtitle" -> builder.iTunes.subtitle(textOrNull(node))
+            "summary" -> builder.iTunes.summary(textOrNull(node))
             else -> pass
         }
     }
 
-    private fun toImageBuilder(node: Node, imageBuilder: ImageBuilder): ImageBuilder? = valid(node) {
+    private fun toImageBuilder(node: Node, imageBuilder: ImageBuilder): ImageBuilder? = ifMatchesNamespace(node) {
         val url: String? = attributeValueByName(node, "href")
         if (url.isNullOrBlank()) {
             null
         } else {
-            imageBuilder
-                .url(url)
+            imageBuilder.url(url)
         }
     }
 
-    private fun toPersonBuilder(node: Node, personBuilder: PersonBuilder): PersonBuilder? = valid(node) {
+    private fun toPersonBuilder(node: Node, personBuilder: PersonBuilder): PersonBuilder? = ifMatchesNamespace(node) {
         for (child in node.childNodes.asListOfNodes()) {
-            val value: String? = toText(child)
+            val value: String? = textOrNull(child)
             when (child.localName) {
                 "name" -> if (value != null) personBuilder.name(value)
                 "email" -> personBuilder.email(value)

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/ITunesParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/ITunesParser.kt
@@ -19,51 +19,51 @@ internal class ITunesParser : NamespaceParser() {
 
     override fun parseChannelNode(builder: PodcastBuilder, node: Node) {
         when (node.localName) {
-            "author" -> builder.iTunes.author(textOrNull(node))
-            "block" -> builder.iTunes.block(textAsBooleanOrNull(node))
+            "author" -> builder.iTunes.author(node.textOrNull())
+            "block" -> builder.iTunes.block(node.textAsBooleanOrNull())
             "category" -> {
                 val category = node.attributes.getNamedItem("text").textContent ?: return
                 builder.iTunes.addCategory(category)
             }
-            "complete" -> builder.iTunes.complete(textAsBooleanOrNull(node))
+            "complete" -> builder.iTunes.complete(node.textAsBooleanOrNull())
             "explicit" -> {
-                val explicit = textAsBooleanOrNull(node) ?: return
+                val explicit = node.textAsBooleanOrNull() ?: return
                 builder.iTunes.explicit(explicit)
             }
             "image" -> {
                 val image = toImageBuilder(node, builder.createImageBuilder()) ?: return
                 builder.iTunes.imageBuilder(image)
             }
-            "keywords" -> builder.iTunes.keywords(textOrNull(node))
+            "keywords" -> builder.iTunes.keywords(node.textOrNull())
             "owner" -> builder.iTunes.ownerBuilder(toPersonBuilder(node, builder.createPersonBuilder()))
-            "subtitle" -> builder.iTunes.subtitle(textOrNull(node))
-            "summary" -> builder.iTunes.summary(textOrNull(node))
-            "type" -> builder.iTunes.type(textOrNull(node))
-            "title" -> builder.iTunes.title(textOrNull(node))
-            "new-feed-url" -> builder.iTunes.newFeedUrl(textOrNull(node))
+            "subtitle" -> builder.iTunes.subtitle(node.textOrNull())
+            "summary" -> builder.iTunes.summary(node.textOrNull())
+            "type" -> builder.iTunes.type(node.textOrNull())
+            "title" -> builder.iTunes.title(node.textOrNull())
+            "new-feed-url" -> builder.iTunes.newFeedUrl(node.textOrNull())
             else -> pass
         }
     }
 
     override fun parseItemNode(builder: EpisodeBuilder, node: Node) {
         when (node.localName) {
-            "block" -> builder.iTunes.block(textAsBooleanOrNull(node))
-            "duration" -> builder.iTunes.duration(textOrNull(node))
-            "episode" -> builder.iTunes.episode(toInt(node))
-            "episodeType" -> builder.iTunes.episodeType(textOrNull(node))
-            "explicit" -> builder.iTunes.explicit(textAsBooleanOrNull(node))
+            "block" -> builder.iTunes.block(node.textAsBooleanOrNull())
+            "duration" -> builder.iTunes.duration(node.textOrNull())
+            "episode" -> builder.iTunes.episode(node.toInt())
+            "episodeType" -> builder.iTunes.episodeType(node.textOrNull())
+            "explicit" -> builder.iTunes.explicit(node.textAsBooleanOrNull())
             "image" -> builder.iTunes.imageBuilder(toImageBuilder(node, builder.createImageBuilder()))
-            "season" -> builder.iTunes.season(toInt(node))
-            "title" -> builder.iTunes.title(textOrNull(node))
-            "author" -> builder.iTunes.author(textOrNull(node))
-            "subtitle" -> builder.iTunes.subtitle(textOrNull(node))
-            "summary" -> builder.iTunes.summary(textOrNull(node))
+            "season" -> builder.iTunes.season(node.toInt())
+            "title" -> builder.iTunes.title(node.textOrNull())
+            "author" -> builder.iTunes.author(node.textOrNull())
+            "subtitle" -> builder.iTunes.subtitle(node.textOrNull())
+            "summary" -> builder.iTunes.summary(node.textOrNull())
             else -> pass
         }
     }
 
-    private fun toImageBuilder(node: Node, imageBuilder: ImageBuilder): ImageBuilder? = ifMatchesNamespace(node) {
-        val url: String? = attributeValueByName(node, "href")
+    private fun toImageBuilder(node: Node, imageBuilder: ImageBuilder): ImageBuilder? = node.ifMatchesNamespace() {
+        val url: String? = node.attributeValueByName("href")
         if (url.isNullOrBlank()) {
             null
         } else {
@@ -71,9 +71,9 @@ internal class ITunesParser : NamespaceParser() {
         }
     }
 
-    private fun toPersonBuilder(node: Node, personBuilder: PersonBuilder): PersonBuilder? = ifMatchesNamespace(node) {
+    private fun toPersonBuilder(node: Node, personBuilder: PersonBuilder): PersonBuilder? = node.ifMatchesNamespace() {
         for (child in node.childNodes.asListOfNodes()) {
-            val value: String? = textOrNull(child)
+            val value: String? = child.textOrNull()
             when (child.localName) {
                 "name" -> if (value != null) personBuilder.name(value)
                 "email" -> personBuilder.email(value)

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/PodloveSimpleChapterParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/PodloveSimpleChapterParser.kt
@@ -17,20 +17,21 @@ internal class PodloveSimpleChapterParser : NamespaceParser() {
 
     override val namespaceURI: String = "http://podlove.org/simple-chapters"
 
-    /** This module does not set any data in the [PodcastBuilder]. */
-    override fun parse(builder: PodcastBuilder, node: Node) {}
+    override fun parseChannelNode(builder: PodcastBuilder, node: Node) {
+        // No-op
+    }
 
-    override fun parse(builder: EpisodeBuilder, node: Node) = valid(node) {
+    override fun parseItemNode(builder: EpisodeBuilder, node: Node) {
         when (node.localName) {
             "chapters" -> {
-                val chapters = toPodloveSimpleChapterBuilders(node, builder) ?: return@valid
+                val chapters = toPodloveSimpleChapterBuilders(node, builder) ?: return
                 builder.podlove.addSimpleChapterBuilders(chapters)
             }
             else -> pass
         }
     }
 
-    private fun toPodloveSimpleChapterBuilders(node: Node, builder: EpisodeBuilder): List<EpisodePodloveSimpleChapterBuilder>? = valid(node) {
+    private fun toPodloveSimpleChapterBuilders(node: Node, builder: EpisodeBuilder): List<EpisodePodloveSimpleChapterBuilder>? = ifMatchesNamespace(node) {
         node.childNodes.asListOfNodes().stream()
             .filter { c -> c.localName == "chapter" }
             .map { it.toPodloveSimpleChapterBuilder(builder.createPodloveSimpleChapterBuilder()) }
@@ -39,10 +40,10 @@ internal class PodloveSimpleChapterParser : NamespaceParser() {
     }
 
     private fun Node.toPodloveSimpleChapterBuilder(chapterBuilder: EpisodePodloveSimpleChapterBuilder): EpisodePodloveSimpleChapterBuilder? =
-        valid(this) {
+        ifMatchesNamespace(this) {
             val start = attributeValueByName(this, "start")
             val title = attributeValueByName(this, "title")
-            if (start == null || title == null) return@valid null
+            if (start == null || title == null) return@ifMatchesNamespace null
 
             chapterBuilder.start(start)
                 .title(title)

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/PodloveSimpleChapterParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/PodloveSimpleChapterParser.kt
@@ -31,7 +31,7 @@ internal class PodloveSimpleChapterParser : NamespaceParser() {
         }
     }
 
-    private fun toPodloveSimpleChapterBuilders(node: Node, builder: EpisodeBuilder): List<EpisodePodloveSimpleChapterBuilder>? = ifMatchesNamespace(node) {
+    private fun toPodloveSimpleChapterBuilders(node: Node, builder: EpisodeBuilder): List<EpisodePodloveSimpleChapterBuilder>? = node.ifMatchesNamespace() {
         node.childNodes.asListOfNodes().stream()
             .filter { c -> c.localName == "chapter" }
             .map { it.toPodloveSimpleChapterBuilder(builder.createPodloveSimpleChapterBuilder()) }
@@ -40,14 +40,14 @@ internal class PodloveSimpleChapterParser : NamespaceParser() {
     }
 
     private fun Node.toPodloveSimpleChapterBuilder(chapterBuilder: EpisodePodloveSimpleChapterBuilder): EpisodePodloveSimpleChapterBuilder? =
-        ifMatchesNamespace(this) {
-            val start = attributeValueByName(this, "start")
-            val title = attributeValueByName(this, "title")
+        this.ifMatchesNamespace() {
+            val start = this.attributeValueByName("start")
+            val title = this.attributeValueByName("title")
             if (start == null || title == null) return@ifMatchesNamespace null
 
             chapterBuilder.start(start)
                 .title(title)
-                .href(attributeValueByName(this, "href"))
-                .image(attributeValueByName(this, "image"))
+                .href(this.attributeValueByName("href"))
+                .image(this.attributeValueByName("image"))
         }
 }

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/RssParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/RssParser.kt
@@ -12,99 +12,98 @@ import org.w3c.dom.Node
 /**
  * Parser implementation for the RSS namespace.
  *
- * Note that RSS 2.0 feeds do not have a namespace URI specified. The document specification is described here:
+ * Note that RSS 2.0 feeds do not have a namespace URI, and thus [namespaceURI] is null.
  *
- * `http://www.rssboard.org/rss-2-0`
+ * The RSS specification is described []here][http://www.rssboard.org/rss-2-0].
  */
 internal class RssParser : NamespaceParser() {
 
-    /** Standard RSS 2.0 elements do not have a namespace. This value is therefore null. */
     override val namespaceURI: String? = null
 
-    override fun parse(builder: PodcastBuilder, node: Node) = valid(node) {
+    override fun parseChannelNode(builder: PodcastBuilder, node: Node) {
         when (node.localName) {
-            "copyright" -> builder.copyright(toText(node))
+            "copyright" -> builder.copyright(textOrNull(node))
             "description" -> {
-                val description = toText(node) ?: return@valid
+                val description = textOrNull(node) ?: return
                 builder.description(description)
             }
-            "docs" -> builder.docs(toText(node))
-            "generator" -> builder.generator(toText(node))
+            "docs" -> builder.docs(textOrNull(node))
+            "generator" -> builder.generator(textOrNull(node))
             "image" -> builder.imageBuilder(toImage(node, builder.createImageBuilder()))
             "language" -> {
-                val language = toText(node) ?: return@valid
+                val language = textOrNull(node) ?: return
                 builder.language(language)
             }
             "lastBuildDate" -> builder.lastBuildDate(toDate(node))
             "link" -> {
-                val link = toText(node) ?: return@valid
+                val link = textOrNull(node) ?: return
                 builder.link(link)
             }
-            "managingEditor" -> builder.managingEditor(toText(node))
+            "managingEditor" -> builder.managingEditor(textOrNull(node))
             "pubDate" -> builder.pubDate(toDate(node))
             "title" -> {
-                val title = toText(node) ?: return@valid
+                val title = textOrNull(node) ?: return
                 builder.title(title)
             }
-            "webMaster" -> builder.webMaster(toText(node))
+            "webMaster" -> builder.webMaster(textOrNull(node))
             "item" -> pass // Items are parsed by WienParser direcly
             else -> pass
         }
     }
 
-    override fun parse(builder: EpisodeBuilder, node: Node) = valid(node) {
+    override fun parseItemNode(builder: EpisodeBuilder, node: Node) {
         when (node.localName) {
-            "author" -> builder.author(toText(node))
+            "author" -> builder.author(textOrNull(node))
             "category" -> {
-                val category = toText(node) ?: return@valid
+                val category = textOrNull(node) ?: return
                 builder.addCategory(category)
             }
-            "comments" -> builder.comments(toText(node))
-            "description" -> builder.description(toText(node))
+            "comments" -> builder.comments(textOrNull(node))
+            "description" -> builder.description(textOrNull(node))
             "enclosure" -> {
-                val enclosure = toEnclosureBuilder(node, builder.createEnclosureBuilder()) ?: return@valid
+                val enclosure = toEnclosureBuilder(node, builder.createEnclosureBuilder()) ?: return
                 builder.enclosureBuilder(enclosure)
             }
             "guid" -> builder.guidBuilder(toGuidBuilder(node, builder.createGuidBuilder()))
-            "link" -> builder.link(toText(node))
+            "link" -> builder.link(textOrNull(node))
             "pubDate" -> builder.pubDate(toDate(node))
-            "source" -> builder.source(toText(node))
+            "source" -> builder.source(textOrNull(node))
             "title" -> {
-                val title = toText(node) ?: return@valid
+                val title = textOrNull(node) ?: return
                 builder.title(title)
             }
             else -> pass
         }
     }
 
-    private fun toEnclosureBuilder(node: Node, enclosureBuilder: EpisodeEnclosureBuilder): EpisodeEnclosureBuilder? = valid(node) {
+    private fun toEnclosureBuilder(node: Node, enclosureBuilder: EpisodeEnclosureBuilder): EpisodeEnclosureBuilder? = ifMatchesNamespace(node) {
         val url = attributeValueByName(it, "url")
         val length = attributeValueByName(it, "length")?.toLongOrNull()
         val type = attributeValueByName(it, "type")
 
-        if (url == null || length == null || type == null) return@valid null
+        if (url == null || length == null || type == null) return@ifMatchesNamespace null
 
         enclosureBuilder.url(url)
             .length(length)
             .type(type)
     }
 
-    private fun toGuidBuilder(node: Node, builder: EpisodeGuidBuilder): EpisodeGuidBuilder? = valid(node) {
-        val guid = toText(it) ?: return@valid null
+    private fun toGuidBuilder(node: Node, builder: EpisodeGuidBuilder): EpisodeGuidBuilder? = ifMatchesNamespace(node) {
+        val guid = textOrNull(it) ?: return@ifMatchesNamespace null
 
         builder.textContent(guid)
-            .isPermalink(toBoolean(attributeValueByName(it, "isPermaLink")))
+            .isPermalink(attributeValueByName(it, "isPermaLink").parseAsBooleanOrNull())
     }
 
-    private fun toImage(node: Node, builder: ImageBuilder): ImageBuilder? = valid(node) {
+    private fun toImage(node: Node, builder: ImageBuilder): ImageBuilder? = ifMatchesNamespace(node) {
         for (child in node.childNodes.asListOfNodes()) {
             when (child.localName) {
-                "description" -> builder.description(toText(child))
+                "description" -> builder.description(textOrNull(child))
                 "height" -> builder.height(toInt(child))
-                "link" -> builder.link(toText(child))
-                "title" -> builder.title(toText(child))
+                "link" -> builder.link(textOrNull(child))
+                "title" -> builder.title(textOrNull(child))
                 "url" -> {
-                    val url = toText(child) ?: continue
+                    val url = textOrNull(child) ?: continue
                     builder.url(url)
                 }
                 "width" -> builder.width(toInt(child))

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/RssParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/RssParser.kt
@@ -22,30 +22,30 @@ internal class RssParser : NamespaceParser() {
 
     override fun parseChannelNode(builder: PodcastBuilder, node: Node) {
         when (node.localName) {
-            "copyright" -> builder.copyright(textOrNull(node))
+            "copyright" -> builder.copyright(node.textOrNull())
             "description" -> {
-                val description = textOrNull(node) ?: return
+                val description = node.textOrNull() ?: return
                 builder.description(description)
             }
-            "docs" -> builder.docs(textOrNull(node))
-            "generator" -> builder.generator(textOrNull(node))
+            "docs" -> builder.docs(node.textOrNull())
+            "generator" -> builder.generator(node.textOrNull())
             "image" -> builder.imageBuilder(toImage(node, builder.createImageBuilder()))
             "language" -> {
-                val language = textOrNull(node) ?: return
+                val language = node.textOrNull() ?: return
                 builder.language(language)
             }
-            "lastBuildDate" -> builder.lastBuildDate(toDate(node))
+            "lastBuildDate" -> builder.lastBuildDate(node.toDate())
             "link" -> {
-                val link = textOrNull(node) ?: return
+                val link = node.textOrNull() ?: return
                 builder.link(link)
             }
-            "managingEditor" -> builder.managingEditor(textOrNull(node))
-            "pubDate" -> builder.pubDate(toDate(node))
+            "managingEditor" -> builder.managingEditor(node.textOrNull())
+            "pubDate" -> builder.pubDate(node.toDate())
             "title" -> {
-                val title = textOrNull(node) ?: return
+                val title = node.textOrNull() ?: return
                 builder.title(title)
             }
-            "webMaster" -> builder.webMaster(textOrNull(node))
+            "webMaster" -> builder.webMaster(node.textOrNull())
             "item" -> pass // Items are parsed by WienParser direcly
             else -> pass
         }
@@ -53,33 +53,33 @@ internal class RssParser : NamespaceParser() {
 
     override fun parseItemNode(builder: EpisodeBuilder, node: Node) {
         when (node.localName) {
-            "author" -> builder.author(textOrNull(node))
+            "author" -> builder.author(node.textOrNull())
             "category" -> {
-                val category = textOrNull(node) ?: return
+                val category = node.textOrNull() ?: return
                 builder.addCategory(category)
             }
-            "comments" -> builder.comments(textOrNull(node))
-            "description" -> builder.description(textOrNull(node))
+            "comments" -> builder.comments(node.textOrNull())
+            "description" -> builder.description(node.textOrNull())
             "enclosure" -> {
                 val enclosure = toEnclosureBuilder(node, builder.createEnclosureBuilder()) ?: return
                 builder.enclosureBuilder(enclosure)
             }
             "guid" -> builder.guidBuilder(toGuidBuilder(node, builder.createGuidBuilder()))
-            "link" -> builder.link(textOrNull(node))
-            "pubDate" -> builder.pubDate(toDate(node))
-            "source" -> builder.source(textOrNull(node))
+            "link" -> builder.link(node.textOrNull())
+            "pubDate" -> builder.pubDate(node.toDate())
+            "source" -> builder.source(node.textOrNull())
             "title" -> {
-                val title = textOrNull(node) ?: return
+                val title = node.textOrNull() ?: return
                 builder.title(title)
             }
             else -> pass
         }
     }
 
-    private fun toEnclosureBuilder(node: Node, enclosureBuilder: EpisodeEnclosureBuilder): EpisodeEnclosureBuilder? = ifMatchesNamespace(node) {
-        val url = attributeValueByName(it, "url")
-        val length = attributeValueByName(it, "length")?.toLongOrNull()
-        val type = attributeValueByName(it, "type")
+    private fun toEnclosureBuilder(node: Node, enclosureBuilder: EpisodeEnclosureBuilder): EpisodeEnclosureBuilder? = node.ifMatchesNamespace() {
+        val url = it.attributeValueByName("url")
+        val length = it.attributeValueByName("length")?.toLongOrNull()
+        val type = it.attributeValueByName("type")
 
         if (url == null || length == null || type == null) return@ifMatchesNamespace null
 
@@ -88,25 +88,25 @@ internal class RssParser : NamespaceParser() {
             .type(type)
     }
 
-    private fun toGuidBuilder(node: Node, builder: EpisodeGuidBuilder): EpisodeGuidBuilder? = ifMatchesNamespace(node) {
-        val guid = textOrNull(it) ?: return@ifMatchesNamespace null
+    private fun toGuidBuilder(node: Node, builder: EpisodeGuidBuilder): EpisodeGuidBuilder? = node.ifMatchesNamespace() {
+        val guid = it.textOrNull() ?: return@ifMatchesNamespace null
 
         builder.textContent(guid)
-            .isPermalink(attributeValueByName(it, "isPermaLink").parseAsBooleanOrNull())
+            .isPermalink(it.attributeValueByName("isPermaLink").parseAsBooleanOrNull())
     }
 
-    private fun toImage(node: Node, builder: ImageBuilder): ImageBuilder? = ifMatchesNamespace(node) {
+    private fun toImage(node: Node, builder: ImageBuilder): ImageBuilder? = node.ifMatchesNamespace() {
         for (child in node.childNodes.asListOfNodes()) {
             when (child.localName) {
-                "description" -> builder.description(textOrNull(child))
-                "height" -> builder.height(toInt(child))
-                "link" -> builder.link(textOrNull(child))
-                "title" -> builder.title(textOrNull(child))
+                "description" -> builder.description(child.textOrNull())
+                "height" -> builder.height(child.toInt())
+                "link" -> builder.link(child.textOrNull())
+                "title" -> builder.title(child.textOrNull())
                 "url" -> {
-                    val url = textOrNull(child) ?: continue
+                    val url = child.textOrNull() ?: continue
                     builder.url(url)
                 }
-                "width" -> builder.width(toInt(child))
+                "width" -> builder.width(child.toInt())
             }
         }
         builder

--- a/src/main/kotlin/io/hemin/wien/util/StringExtensions.kt
+++ b/src/main/kotlin/io/hemin/wien/util/StringExtensions.kt
@@ -1,0 +1,7 @@
+package io.hemin.wien.util
+
+/** Returns the trimmed string, or null if it was blank to begin with. */
+internal fun String.trimmedOrNullIfBlank(): String? {
+    val trimmed = trim()
+    return if (trimmed.isNotEmpty()) trimmed else null
+}

--- a/src/test/kotlin/io/hemin/wien/TestUtil.kt
+++ b/src/test/kotlin/io/hemin/wien/TestUtil.kt
@@ -46,9 +46,11 @@ internal fun dateTime(
     minute: Int = 0,
     second: Int = 0,
     nanosecond: Int = 0,
-    zoneId: ZoneId = ZoneId.of("UTC")
-): TemporalAccessor = ZonedDateTime.of(
-    LocalDate.of(year, month, day),
-    LocalTime.of(hour, minute, second, nanosecond),
-    zoneId
-)
+    overrideZoneId: ZoneId? = null
+): TemporalAccessor {
+    val localDate = LocalDate.of(year, month, day)
+    val localTime = LocalTime.of(hour, minute, second, nanosecond)
+
+    val zoneId = overrideZoneId ?: ZoneId.of("Z")
+    return ZonedDateTime.of(localDate, localTime, zoneId)
+}

--- a/src/test/kotlin/io/hemin/wien/TestUtil.kt
+++ b/src/test/kotlin/io/hemin/wien/TestUtil.kt
@@ -5,9 +5,12 @@ import io.hemin.wien.util.DomBuilderFactory
 import io.hemin.wien.util.NodeListWrapper.Companion.asListOfNodes
 import org.w3c.dom.Document
 import org.w3c.dom.Node
-import java.util.Calendar
-import java.util.Locale
-import java.util.TimeZone
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.Month
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.temporal.TemporalAccessor
 import javax.xml.parsers.DocumentBuilder
 
 private val domBuilder: DocumentBuilder = DomBuilderFactory.newBuilder()
@@ -37,16 +40,15 @@ internal fun documentFromResource(filePath: String): Document {
 /** Creates a [java.util.Date] as specified. Defaults to UTC timezone, and midnight. */
 internal fun dateTime(
     year: Int,
-    monthZeroBased: Int,
+    month: Month,
     day: Int,
     hour: Int = 0,
     minute: Int = 0,
     second: Int = 0,
-    timeZone: TimeZone = TimeZone.getTimeZone("UTC")
-) = Calendar.Builder()
-    .setLocale(Locale.ENGLISH)
-    .setTimeZone(timeZone)
-    .setDate(year, monthZeroBased, day)
-    .setTimeOfDay(hour, minute, second)
-    .build()
-    .time
+    nanosecond: Int = 0,
+    zoneId: ZoneId = ZoneId.of("UTC")
+): TemporalAccessor = ZonedDateTime.of(
+    LocalDate.of(year, month, day),
+    LocalTime.of(hour, minute, second, nanosecond),
+    zoneId
+)

--- a/src/test/kotlin/io/hemin/wien/WienParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/WienParserTest.kt
@@ -17,6 +17,7 @@ import io.hemin.wien.model.Podcast
 import io.hemin.wien.util.findElementByTagName
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
+import java.time.Month
 import javax.xml.parsers.DocumentBuilderFactory
 
 internal class WienParserTest {
@@ -131,7 +132,7 @@ internal class WienParserTest {
             prop(Podcast::generator).isEqualTo("Fireside (https://fireside.fm)")
             prop(Podcast::title).isEqualTo("Smashing Security")
             prop(Podcast::link).isEqualTo("http://www.smashingsecurity.com")
-            prop(Podcast::pubDate).isEqualTo(dateTime(year = 2020, monthZeroBased = 11, day = 17, hour = 0, minute = 45, second = 6))
+            prop(Podcast::pubDate).isEqualTo(dateTime(year = 2020, month = Month.DECEMBER, day = 17, hour = 0, minute = 45, second = 6))
             prop(Podcast::description).isEqualTo(
                 "A helpful and hilarious take on the week's tech SNAFUs. Computer security industry veterans <a href=\"https://www.smashingsecurity.com/hosts/graham-cluley\">Graham Cluley</a> and <a href=\"https://www.smashingsecurity.com/hosts/carole-theriault\">Carole Theriault</a> chat with <a href=\"https://www.smashingsecurity.com/guests\">guests</a> about cybercrime, hacking, and online privacy.   It's not your typical cybersecurity podcast...\n" +
                         "Winner of the \"Best Security Podcast 2018\" and \"Best Security Podcast 2019\", Smashing Security has had over four million downloads. Past guests include Garry Kasparov, Mikko Hyppönen, and Rory Cellan-Jones.\n" +
@@ -178,7 +179,7 @@ internal class WienParserTest {
                         prop(Episode.Guid::textContent).isEqualTo("2ed98bdd-ea95-4129-98cf-ee23dd2ab478")
                         prop(Episode.Guid::isPermalink).isNotNull().isFalse()
                     }
-                    prop(Episode::pubDate).isEqualTo(dateTime(year = 2020, monthZeroBased = 10, day = 12))
+                    prop(Episode::pubDate).isEqualTo(dateTime(year = 2020, month = Month.NOVEMBER, day = 12))
                     prop(Episode::author).isEqualTo("Graham Cluley, Carole Theriault")
                     prop(Episode::enclosure).all {
                         prop(Episode.Enclosure::url).isEqualTo("https://aphid.fireside.fm/d/1437767933/dd3252a8-95c3-41f8-a8a0-9d5d2f9e0bc6/2ed98bdd-ea95-4129-98cf-ee23dd2ab478.mp3")

--- a/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodeBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodeBuilder.kt
@@ -12,7 +12,7 @@ import io.hemin.wien.builder.fake.FakeImageBuilder
 import io.hemin.wien.builder.fake.FakeLinkBuilder
 import io.hemin.wien.builder.fake.FakePersonBuilder
 import io.hemin.wien.model.Episode
-import java.util.Date
+import java.time.temporal.TemporalAccessor
 
 @Suppress("MemberVisibilityCanBePrivate", "Unused")
 internal class FakeEpisodeBuilder : FakeBuilder<Episode>(), EpisodeBuilder {
@@ -26,7 +26,7 @@ internal class FakeEpisodeBuilder : FakeBuilder<Episode>(), EpisodeBuilder {
     val categories: MutableList<String> = mutableListOf()
     var comments: String? = null
     var guidBuilder: EpisodeGuidBuilder? = null
-    var pubDate: Date? = null
+    var pubDate: TemporalAccessor? = null
     var source: String? = null
 
     override val content: FakeEpisodeContentBuilder = FakeEpisodeContentBuilder()
@@ -61,7 +61,7 @@ internal class FakeEpisodeBuilder : FakeBuilder<Episode>(), EpisodeBuilder {
 
     override fun guidBuilder(guidBuilder: EpisodeGuidBuilder?): EpisodeBuilder = apply { this.guidBuilder = guidBuilder }
 
-    override fun pubDate(pubDate: Date?): EpisodeBuilder = apply { this.pubDate = pubDate }
+    override fun pubDate(pubDate: TemporalAccessor?): EpisodeBuilder = apply { this.pubDate = pubDate }
 
     override fun source(source: String?): EpisodeBuilder = apply { this.source = source }
 

--- a/src/test/kotlin/io/hemin/wien/builder/fake/podcast/FakePodcastBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/podcast/FakePodcastBuilder.kt
@@ -10,7 +10,7 @@ import io.hemin.wien.builder.fake.FakeLinkBuilder
 import io.hemin.wien.builder.fake.FakePersonBuilder
 import io.hemin.wien.builder.podcast.PodcastBuilder
 import io.hemin.wien.model.Podcast
-import java.util.Date
+import java.time.temporal.TemporalAccessor
 
 @Suppress("MemberVisibilityCanBePrivate", "Unused")
 internal class FakePodcastBuilder : FakeBuilder<Podcast>(), PodcastBuilder {
@@ -20,8 +20,8 @@ internal class FakePodcastBuilder : FakeBuilder<Podcast>(), PodcastBuilder {
     var descriptionValue: String? = null
     var languageValue: String? = null
 
-    var pubDate: Date? = null
-    var lastBuildDate: Date? = null
+    var pubDate: TemporalAccessor? = null
+    var lastBuildDate: TemporalAccessor? = null
     var generator: String? = null
     var copyright: String? = null
     var docs: String? = null
@@ -47,9 +47,9 @@ internal class FakePodcastBuilder : FakeBuilder<Podcast>(), PodcastBuilder {
 
     override fun description(description: String): PodcastBuilder = apply { this.descriptionValue = description }
 
-    override fun pubDate(pubDate: Date?): PodcastBuilder = apply { this.pubDate = pubDate }
+    override fun pubDate(pubDate: TemporalAccessor?): PodcastBuilder = apply { this.pubDate = pubDate }
 
-    override fun lastBuildDate(lastBuildDate: Date?): PodcastBuilder = apply { this.lastBuildDate = lastBuildDate }
+    override fun lastBuildDate(lastBuildDate: TemporalAccessor?): PodcastBuilder = apply { this.lastBuildDate = lastBuildDate }
 
     override fun language(language: String): PodcastBuilder = apply { this.languageValue = language }
 

--- a/src/test/kotlin/io/hemin/wien/builder/validating/episode/ValidatingEpisodeBuilderTest.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/validating/episode/ValidatingEpisodeBuilderTest.kt
@@ -9,22 +9,14 @@ import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.prop
 import io.hemin.wien.builder.validating.ValidatingPersonBuilder
+import io.hemin.wien.dateTime
 import io.hemin.wien.model.Episode
 import org.junit.jupiter.api.Test
-import java.util.Calendar
-import java.util.Date
-import java.util.Locale
-import java.util.TimeZone
+import java.time.Month
 
 internal class ValidatingEpisodeBuilderTest {
 
-    private val expectedDate: Date = Calendar.Builder()
-        .setLocale(Locale.ENGLISH)
-        .setTimeZone(TimeZone.getTimeZone("UTC"))
-        .setDate(2018, Calendar.MARCH, 16) // "Fri, 16 Mar 2018 22:49:08 +0000"
-        .setTimeOfDay(22, 49, 8)
-        .build()
-        .time
+    private val expectedDate = dateTime(year = 2018, month = Month.MARCH, day = 16, hour = 22, minute = 49, second = 8)
 
     private val expectedEnclosureBuilder = ValidatingEpisodeEnclosureBuilder()
         .url("enclosure url")

--- a/src/test/kotlin/io/hemin/wien/builder/validating/podcast/ValidatingPodcastBuilderTest.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/validating/podcast/ValidatingPodcastBuilderTest.kt
@@ -14,17 +14,15 @@ import io.hemin.wien.builder.validating.episode.ValidatingEpisodeEnclosureBuilde
 import io.hemin.wien.dateTime
 import io.hemin.wien.model.Podcast
 import org.junit.jupiter.api.Test
-import java.util.Calendar
+import java.time.Month
 
 internal class ValidatingPodcastBuilderTest {
 
     // "Fri, 16 Mar 2018 22:49:08 +0000"
-    private val aPubDate =
-        dateTime(year = 2018, monthZeroBased = Calendar.MARCH, day = 16, hour = 22, minute = 49, second = 8)
+    private val aPubDate = dateTime(year = 2018, month = Month.MARCH, day = 16, hour = 22, minute = 49, second = 8)
 
     // "Fri, 1 May 2020 12:55:22 +0000"
-    private val aLastBuildDate =
-        dateTime(year = 2020, monthZeroBased = Calendar.MAY, day = 1, hour = 12, minute = 55, second = 22)
+    private val aLastBuildDate = dateTime(year = 2020, month = Month.MAY, day = 1, hour = 12, minute = 55, second = 22)
 
     private val expectedImageBuilder = ValidatingImageBuilder()
         .url("image url")

--- a/src/test/kotlin/io/hemin/wien/parser/AtomParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/AtomParserTest.kt
@@ -35,7 +35,7 @@ internal class AtomParserTest : NamespaceParserTest() {
     fun `should extract all atom fields from channel when present`() {
         val channel: Node = nodeFromResource("channel", "/xml/channel.xml")
         val builder = FakePodcastBuilder()
-        parseChannelNode(builder, channel)
+        parseChannelChildNodes(builder, channel)
 
         assertThat(builder.atom, "atom podcast data").all {
             prop(FakePodcastAtomBuilder::authorBuilders).containsExactly(expectedPersonBuilder)
@@ -48,7 +48,7 @@ internal class AtomParserTest : NamespaceParserTest() {
     fun `should extract nothing from channel when no atom data is present`() {
         val channel: Node = nodeFromResource("channel", "/xml/channel-incomplete.xml")
         val builder = FakePodcastBuilder()
-        parseChannelNode(builder, channel)
+        parseChannelChildNodes(builder, channel)
 
         assertThat(builder.atom, "atom episode data").all {
             prop(FakePodcastAtomBuilder::authorBuilders).isEmpty()
@@ -61,7 +61,7 @@ internal class AtomParserTest : NamespaceParserTest() {
     fun `should extract all atom fields from item when present`() {
         val item: Node = nodeFromResource("item", "/xml/item.xml")
         val builder = FakeEpisodeBuilder()
-        parseItemNode(builder, item)
+        parseItemChildNodes(builder, item)
 
         assertThat(builder.atom, "atom item data").all {
             prop(FakeEpisodeAtomBuilder::authorBuilders).containsExactly(expectedPersonBuilder)
@@ -74,7 +74,7 @@ internal class AtomParserTest : NamespaceParserTest() {
     fun `should extract nothing from item when no atom data is present`() {
         val item: Node = nodeFromResource("item", "/xml/item-incomplete.xml")
         val builder = FakeEpisodeBuilder()
-        parseItemNode(builder, item)
+        parseItemChildNodes(builder, item)
 
         assertThat(builder.atom, "atom item data").all {
             prop(FakeEpisodeAtomBuilder::authorBuilders).isEmpty()

--- a/src/test/kotlin/io/hemin/wien/parser/BitloveParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/BitloveParserTest.kt
@@ -19,7 +19,7 @@ internal class BitloveParserTest : NamespaceParserTest() {
     fun `should not extract the Bitlove guid attribute from enclosure nodes when it's absent`() {
         val node: Node = nodeFromResource("item", "/xml/item-incomplete.xml")
         val builder = FakeEpisodeBuilder()
-        parseItemNode(builder, node)
+        parseItemChildNodes(builder, node)
 
         assertThat(builder.bitlove, "item bitlove data")
             .prop(FakeEpisodeBitloveBuilder::guid).isNull()
@@ -29,7 +29,7 @@ internal class BitloveParserTest : NamespaceParserTest() {
     fun `should extract the Bitlove guid attribute from enclosure nodes when it's present`() {
         val node: Node = nodeFromResource("item", "/xml/item.xml")
         val builder = FakeEpisodeBuilder()
-        parseItemNode(builder, node)
+        parseItemChildNodes(builder, node)
 
         assertThat(builder.bitlove, "item bitlove data")
             .prop(FakeEpisodeBitloveBuilder::guid).isEqualTo("abcdefg")

--- a/src/test/kotlin/io/hemin/wien/parser/ContentParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/ContentParserTest.kt
@@ -19,7 +19,7 @@ internal class ContentParserTest : NamespaceParserTest() {
     fun `should not extract content data from item when absent`() {
         val node: Node = nodeFromResource("item", "/xml/item-incomplete.xml")
         val builder = FakeEpisodeBuilder()
-        parseItemNode(builder, node)
+        parseItemChildNodes(builder, node)
 
         assertThat(builder.content, "item content data")
             .prop(FakeEpisodeContentBuilder::encoded).isNull()
@@ -29,7 +29,7 @@ internal class ContentParserTest : NamespaceParserTest() {
     fun `should extract content data from item when present`() {
         val node: Node = nodeFromResource("item", "/xml/item.xml")
         val builder = FakeEpisodeBuilder()
-        parseItemNode(builder, node)
+        parseItemChildNodes(builder, node)
 
         assertThat(builder.content, "item content data")
             .prop(FakeEpisodeContentBuilder::encoded).isEqualTo("Lorem Ipsum")

--- a/src/test/kotlin/io/hemin/wien/parser/DateParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/DateParserTest.kt
@@ -10,6 +10,7 @@ import java.time.LocalTime
 import java.time.Month
 import java.time.ZoneId
 import java.time.ZonedDateTime
+import java.util.concurrent.TimeUnit
 
 internal class DateParserTest {
 
@@ -43,28 +44,19 @@ internal class DateParserTest {
     @Test
     fun `should parse ISO-8601 timestamps correctly`() {
         assertAll {
-            assertThat(DateParser.parse("20111203T101530Z"), "20111203T101530Z")
-                .isEqualTo(zonedDateTime(hour = 10, minute = 15, second = 30))
-            assertThat(DateParser.parse("2011-12-03T10:15:30Z"), "2011-12-03T10:15:30Z")
-                .isEqualTo(zonedDateTime(hour = 10, minute = 15, second = 30))
-            assertThat(DateParser.parse("2011-W48-6T09:15:30Z"), "2011-W48-6T09:15:30Z")
-                .isEqualTo(zonedDateTime(hour = 10, minute = 15, second = 30))
-            assertThat(DateParser.parse("2011-337T10:15:30Z"), "2011-337T10:15:30Z")
-                .isEqualTo(zonedDateTime(hour = 10, minute = 15, second = 30))
-
             assertThat(DateParser.parse("2011-12-03T10:15Z"), "2011-12-03T10:15Z")
                 .isEqualTo(zonedDateTime(hour = 10, minute = 15))
             assertThat(DateParser.parse("2011-12-03T10:15:30Z"), "2011-12-03T10:15:30Z")
                 .isEqualTo(zonedDateTime(hour = 10, minute = 15, second = 30))
             assertThat(DateParser.parse("2011-12-03T10:15:30.123Z"), "2011-12-03T10:15:30.123Z")
-                .isEqualTo(zonedDateTime(hour = 10, minute = 15, second = 30, nanosecond = 123))
+                .isEqualTo(zonedDateTime(hour = 10, minute = 15, second = 30, millisecond = 123))
 
             assertThat(DateParser.parse("2011-12-03T10:15+01:00"), "2011-12-03T10:15+01:00")
                 .isEqualTo(zonedDateTime(hour = 10, minute = 15, timeZoneId = ZoneId.of("+01:00")))
             assertThat(DateParser.parse("2011-12-03T10:15:30+01:00"), "2011-12-03T10:15:30+01:00")
                 .isEqualTo(zonedDateTime(hour = 10, minute = 15, second = 30, timeZoneId = ZoneId.of("+01:00")))
             assertThat(DateParser.parse("2011-12-03T10:15:30.123+01:00"), "2011-12-03T10:15:30.123+01:00")
-                .isEqualTo(zonedDateTime(hour = 10, minute = 15, second = 30, nanosecond = 123, timeZoneId = ZoneId.of("+01:00")))
+                .isEqualTo(zonedDateTime(hour = 10, minute = 15, second = 30, millisecond = 123, timeZoneId = ZoneId.of("+01:00")))
         }
     }
 
@@ -85,11 +77,11 @@ internal class DateParserTest {
         hour: Int = 0,
         minute: Int = 0,
         second: Int = 0,
-        nanosecond: Int = 0,
-        timeZoneId: ZoneId = ZoneId.of("GMT")
+        millisecond: Int = 0,
+        timeZoneId: ZoneId = ZoneId.of("Z")
     ) = ZonedDateTime.of(
         LocalDate.of(year, month, day),
-        LocalTime.of(hour, minute, second, nanosecond),
+        LocalTime.of(hour, minute, second, TimeUnit.MILLISECONDS.toNanos(millisecond.toLong()).toInt()),
         timeZoneId
     )
 }

--- a/src/test/kotlin/io/hemin/wien/parser/DateParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/DateParserTest.kt
@@ -1,22 +1,95 @@
 package io.hemin.wien.parser
 
-import org.junit.jupiter.api.Assertions.assertEquals
+import assertk.assertAll
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import org.junit.jupiter.api.Test
-import java.time.Instant
-import java.util.Date
-
-// TODO test: 2019-05-01T21:04:13.958+02:00[Europe/Vienna]
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.Month
+import java.time.ZoneId
+import java.time.ZonedDateTime
 
 internal class DateParserTest {
 
-    // millis calculated from: "Fri, 16 Mar 2018 22:49:08 +0000"
-    private val expected: Date = Date.from(Instant.ofEpochMilli(1521240548000))
+    @Test
+    fun `should parse RFC-1123 aka RFC-(2)822 timestamps correctly`() {
+        assertAll {
+            assertThat(DateParser.parse("3 Dec 2011 10:15"), "3 Dec 2011 10:15")
+                .isEqualTo(localDateTime(hour = 10, minute = 15))
+            assertThat(DateParser.parse("Sat, 3 Dec 2011 10:15"), "Sat, 3 Dec 2011 10:15")
+                .isEqualTo(localDateTime(hour = 10, minute = 15))
+            assertThat(DateParser.parse("Sat, 3 Dec 2011 10:15:30"), "Sat, 3 Dec 2011 10:15:30")
+                .isEqualTo(localDateTime(hour = 10, minute = 15, second = 30))
+            assertThat(DateParser.parse("Sat, 3 Dec 2011 10:15 +0100"), "Sat, 3 Dec 2011 10:15 +0100")
+                .isEqualTo(zonedDateTime(hour = 10, minute = 15, timeZoneId = ZoneId.of("+0100")))
+            assertThat(DateParser.parse("Sat, 3 Dec 2011 10:15:30 +0100"), "Sat, 3 Dec 2011 10:15:30 +0100")
+                .isEqualTo(zonedDateTime(hour = 10, minute = 15, second = 30, timeZoneId = ZoneId.of("+0100")))
+            assertThat(DateParser.parse("3 Dec 2011 10:15:30"), "3 Dec 2011 10:15:30")
+                .isEqualTo(localDateTime(hour = 10, minute = 15, second = 30))
+            assertThat(DateParser.parse("3 Dec 2011 10:15 +0100"), "3 Dec 2011 10:15 +0100")
+                .isEqualTo(zonedDateTime(hour = 10, minute = 15, timeZoneId = ZoneId.of("+0100")))
+            assertThat(DateParser.parse("3 Dec 2011 10:15:30 +0100"), "3 Dec 2011 10:15:30 +0100")
+                .isEqualTo(zonedDateTime(hour = 10, minute = 15, second = 30, timeZoneId = ZoneId.of("+0100")))
+
+            assertThat(DateParser.parse("Tue, 13 Dec 2011 10:15:30 +0100"), "Tue, 13 Dec 2011 10:15:30 +0100")
+                .isEqualTo(zonedDateTime(day = 13, hour = 10, minute = 15, second = 30, timeZoneId = ZoneId.of("+0100")))
+            assertThat(DateParser.parse("13 Dec 2011 10:15:30 +0100"), "13 Dec 2011 10:15:30 +0100")
+                .isEqualTo(zonedDateTime(day = 13, hour = 10, minute = 15, second = 30, timeZoneId = ZoneId.of("+0100")))
+        }
+    }
 
     @Test
-    fun testParseDateFormats() {
+    fun `should parse ISO-8601 timestamps correctly`() {
+        assertAll {
+            assertThat(DateParser.parse("20111203T101530Z"), "20111203T101530Z")
+                .isEqualTo(zonedDateTime(hour = 10, minute = 15, second = 30))
+            assertThat(DateParser.parse("2011-12-03T10:15:30Z"), "2011-12-03T10:15:30Z")
+                .isEqualTo(zonedDateTime(hour = 10, minute = 15, second = 30))
+            assertThat(DateParser.parse("2011-W48-6T09:15:30Z"), "2011-W48-6T09:15:30Z")
+                .isEqualTo(zonedDateTime(hour = 10, minute = 15, second = 30))
+            assertThat(DateParser.parse("2011-337T10:15:30Z"), "2011-337T10:15:30Z")
+                .isEqualTo(zonedDateTime(hour = 10, minute = 15, second = 30))
 
-        assertEquals(expected, DateParser.parse("Fri, 16 Mar 2018 22:49:08 +0000"))
+            assertThat(DateParser.parse("2011-12-03T10:15Z"), "2011-12-03T10:15Z")
+                .isEqualTo(zonedDateTime(hour = 10, minute = 15))
+            assertThat(DateParser.parse("2011-12-03T10:15:30Z"), "2011-12-03T10:15:30Z")
+                .isEqualTo(zonedDateTime(hour = 10, minute = 15, second = 30))
+            assertThat(DateParser.parse("2011-12-03T10:15:30.123Z"), "2011-12-03T10:15:30.123Z")
+                .isEqualTo(zonedDateTime(hour = 10, minute = 15, second = 30, nanosecond = 123))
 
-        // TODO add more date formats
+            assertThat(DateParser.parse("2011-12-03T10:15+01:00"), "2011-12-03T10:15+01:00")
+                .isEqualTo(zonedDateTime(hour = 10, minute = 15, timeZoneId = ZoneId.of("+01:00")))
+            assertThat(DateParser.parse("2011-12-03T10:15:30+01:00"), "2011-12-03T10:15:30+01:00")
+                .isEqualTo(zonedDateTime(hour = 10, minute = 15, second = 30, timeZoneId = ZoneId.of("+01:00")))
+            assertThat(DateParser.parse("2011-12-03T10:15:30.123+01:00"), "2011-12-03T10:15:30.123+01:00")
+                .isEqualTo(zonedDateTime(hour = 10, minute = 15, second = 30, nanosecond = 123, timeZoneId = ZoneId.of("+01:00")))
+        }
     }
+
+    private fun localDateTime(
+        hour: Int = 0,
+        minute: Int = 0,
+        second: Int = 0,
+        nanosecond: Int = 0
+    ) = LocalDateTime.of(
+        LocalDate.of(2011, Month.DECEMBER, 3),
+        LocalTime.of(hour, minute, second, nanosecond)
+    )
+
+    private fun zonedDateTime(
+        year: Int = 2011,
+        month: Month = Month.DECEMBER,
+        day: Int = 3,
+        hour: Int = 0,
+        minute: Int = 0,
+        second: Int = 0,
+        nanosecond: Int = 0,
+        timeZoneId: ZoneId = ZoneId.of("GMT")
+    ) = ZonedDateTime.of(
+        LocalDate.of(year, month, day),
+        LocalTime.of(hour, minute, second, nanosecond),
+        timeZoneId
+    )
 }

--- a/src/test/kotlin/io/hemin/wien/parser/FeedpressParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/FeedpressParserTest.kt
@@ -19,7 +19,7 @@ internal class FeedpressParserTest : NamespaceParserTest() {
     fun `should extract feedpress data from channel when present`() {
         val node = nodeFromResource("channel", "/xml/channel.xml")
         val builder = FakePodcastBuilder()
-        parseChannelNode(builder, node)
+        parseChannelChildNodes(builder, node)
 
         assertThat(builder.feedpress, "channel feedpress data").all {
             prop(FakePodcastFeedpressBuilder::newsletterIdValue).isEqualTo("abc123")
@@ -34,7 +34,7 @@ internal class FeedpressParserTest : NamespaceParserTest() {
     fun `should not extract feedpress data from channel when present`() {
         val node = nodeFromResource("channel", "/xml/channel-incomplete.xml")
         val builder = FakePodcastBuilder()
-        parseChannelNode(builder, node)
+        parseChannelChildNodes(builder, node)
 
         assertThat(builder.feedpress, "channel feedpress data").all {
             prop(FakePodcastFeedpressBuilder::newsletterIdValue).isNull()

--- a/src/test/kotlin/io/hemin/wien/parser/FyydParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/FyydParserTest.kt
@@ -18,7 +18,7 @@ internal class FyydParserTest : NamespaceParserTest() {
     fun `should extract fyyd data from channel when present`() {
         val node = nodeFromResource("channel", "/xml/channel.xml")
         val builder = FakePodcastBuilder()
-        parseChannelNode(builder, node)
+        parseChannelChildNodes(builder, node)
 
         assertThat(builder.fyyd, "channel.fyyd")
             .prop(FakePodcastFyydBuilder::verifyValue).isEqualTo("abcdefg")
@@ -28,7 +28,7 @@ internal class FyydParserTest : NamespaceParserTest() {
     fun `should not extract fyyd data from channel when absent`() {
         val node = nodeFromResource("channel", "/xml/channel-incomplete.xml")
         val builder = FakePodcastBuilder()
-        parseChannelNode(builder, node)
+        parseChannelChildNodes(builder, node)
 
         assertThat(builder.fyyd, "channel.fyyd")
             .prop(FakePodcastFyydBuilder::verifyValue).isNull()

--- a/src/test/kotlin/io/hemin/wien/parser/GooglePlayParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/GooglePlayParserTest.kt
@@ -30,7 +30,7 @@ internal class GooglePlayParserTest : NamespaceParserTest() {
     fun `should extract all google play fields from channel when present`() {
         val node = nodeFromResource("channel", "/xml/channel.xml")
         val builder = FakePodcastBuilder()
-        parseChannelNode(builder, node)
+        parseChannelChildNodes(builder, node)
 
         assertThat(builder.googlePlay, "channel.googleplay").all {
             prop(FakePodcastGooglePlayBuilder::author).isEqualTo("Lorem Ipsum")
@@ -47,7 +47,7 @@ internal class GooglePlayParserTest : NamespaceParserTest() {
     fun `should not extract google play fields from channel when absent`() {
         val node = nodeFromResource("channel", "/xml/channel-incomplete.xml")
         val builder = FakePodcastBuilder()
-        parseChannelNode(builder, node)
+        parseChannelChildNodes(builder, node)
 
         assertThat(builder.googlePlay, "channel.googleplay").all {
             prop(FakePodcastGooglePlayBuilder::author).isNull()
@@ -64,7 +64,7 @@ internal class GooglePlayParserTest : NamespaceParserTest() {
     fun `should extract all google play fields from item when present`() {
         val node = nodeFromResource("item", "/xml/item.xml")
         val builder = FakeEpisodeBuilder()
-        parseItemNode(builder, node)
+        parseItemChildNodes(builder, node)
 
         assertThat(builder.googlePlay, "item.googleplay").all {
             prop(FakeEpisodeGooglePlayBuilder::description).isEqualTo("Lorem Ipsum")
@@ -78,7 +78,7 @@ internal class GooglePlayParserTest : NamespaceParserTest() {
     fun `should not extract google play fields from item when absent`() {
         val node = nodeFromResource("item", "/xml/item-incomplete.xml")
         val builder = FakeEpisodeBuilder()
-        parseItemNode(builder, node)
+        parseItemChildNodes(builder, node)
 
         assertThat(builder.googlePlay, "item.googleplay").all {
             prop(FakeEpisodeGooglePlayBuilder::description).isNull()

--- a/src/test/kotlin/io/hemin/wien/parser/ITunesParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/ITunesParserTest.kt
@@ -37,7 +37,7 @@ internal class ITunesParserTest : NamespaceParserTest() {
     fun `should extract all itunes fields from channel when present`() {
         val node = nodeFromResource("channel", "/xml/channel.xml")
         val builder = FakePodcastBuilder()
-        parseChannelNode(builder, node)
+        parseChannelChildNodes(builder, node)
 
         assertThat(builder.iTunes, "channel.itunes").all {
             prop(FakePodcastITunesBuilder::author).isEqualTo("Lorem Ipsum")
@@ -58,7 +58,7 @@ internal class ITunesParserTest : NamespaceParserTest() {
     fun `should not extract itunes fields from channel when absent`() {
         val node = nodeFromResource("channel", "/xml/channel-incomplete.xml")
         val builder = FakePodcastBuilder()
-        parseChannelNode(builder, node)
+        parseChannelChildNodes(builder, node)
 
         assertThat(builder.iTunes, "channel.itunes").all {
             prop(FakePodcastITunesBuilder::author).isNull()
@@ -79,7 +79,7 @@ internal class ITunesParserTest : NamespaceParserTest() {
     fun `should extract all itunes fields from item when present`() {
         val node = nodeFromResource("item", "/xml/item.xml")
         val builder = FakeEpisodeBuilder()
-        parseItemNode(builder, node)
+        parseItemChildNodes(builder, node)
 
         assertThat(builder.iTunes, "item.itunes").all {
             prop(FakeEpisodeITunesBuilder::title).isEqualTo("Lorem Ipsum")
@@ -100,7 +100,7 @@ internal class ITunesParserTest : NamespaceParserTest() {
     fun `should not extract itunes fields from item when absent`() {
         val node = nodeFromResource("item", "/xml/item-incomplete.xml")
         val builder = FakeEpisodeBuilder()
-        parseItemNode(builder, node)
+        parseItemChildNodes(builder, node)
 
         assertThat(builder.iTunes, "item.itunes").all {
             prop(FakeEpisodeITunesBuilder::title).isNull()

--- a/src/test/kotlin/io/hemin/wien/parser/NamespaceParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/NamespaceParserTest.kt
@@ -9,15 +9,15 @@ internal abstract class NamespaceParserTest {
 
     abstract val parser: NamespaceParser
 
-    protected fun parseChannelNode(builder: FakePodcastBuilder, channel: Node) {
+    protected fun parseChannelChildNodes(builder: FakePodcastBuilder, channel: Node) {
         for (element in channel.childNodes.asListOfNodes()) {
-            parser.parse(builder, element)
+            parser.tryParsingChannelChildNode(builder, element)
         }
     }
 
-    protected fun parseItemNode(builder: FakeEpisodeBuilder, item: Node) {
+    protected fun parseItemChildNodes(builder: FakeEpisodeBuilder, item: Node) {
         for (element in item.childNodes.asListOfNodes()) {
-            parser.parse(builder, element)
+            parser.tryParsingItemChildNode(builder, element)
         }
     }
 }

--- a/src/test/kotlin/io/hemin/wien/parser/PodloveSimpleChapterParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/PodloveSimpleChapterParserTest.kt
@@ -17,7 +17,7 @@ internal class PodloveSimpleChapterParserTest : NamespaceParserTest() {
     fun `should not extract podlove chapter data from item when absent`() {
         val node = nodeFromResource("item", "/xml/item-incomplete.xml")
         val builder = FakeEpisodeBuilder()
-        parseItemNode(builder, node)
+        parseItemChildNodes(builder, node)
 
         assertThat(builder.podlove.chapterBuilders, "item.podlove_simple_chapters").isEmpty()
     }
@@ -26,7 +26,7 @@ internal class PodloveSimpleChapterParserTest : NamespaceParserTest() {
     fun `should extract podlove chapter data from item when present`() {
         val node = nodeFromResource("item", "/xml/item.xml")
         val builder = FakeEpisodeBuilder()
-        parseItemNode(builder, node)
+        parseItemChildNodes(builder, node)
 
         assertThat(builder.podlove.chapterBuilders, "item.podlove_simple_chapters")
             .containsExactly(

--- a/src/test/kotlin/io/hemin/wien/parser/RssParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/RssParserTest.kt
@@ -16,15 +16,14 @@ import io.hemin.wien.dateTime
 import io.hemin.wien.nodeFromResource
 import io.hemin.wien.parser.namespace.RssParser
 import org.junit.jupiter.api.Test
-import java.util.Calendar
-import java.util.Date
+import java.time.Month
 
 internal class RssParserTest : NamespaceParserTest() {
 
     override val parser = RssParser()
 
     // "Fri, 16 Mar 2018 22:49:08 +0000"
-    private val expectedDate: Date = dateTime(year = 2018, monthZeroBased = Calendar.MARCH, day = 16, hour = 22, minute = 49, second = 8)
+    private val expectedDate = dateTime(year = 2018, month = Month.MARCH, day = 16, hour = 22, minute = 49, second = 8)
 
     private val expectedEnclosureBuilder = FakeEpisodeEnclosureBuilder().apply {
         urlValue = "http://example.org/episode1.m4a"
@@ -50,7 +49,7 @@ internal class RssParserTest : NamespaceParserTest() {
     fun `should extract all RSS fields from channel when present`() {
         val node = nodeFromResource("channel", "/xml/channel.xml")
         val builder = FakePodcastBuilder()
-        parseChannelNode(builder, node)
+        parseChannelChildNodes(builder, node)
 
         assertThat(builder, "channel").all {
             prop(FakePodcastBuilder::titleValue).isEqualTo("Lorem Ipsum")
@@ -72,7 +71,7 @@ internal class RssParserTest : NamespaceParserTest() {
     fun `should not extract RSS fields from channel when absent`() {
         val node = nodeFromResource("channel", "/xml/channel-incomplete.xml")
         val builder = FakePodcastBuilder()
-        parseChannelNode(builder, node)
+        parseChannelChildNodes(builder, node)
 
         assertThat(builder, "channel").all {
             prop(FakePodcastBuilder::titleValue).isEqualTo("Lorem Ipsum")
@@ -94,7 +93,7 @@ internal class RssParserTest : NamespaceParserTest() {
     fun `should extract all RSS fields from item when present`() {
         val node = nodeFromResource("item", "/xml/item.xml")
         val builder = FakeEpisodeBuilder()
-        parseItemNode(builder, node)
+        parseItemChildNodes(builder, node)
 
         assertThat(builder, "item").all {
             prop(FakeEpisodeBuilder::titleValue).isEqualTo("Lorem Ipsum")
@@ -114,7 +113,7 @@ internal class RssParserTest : NamespaceParserTest() {
     fun `should not extract RSS fields from item when absent`() {
         val node = nodeFromResource("item", "/xml/item-incomplete.xml")
         val builder = FakeEpisodeBuilder()
-        parseItemNode(builder, node)
+        parseItemChildNodes(builder, node)
 
         assertThat(builder, "item").all {
             prop(FakeEpisodeBuilder::titleValue).isEqualTo("Lorem Ipsum")


### PR DESCRIPTION
This PR switches the code from using `java.util.Date` to `java.time.*`-based APIs. This provides more robust parsing and better overall handling for timestamps, and makes the code rely on the more modern Java APIs, so newer applications using it don't need to convert back and forth.

There's also a couple minor (protected) API changes in `NamespaceParser`, making it more idiomatic, and KDoc tweaks.