### PR TITLE
Create RSS feed writer

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test:$kotlinVersion")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:$junit5Version")
     testImplementation("com.willowtreeapps.assertk:assertk:0.23")
+    testImplementation("org.xmlunit:xmlunit-core:2.8.2")
 }
 
 tasks {

--- a/src/main/kotlin/io/hemin/wien/PodcastRssParser.kt
+++ b/src/main/kotlin/io/hemin/wien/PodcastRssParser.kt
@@ -1,19 +1,23 @@
 package io.hemin.wien
 
 import io.hemin.wien.builder.episode.EpisodeBuilder
+import io.hemin.wien.builder.podcast.PodcastBuilder
 import io.hemin.wien.builder.validating.episode.ValidatingEpisodeBuilder
 import io.hemin.wien.builder.validating.podcast.ValidatingPodcastBuilder
 import io.hemin.wien.model.Podcast
 import io.hemin.wien.parser.NamespaceParser
 import io.hemin.wien.parser.namespace.AtomParser
+import io.hemin.wien.parser.namespace.BitloveParser
 import io.hemin.wien.parser.namespace.ContentParser
+import io.hemin.wien.parser.namespace.FeedpressParser
+import io.hemin.wien.parser.namespace.FyydParser
 import io.hemin.wien.parser.namespace.GooglePlayParser
 import io.hemin.wien.parser.namespace.ITunesParser
 import io.hemin.wien.parser.namespace.PodloveSimpleChapterParser
 import io.hemin.wien.parser.namespace.RssParser
 import io.hemin.wien.util.DomBuilderFactory
-import io.hemin.wien.util.NodeListWrapper.Companion.asListOfNodes
-import io.hemin.wien.util.findElementByTagName
+import io.hemin.wien.util.asListOfNodes
+import io.hemin.wien.util.findElementByName
 import io.hemin.wien.util.isNotEmpty
 import org.w3c.dom.Document
 import org.w3c.dom.Element
@@ -24,21 +28,24 @@ import java.io.File
 import java.io.InputStream
 import javax.xml.parsers.DocumentBuilder
 
-object WienParser {
+@Suppress("unused")
+object PodcastRssParser {
 
     private val parsers: List<NamespaceParser> = listOf(
-            RssParser(),
-            ContentParser(),
-            ITunesParser(),
-            AtomParser(),
-            PodloveSimpleChapterParser(),
-            GooglePlayParser()
-        )
+        AtomParser(),
+        BitloveParser(),
+        ContentParser(),
+        FeedpressParser(),
+        FyydParser(),
+        GooglePlayParser(),
+        ITunesParser(),
+        PodloveSimpleChapterParser(),
+        RssParser()
+    )
 
     /** Set of all XML namespaces supported when parsing documents. */
-    val supportedNamespaces: Set<String> =
-        parsers.mapNotNull { parser -> parser.namespaceURI }
-            .toSet()
+    val supportedNamespaces: Set<String> = parsers.mapNotNull { parser -> parser.namespace?.uri }
+        .toSet()
 
     private val builder: DocumentBuilder = DomBuilderFactory.newBuilder()
 
@@ -100,8 +107,8 @@ object WienParser {
     }
 
     private fun Document.findRssChannelElement() =
-        findElementByTagName("rss") { rss -> rss.childNodes.isNotEmpty() }
-            ?.findElementByTagName("channel") { channel -> channel.childNodes.isNotEmpty() }
+        findElementByName("rss") { rss -> rss.childNodes.isNotEmpty() }
+            ?.findElementByName("channel") { channel -> channel.childNodes.isNotEmpty() }
 
     private fun Element.parseChannelElement(): Podcast? = ifTagNameIs("channel") {
         val builder = ValidatingPodcastBuilder()

--- a/src/main/kotlin/io/hemin/wien/PodcastRssWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/PodcastRssWriter.kt
@@ -51,11 +51,23 @@ object PodcastRssWriter {
             setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2")
         }
 
+    /**
+     * Writes a [Podcast] to a [File] as an RSS feed.
+     *
+     * @param podcast The [Podcast] to write out.
+     * @param file The [File] to write to. Any contents will be overwritten.
+     */
     fun writeRssFeed(podcast: Podcast, file: File) {
         file.outputStream()
             .use { outputStream -> writeRssFeed(podcast, outputStream) }
     }
 
+    /**
+     * Writes a [Podcast] to a [OutputStream] as an RSS feed.
+     *
+     * @param podcast The [Podcast] to write out.
+     * @param stream The [OutputStream] to write to.
+     */
     fun writeRssFeed(podcast: Podcast, stream: OutputStream) {
         val document = writeToDocument(podcast)
         val source = DOMSource(document)

--- a/src/main/kotlin/io/hemin/wien/PodcastRssWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/PodcastRssWriter.kt
@@ -1,0 +1,106 @@
+package io.hemin.wien
+
+import io.hemin.wien.model.Podcast
+import io.hemin.wien.writer.namespace.AtomWriter
+import io.hemin.wien.writer.namespace.BitloveWriter
+import io.hemin.wien.writer.namespace.ContentWriter
+import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.writer.namespace.FeedpressWriter
+import io.hemin.wien.writer.namespace.FyydWriter
+import io.hemin.wien.writer.namespace.GooglePlayWriter
+import io.hemin.wien.writer.namespace.ITunesWriter
+import io.hemin.wien.writer.NamespaceWriter
+import io.hemin.wien.writer.namespace.PodloveSimpleChapterWriter
+import io.hemin.wien.writer.namespace.RssWriter
+import io.hemin.wien.util.asElement
+import org.w3c.dom.Document
+import org.w3c.dom.Element
+import java.io.File
+import java.io.OutputStream
+import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.transform.OutputKeys
+import javax.xml.transform.TransformerFactory
+import javax.xml.transform.dom.DOMSource
+import javax.xml.transform.stream.StreamResult
+
+object PodcastRssWriter {
+
+    // Writers are sorted in order of "importance"
+    private val writers: List<NamespaceWriter> = listOf(
+        RssWriter(),
+        ContentWriter(),
+        ITunesWriter(),
+        GooglePlayWriter(),
+        AtomWriter(),
+        BitloveWriter(),
+        FeedpressWriter(),
+        FyydWriter(),
+        PodloveSimpleChapterWriter()
+    )
+
+    private val supportedNamespaces = writers.mapNotNull { it.namespace }
+
+    private val documentBuilder = DocumentBuilderFactory.newInstance()
+        .apply { isNamespaceAware = true }
+        .newDocumentBuilder()
+
+    private val transformer = TransformerFactory.newInstance()
+        .newTransformer()
+        .apply {
+            setOutputProperty(OutputKeys.INDENT, "yes")
+            setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2")
+        }
+
+    fun writeRssFeed(podcast: Podcast, file: File) {
+        file.outputStream()
+            .use { outputStream -> writeRssFeed(podcast, outputStream) }
+    }
+
+    fun writeRssFeed(podcast: Podcast, stream: OutputStream) {
+        val document = writeToDocument(podcast)
+        val source = DOMSource(document)
+
+        stream.bufferedWriter().use { writer ->
+            val result = StreamResult(writer)
+            transformer.transform(source, result)
+        }
+    }
+
+    private fun writeToDocument(podcast: Podcast): Document {
+        val document = documentBuilder.newDocument()
+        val rssElement = createRssElement(document)
+
+        val channelElement = rssElement.appendChild(document.createElement("channel"))
+            .asElement()
+
+        for (writer in writers) {
+            writer.tryWritingPodcastData(podcast, channelElement)
+        }
+
+        for (episode in podcast.episodes) {
+            val itemElement = channelElement.appendChild(document.createElement("item"))
+                .asElement()
+
+            for (writer in writers) {
+                writer.tryWritingEpisodeData(episode, itemElement)
+            }
+        }
+
+        return document
+    }
+
+    private fun createRssElement(document: Document) = document.appendChild(document.createElement("rss"))
+        .asElement()
+        .addNamespaces(supportedNamespaces)
+        .apply {
+            setAttribute("version", "2.0")
+            setAttribute("encoding", "UTF-8")
+        }
+
+    private fun Element.addNamespaces(namespaces: List<FeedNamespace>): Element {
+        for (ns in namespaces) {
+            setAttributeNS("http://www.w3.org/2000/xmlns/", "xmlns:${ns.prefix}", ns.uri)
+        }
+        return this
+    }
+}

--- a/src/main/kotlin/io/hemin/wien/builder/DomParsingExtensions.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/DomParsingExtensions.kt
@@ -1,0 +1,130 @@
+package io.hemin.wien.builder
+
+import io.hemin.wien.parser.DateParser
+import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.asListOfAttrs
+import io.hemin.wien.util.asListOfNodes
+import io.hemin.wien.util.getAttributeValueByName
+import io.hemin.wien.util.trimmedOrNullIfBlank
+import org.w3c.dom.Element
+import org.w3c.dom.Node
+import java.time.temporal.TemporalAccessor
+import java.util.Locale
+
+/**
+ * Extracts the [Node.getTextContent] of a DOM node. Trims whitespace at the beginning and the end.
+ * Returns `null` if the text is blank.
+ *
+ * @return The content of the DOM node in string representation, or null.
+ */
+internal fun Node.textOrNull(): String? = textContent.trimmedOrNullIfBlank()
+
+/**
+ * Extracts the [Node.getTextContent] of a DOM node, and tries to parse it as a boolean.
+ * If the textContent cannot be parsed, returns `null`.
+ *
+ * @see parseAsBooleanOrNull
+ * @return The logical interpretation of the DOM node's text content as boolean, or `null`.
+ */
+internal fun Node.textAsBooleanOrNull(): Boolean? = textOrNull().parseAsBooleanOrNull()
+
+/**
+ * Interprets a string content as a boolean. If the string value cannot be parsed, returns `null`.
+ * Supports values of `yes`/`no`, or `true`/`false`, case insensitive.
+ *
+ * @return The logical interpretation of the string parameter, or `null`.
+ */
+internal fun String?.parseAsBooleanOrNull() = when (this?.toLowerCase(Locale.ROOT)) {
+    "true", "yes" -> true
+    "false", "no" -> false
+    else -> null
+}
+
+/**
+ * Extracts the text content of a DOM node, and transforms it to an Int instance.
+ *
+ * @return The DOM node content as an [Int], or `null` if conversion failed.
+ */
+internal fun Node.parseAsInt(): Int? = textOrNull()?.toIntOrNull()
+
+/**
+ * Extracts the text content of a DOM node, and parses it as a [TemporalAccessor] instance
+ * if possible.
+ *
+ * @return The DOM node content as a [TemporalAccessor], or `null` if parsing failed.
+ */
+internal fun Node.parseAsTemporalAccessor(): TemporalAccessor? = DateParser.parse(textOrNull())
+
+/**
+ * Parses the node contents as an [ImageBuilder] if possible, interpreting it as an RSS
+ * `<image>` tag.
+ *
+ * @see toHrefOnlyImageBuilder
+ *
+ * @param imageBuilder An empty [ImageBuilder] instance to initialise with the node's
+ * contents.
+ * @param namespace The [FeedNamespace] to ensure the child nodes have.
+ *
+ * @return The DOM node content as an [ImageBuilder], or `null` if parsing failed.
+ */
+internal fun Node.toRssImageBuilder(imageBuilder: ImageBuilder, namespace: FeedNamespace? = null): ImageBuilder {
+    for (node in childNodes.asListOfNodes()) {
+        if (node.namespaceURI != namespace?.uri) continue
+
+        when (node.localName) {
+            "description" -> imageBuilder.description(node.textOrNull())
+            "height" -> imageBuilder.height(node.parseAsInt())
+            "link" -> imageBuilder.link(node.textOrNull())
+            "title" -> imageBuilder.title(node.textOrNull())
+            "url" -> {
+                val url = node.textOrNull() ?: continue
+                imageBuilder.url(url)
+            }
+            "width" -> imageBuilder.width(node.parseAsInt())
+        }
+    }
+    return imageBuilder
+}
+
+/**
+ * Parses the node contents as an [ImageBuilder] if possible, interpreting it as a
+ * `<namespace:image href="..."/>` tag.
+ *
+ * @see toRssImageBuilder
+ *
+ * @param imageBuilder An empty [ImageBuilder] instance to initialise with the node's
+ * contents.
+ * @param namespace The [FeedNamespace] to ensure the `href` attribute has.
+ *
+ * @return The DOM node content as an [ImageBuilder], or `null` if parsing failed.
+ */
+internal fun Node.toHrefOnlyImageBuilder(imageBuilder: ImageBuilder, namespace: FeedNamespace? = null): ImageBuilder {
+    val url: String? = getAttributeValueByName("href", namespace)
+    if (!url.isNullOrBlank()) imageBuilder.url(url)
+    return imageBuilder
+}
+
+/**
+ * Parses the node contents into a [PersonBuilder] if possible, ensuring the child nodes
+ * have the specified [namespace].
+ *
+ * @param personBuilder An empty [PersonBuilder] instance to initialise with the node's
+ * contents.
+ * @param namespace The [FeedNamespace] to ensure the child nodes have.
+ *
+ * @return The DOM node content as a [PersonBuilder], or `null` if parsing failed.
+ */
+internal fun Node.toPersonBuilder(personBuilder: PersonBuilder, namespace: FeedNamespace? = null): PersonBuilder {
+    for (child in childNodes.asListOfNodes()) {
+        if (child !is Element) continue
+        if (child.namespaceURI != namespace?.uri) continue
+        val value: String? = child.textOrNull()
+
+        when (child.localName) {
+            "name" -> if (value != null) personBuilder.name(value)
+            "email" -> personBuilder.email(value)
+            "uri" -> personBuilder.uri(value)
+        }
+    }
+    return personBuilder
+}

--- a/src/main/kotlin/io/hemin/wien/parser/NamespaceParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/NamespaceParser.kt
@@ -2,36 +2,35 @@ package io.hemin.wien.parser
 
 import io.hemin.wien.builder.episode.EpisodeBuilder
 import io.hemin.wien.builder.podcast.PodcastBuilder
-import io.hemin.wien.util.trimmedOrNullIfBlank
+import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.isDirectChildOf
 import org.w3c.dom.Node
-import java.time.temporal.TemporalAccessor
-import java.util.Locale
 
 /** Base class for XML namespace parser implementations. */
 internal abstract class NamespaceParser {
 
     /** The URI of the namespace processed by this parser. */
-    abstract val namespaceURI: String?
+    abstract val namespace: FeedNamespace?
 
     /**
      * Parses a child [Node] that lives inside a `<channel>` node.
-     * Extracts data from the XML namespace defined by [namespaceURI]
+     * Extracts data from the XML namespace defined by [namespace]
      * and applies the values to properties of the [PodcastBuilder].
      * Parsing is only executed when the node's [Node.getNamespaceURI]
-     * matches this parser's [namespaceURI].
+     * matches this parser's [namespace].
      *
-     * @see canParseNode
+     * @see canParse
      * @param builder The builder where all parsed data is added to.
      * @param node The DOM node from which all data is extracted from.
      */
     fun tryParsingChannelChildNode(builder: PodcastBuilder, node: Node) {
-        if (!node.canParseNode()) return
+        if (!canParse(node)) return
         require(node.isDirectChildOf("channel")) { "This function can only parse nodes that are direct children of <channel>" }
         parseChannelNode(builder, node)
     }
 
     /**
-     * Extract all the data from a `<channel>` child node for the [namespaceURI],
+     * Extract all the data from a `<channel>` child node for the [namespace],
      * adding it to the provided builder as it goes.
      * **Note:** this method is only ever called when the node
      *
@@ -41,26 +40,26 @@ internal abstract class NamespaceParser {
     protected abstract fun parseChannelNode(builder: PodcastBuilder, node: Node)
 
     /**
-     * Extracts data from the XML namespace defined by [namespaceURI]
+     * Extracts data from the XML namespace defined by [namespace]
      * and applies the values to properties of the [EpisodeBuilder].
      *
      * Parsing is only executed when the parser supports the node, which
      * by default means that the node's namespaceURI property matches
-     * the parser's [namespaceURI]. Some parsers may change this behavior,
+     * the parser's [namespace]. Some parsers may change this behavior,
      * such as [io.hemin.wien.parser.namespace.BitloveParser].
      *
-     * @see canParseNode
+     * @see canParse
      * @param builder The builder where all parsed data is added to.
      * @param node The DOM node from which all data is extracted from.
      */
     fun tryParsingItemChildNode(builder: EpisodeBuilder, node: Node) {
-        if (!node.canParseNode()) return
+        if (!canParse(node)) return
         require(node.isDirectChildOf("item")) { "This function can only parse nodes that are direct children of <item>" }
         parseItemNode(builder, node)
     }
 
     /**
-     * Extract all the data from a `<channel>` node for the [namespaceURI],
+     * Extract all the data from a `<channel>` node for the [namespace],
      * adding it to the provided builder as it goes.
      * **Note:** this method is only ever called when the node has the correct
      * namespace, and it is indeed a direct child of `<item>`.
@@ -73,82 +72,22 @@ internal abstract class NamespaceParser {
     protected abstract fun parseItemNode(builder: EpisodeBuilder, node: Node)
 
     /**
-     * Extracts the [Node.getTextContent] of a DOM node. Trims whitespace at the beginning and the end.
-     * Returns `null` if the text is blank.
+     * Executes a block of code on the DOM node if the node has the same [namespace] of this parser.
      *
-     * @return The content of the DOM node in string representation, or null.
-     */
-    protected fun Node.textOrNull(): String? = this.ifMatchesNamespace() {
-        it.textContent.trimmedOrNullIfBlank()
-    }
-
-    /**
-     * Extracts the [Node.getTextContent] of a DOM node, and tries to parse it as a boolean.
-     * If the textContent cannot be parsed, returns `null`.
-     *
-     * @see parseAsBooleanOrNull
-     * @return The logical interpretation of the DOM node's text content as boolean, or `null`.
-     */
-    protected fun Node.textAsBooleanOrNull(): Boolean? = this.ifMatchesNamespace() {
-        it.textOrNull().parseAsBooleanOrNull()
-    }
-
-    /**
-     * Interprets a string content as a boolean. If the string value cannot be parsed, returns `null`.
-     * Supports values of `yes`/`no`, or `true`/`false`, case insensitive.
-     *
-     * @return The logical interpretation of the string parameter, or `null`.
-     */
-    protected fun String?.parseAsBooleanOrNull() = when (this?.toLowerCase(Locale.ROOT)) {
-        "true", "yes" -> true
-        "false", "no" -> false
-        else -> null
-    }
-
-    /**
-     * Extracts the text content of a DOM node, and transforms it to an Int instance.
-     *
-     * @return The DOM nodes content as an Int, or null if conversion failed.
-     */
-    protected fun Node.toInt(): Int? = this.ifMatchesNamespace() {
-        it.textOrNull()?.toIntOrNull()
-    }
-
-    /**
-     * Extracts the text content of a DOM node, and parses it as a [TemporalAccessor] instance
-     * if possible.
-     *
-     * @return The DOM nodes content as an Int, or null if parsing failed.
-     */
-    protected fun Node.toDate(): TemporalAccessor? = this.ifMatchesNamespace() {
-        DateParser.parse(it.textOrNull())
-    }
-
-    /**
-     * Extract the textContent of a DOM node attribute identified by name.
-     *
-     * @param attributeName The name of the node's attribute.
-     * @return The textContent of the node's attribute.
-     */
-    protected fun Node.attributeValueByName(attributeName: String): String? =
-        attributes?.getNamedItem(attributeName)?.textContent?.trim()
-
-    /**
-     * Executes a block of code on a DOM node if the node has the same [namespaceURI] of this parser.
-     *
-     * @param this@ifMatchesNamespace The DOM node to execute the [block] of code on.
      * @param block The block of code to execute on the [this@ifMatchesNamespace] when the namespace matches the parser's.
      */
-    protected fun <T> Node.ifMatchesNamespace(block: (Node) -> T?) =
-        if (canParseNode()) {
+    internal fun <T> Node.ifCanBeParsed(block: Node.() -> T?) =
+        if (canParse(this)) {
             block(this)
         } else {
             null
         }
 
-    protected open fun Node.canParseNode() = namespaceURI == this@NamespaceParser.namespaceURI
-
-    protected fun Node.isDirectChildOf(tagName: String) = parentNode.nodeName == tagName && parentNode.namespaceURI == null
+    /**
+     * Should return `true` when this parser can parse a given [Node]. By default true when the node namespace
+     * matches the parser's [namespace], checking its [`uri`][FeedNamespace.uri].
+     */
+    protected open fun canParse(node: Node) = node.namespaceURI == this.namespace?.uri
 
     /** Explicitly do nothing. Used for exhaustive when blocks. */
     protected val pass: Unit = Unit

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/AtomParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/AtomParser.kt
@@ -1,11 +1,12 @@
 package io.hemin.wien.parser.namespace
 
 import io.hemin.wien.builder.LinkBuilder
-import io.hemin.wien.builder.PersonBuilder
 import io.hemin.wien.builder.episode.EpisodeBuilder
 import io.hemin.wien.builder.podcast.PodcastBuilder
+import io.hemin.wien.builder.toPersonBuilder
 import io.hemin.wien.parser.NamespaceParser
-import io.hemin.wien.util.NodeListWrapper.Companion.asListOfNodes
+import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.getAttributeValueByName
 import org.w3c.dom.Node
 
 /**
@@ -15,20 +16,20 @@ import org.w3c.dom.Node
  */
 internal class AtomParser : NamespaceParser() {
 
-    override val namespaceURI: String = "http://www.w3.org/2005/Atom"
+    override val namespace = FeedNamespace.ATOM
 
     override fun parseChannelNode(builder: PodcastBuilder, node: Node) {
         when (node.localName) {
             "contributor" -> {
-                val personBuilder = toPersonBuilder(node, builder.createPersonBuilder()) ?: return
+                val personBuilder = node.ifCanBeParsed { toPersonBuilder(builder.createPersonBuilder(), namespace) } ?: return
                 builder.atom.addContributorBuilder(personBuilder)
             }
             "author" -> {
-                val personBuilder = toPersonBuilder(node, builder.createPersonBuilder()) ?: return
+                val personBuilder = node.ifCanBeParsed { toPersonBuilder(builder.createPersonBuilder(), namespace) } ?: return
                 builder.atom.addAuthorBuilder(personBuilder)
             }
             "link" -> {
-                val linkBuilder = toLinkBuilder(node, builder.createLinkBuilder()) ?: return
+                val linkBuilder = node.ifCanBeParsed { toLinkBuilder(builder.createLinkBuilder()) } ?: return
                 builder.atom.addLinkBuilder(linkBuilder)
             }
             else -> pass
@@ -38,45 +39,31 @@ internal class AtomParser : NamespaceParser() {
     override fun parseItemNode(builder: EpisodeBuilder, node: Node) {
         when (node.localName) {
             "contributor" -> {
-                val person = toPersonBuilder(node, builder.createPersonBuilder()) ?: return
-                builder.atom.addContributorBuilder(person)
+                val personBuilder = node.ifCanBeParsed { toPersonBuilder(builder.createPersonBuilder(), namespace) } ?: return
+                builder.atom.addContributorBuilder(personBuilder)
             }
             "author" -> {
-                val person = toPersonBuilder(node, builder.createPersonBuilder()) ?: return
-                builder.atom.addAuthorBuilder(person)
+                val personBuilder = node.ifCanBeParsed { toPersonBuilder(builder.createPersonBuilder(), namespace) } ?: return
+                builder.atom.addAuthorBuilder(personBuilder)
             }
             "link" -> {
-                val link = toLinkBuilder(node, builder.createLinkBuilder()) ?: return
-                builder.atom.addLinkBuilder(link)
+                val linkBuilder = node.ifCanBeParsed { toLinkBuilder(builder.createLinkBuilder()) } ?: return
+                builder.atom.addLinkBuilder(linkBuilder)
             }
             else -> pass
         }
     }
 
-    private fun toLinkBuilder(node: Node, linkBuilder: LinkBuilder): LinkBuilder? = node.ifMatchesNamespace() {
-        val href = it.attributeValueByName("href") ?: return@ifMatchesNamespace null
+    private fun Node.toLinkBuilder(linkBuilder: LinkBuilder): LinkBuilder? = ifCanBeParsed {
+        val href = getAttributeValueByName("href") ?: return@ifCanBeParsed null
 
         linkBuilder
             .href(href)
-            .hrefLang(it.attributeValueByName("hrefLang"))
-            .hrefResolved(it.attributeValueByName("hrefResolved"))
-            .length(it.attributeValueByName("length"))
-            .rel(it.attributeValueByName("rel"))
-            .title(it.attributeValueByName("title"))
-            .type(it.attributeValueByName("type"))
-    }
-
-    private fun toPersonBuilder(node: Node, personBuilder: PersonBuilder): PersonBuilder? = node.ifMatchesNamespace() {
-        for (child in node.childNodes.asListOfNodes()) {
-            when (child.localName) {
-                "name" -> {
-                    val name = child.textOrNull()
-                    if (name != null) personBuilder.name(name)
-                }
-                "email" -> personBuilder.email(child.textOrNull())
-                "uri" -> personBuilder.uri(child.textOrNull())
-            }
-        }
-        personBuilder
+            .hrefLang(getAttributeValueByName("hrefLang"))
+            .hrefResolved(getAttributeValueByName("hrefResolved"))
+            .length(getAttributeValueByName("length"))
+            .rel(getAttributeValueByName("rel"))
+            .title(getAttributeValueByName("title"))
+            .type(getAttributeValueByName("type"))
     }
 }

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/BitloveParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/BitloveParser.kt
@@ -3,6 +3,9 @@ package io.hemin.wien.parser.namespace
 import io.hemin.wien.builder.episode.EpisodeBuilder
 import io.hemin.wien.builder.podcast.PodcastBuilder
 import io.hemin.wien.parser.NamespaceParser
+import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.getAttributeValueByName
+import io.hemin.wien.util.isDirectChildOf
 import org.w3c.dom.Node
 
 /**
@@ -12,19 +15,19 @@ import org.w3c.dom.Node
  */
 internal class BitloveParser : NamespaceParser() {
 
-    override val namespaceURI: String = "http://bitlove.org"
+    override val namespace = FeedNamespace.BITLOVE
 
     override fun parseChannelNode(builder: PodcastBuilder, node: Node) {
         // No-op
     }
 
     override fun parseItemNode(builder: EpisodeBuilder, node: Node) {
-        val guid = toGuid(node) ?: return
+        val guid = node.findGuid() ?: return
         builder.bitlove.guid(guid)
     }
 
-    override fun Node.canParseNode() = namespaceURI == null && localName == "enclosure" && isDirectChildOf("item")
+    private fun Node.findGuid(): String? = getAttributeValueByName("guid", namespace)
 
-    private fun toGuid(node: Node): String? =
-        node.attributes?.getNamedItemNS(namespaceURI, "guid")?.textContent?.trim()
+    override fun canParse(node: Node) =
+        node.namespaceURI == null && node.localName == "enclosure" && node.isDirectChildOf("item")
 }

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/ContentParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/ContentParser.kt
@@ -2,7 +2,9 @@ package io.hemin.wien.parser.namespace
 
 import io.hemin.wien.builder.episode.EpisodeBuilder
 import io.hemin.wien.builder.podcast.PodcastBuilder
+import io.hemin.wien.builder.textOrNull
 import io.hemin.wien.parser.NamespaceParser
+import io.hemin.wien.util.FeedNamespace
 import org.w3c.dom.Node
 
 /**
@@ -12,7 +14,7 @@ import org.w3c.dom.Node
  */
 internal class ContentParser : NamespaceParser() {
 
-    override val namespaceURI: String = "http://purl.org/rss/1.0/modules/content/"
+    override val namespace = FeedNamespace.CONTENT
 
     override fun parseChannelNode(builder: PodcastBuilder, node: Node) {
         // No-op
@@ -21,8 +23,8 @@ internal class ContentParser : NamespaceParser() {
     override fun parseItemNode(builder: EpisodeBuilder, node: Node) {
         when (node.localName) {
             "encoded" -> {
-                val encoded = node.textOrNull()
-                if (encoded != null) builder.content.encoded(encoded)
+                val encoded = node.ifCanBeParsed { textOrNull() } ?: return
+                builder.content.encoded(encoded)
             }
             else -> pass
         }

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/FeedpressParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/FeedpressParser.kt
@@ -2,7 +2,9 @@ package io.hemin.wien.parser.namespace
 
 import io.hemin.wien.builder.episode.EpisodeBuilder
 import io.hemin.wien.builder.podcast.PodcastBuilder
+import io.hemin.wien.builder.textOrNull
 import io.hemin.wien.parser.NamespaceParser
+import io.hemin.wien.util.FeedNamespace
 import org.w3c.dom.Node
 
 /**
@@ -12,15 +14,15 @@ import org.w3c.dom.Node
  */
 internal class FeedpressParser : NamespaceParser() {
 
-    override val namespaceURI: String = "https://feed.press/xmlns"
+    override val namespace = FeedNamespace.FEEDPRESS
 
     override fun parseChannelNode(builder: PodcastBuilder, node: Node) {
         when (node.localName) {
-            "newsletterId" -> builder.feedpress.newsletterId(node.textOrNull())
-            "locale" -> builder.feedpress.locale(node.textOrNull())
-            "podcastId" -> builder.feedpress.podcastId(node.textOrNull())
-            "cssFile" -> builder.feedpress.cssFile(node.textOrNull())
-            "link" -> builder.feedpress.link(node.textOrNull())
+            "newsletterId" -> builder.feedpress.newsletterId(node.ifCanBeParsed { textOrNull() })
+            "locale" -> builder.feedpress.locale(node.ifCanBeParsed { textOrNull() })
+            "podcastId" -> builder.feedpress.podcastId(node.ifCanBeParsed { textOrNull() })
+            "cssFile" -> builder.feedpress.cssFile(node.ifCanBeParsed { textOrNull() })
+            "link" -> builder.feedpress.link(node.ifCanBeParsed { textOrNull() })
             else -> pass
         }
     }

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/FyydParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/FyydParser.kt
@@ -2,7 +2,9 @@ package io.hemin.wien.parser.namespace
 
 import io.hemin.wien.builder.episode.EpisodeBuilder
 import io.hemin.wien.builder.podcast.PodcastBuilder
+import io.hemin.wien.builder.textOrNull
 import io.hemin.wien.parser.NamespaceParser
+import io.hemin.wien.util.FeedNamespace
 import org.w3c.dom.Node
 
 /**
@@ -12,12 +14,12 @@ import org.w3c.dom.Node
  */
 internal class FyydParser : NamespaceParser() {
 
-    override val namespaceURI: String = "https://fyyd.de/fyyd-ns/"
+    override val namespace = FeedNamespace.FYYD
 
     override fun parseChannelNode(builder: PodcastBuilder, node: Node) {
         when (node.localName) {
             "verify" -> {
-                val verify = node.textOrNull() ?: return
+                val verify = node.ifCanBeParsed { textOrNull() } ?: return
                 builder.fyyd.verify(verify)
             }
             else -> pass

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/GooglePlayParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/GooglePlayParser.kt
@@ -1,9 +1,13 @@
 package io.hemin.wien.parser.namespace
 
-import io.hemin.wien.builder.ImageBuilder
 import io.hemin.wien.builder.episode.EpisodeBuilder
 import io.hemin.wien.builder.podcast.PodcastBuilder
+import io.hemin.wien.builder.textAsBooleanOrNull
+import io.hemin.wien.builder.textOrNull
+import io.hemin.wien.builder.toHrefOnlyImageBuilder
 import io.hemin.wien.parser.NamespaceParser
+import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.getAttributeValueByName
 import org.w3c.dom.Node
 
 /**
@@ -13,40 +17,37 @@ import org.w3c.dom.Node
  */
 internal class GooglePlayParser : NamespaceParser() {
 
-    override val namespaceURI: String = "http://www.google.com/schemas/play-podcasts/1.0"
+    override val namespace = FeedNamespace.GOOGLE_PLAY
 
     override fun parseChannelNode(builder: PodcastBuilder, node: Node) {
         when (node.localName) {
-            "author" -> builder.googlePlay.author(node.textOrNull())
-            "owner" -> builder.googlePlay.owner(node.textOrNull())
+            "author" -> builder.googlePlay.author(node.ifCanBeParsed { textOrNull() })
+            "owner" -> builder.googlePlay.owner(node.ifCanBeParsed { textOrNull() })
             "category" -> {
-                val category = node.attributes.getNamedItem("text").textContent ?: return
+                val category = node.ifCanBeParsed { getAttributeValueByName("text") } ?: return
                 builder.googlePlay.addCategory(category)
             }
-            "description" -> builder.googlePlay.description(node.textOrNull())
-            "explicit" -> builder.googlePlay.explicit(node.textAsBooleanOrNull())
-            "block" -> builder.googlePlay.block(node.textAsBooleanOrNull())
-            "image" -> builder.googlePlay.imageBuilder(toImageBuilder(node, builder.createImageBuilder()))
+            "description" -> builder.googlePlay.description(node.ifCanBeParsed { textOrNull() })
+            "explicit" -> builder.googlePlay.explicit(node.ifCanBeParsed { textAsBooleanOrNull() })
+            "block" -> builder.googlePlay.block(node.ifCanBeParsed { textAsBooleanOrNull() })
+            "image" -> {
+                val imageBuilder = node.ifCanBeParsed { toHrefOnlyImageBuilder(builder.createImageBuilder()) }
+                builder.googlePlay.imageBuilder(imageBuilder)
+            }
             else -> pass
         }
     }
 
     override fun parseItemNode(builder: EpisodeBuilder, node: Node) {
         when (node.localName) {
-            "description" -> builder.googlePlay.description(node.textOrNull())
-            "explicit" -> builder.googlePlay.explicit(node.textAsBooleanOrNull())
-            "block" -> builder.googlePlay.block(node.textAsBooleanOrNull())
-            "image" -> builder.googlePlay.imageBuilder(toImageBuilder(node, builder.createImageBuilder()))
+            "description" -> builder.googlePlay.description(node.ifCanBeParsed { textOrNull() })
+            "explicit" -> builder.googlePlay.explicit(node.ifCanBeParsed { textAsBooleanOrNull() })
+            "block" -> builder.googlePlay.block(node.ifCanBeParsed { textAsBooleanOrNull() })
+            "image" -> {
+                val imageBuilder = node.ifCanBeParsed { toHrefOnlyImageBuilder(builder.createImageBuilder()) }
+                builder.googlePlay.imageBuilder(imageBuilder)
+            }
             else -> pass
-        }
-    }
-
-    private fun toImageBuilder(node: Node, imageBuilder: ImageBuilder): ImageBuilder? = node.ifMatchesNamespace() {
-        val url: String? = node.attributeValueByName("href")
-        if (url.isNullOrBlank()) {
-            null
-        } else {
-            imageBuilder.url(url)
         }
     }
 }

--- a/src/main/kotlin/io/hemin/wien/util/BooleanStringStyle.kt
+++ b/src/main/kotlin/io/hemin/wien/util/BooleanStringStyle.kt
@@ -1,0 +1,17 @@
+package io.hemin.wien.util
+
+/**
+ * Indicates how a boolean value should be written as a string.
+ */
+internal enum class BooleanStringStyle(val trueValue: String, val falseValue: String?) {
+    /** A true value will be written as `true`, a false value as `false`. */
+    TRUE_FALSE("true", "false"),
+    /**
+     * A true value will be written as `yes`, a false value as `null`. Useful for cases
+     * when false values should cause a node to be omitted, as it only supports `yes`.
+     */
+    YES_NULL("yes", null)
+}
+
+internal fun Boolean.asBooleanString(style: BooleanStringStyle) =
+    if (this) style.trueValue else style.falseValue

--- a/src/main/kotlin/io/hemin/wien/util/DomExtensions.kt
+++ b/src/main/kotlin/io/hemin/wien/util/DomExtensions.kt
@@ -1,15 +1,186 @@
 package io.hemin.wien.util
 
-import io.hemin.wien.util.NodeListWrapper.Companion.asListOfNodes
+import io.hemin.wien.model.Image
+import io.hemin.wien.model.Person
+import org.w3c.dom.Attr
+import org.w3c.dom.Document
 import org.w3c.dom.Element
+import org.w3c.dom.NamedNodeMap
 import org.w3c.dom.Node
 import org.w3c.dom.NodeList
 
-internal fun Node.findElementByTagName(nodeName: String, filter: (Node) -> Boolean = { true }) =
-    childNodes.asListOfNodes()
-        .firstOrNull { it.nodeName == nodeName && filter(it) }
-        ?.asElement()
+/** Finds the first element matching the given (local)[name], [namespace] and [filter], if any. */
+internal fun Node.findElementByName(
+    name: String,
+    namespace: FeedNamespace? = null,
+    filter: (Node) -> Boolean = { true }
+) = childNodes.asListOfNodes()
+    .firstOrNull { it.getTagName() == name && it.namespaceURI == namespace?.uri && filter(it) }
+    ?.asElement()
 
+private fun Node.getTagName(): String? = when (this) {
+    is Element -> localName ?: tagName ?: nodeName
+    else -> localName ?: nodeName
+}
+
+/**
+ * Checks whether the node is a direct child of a tag with the given name.
+ */
+internal fun Node.isDirectChildOf(tagName: String) =
+    parentNode.nodeName == tagName && parentNode.namespaceURI == null
+
+/**
+ * Extract the [`textContent`][Node.getTextContent] of a DOM node attribute identified by name.
+ *
+ * @param attributeName The name of the node's attribute.
+ * @param namespace The namespace to use, if any.
+ * @return The textContent of the node's attribute.
+ */
+internal fun Node.getAttributeValueByName(attributeName: String, namespace: FeedNamespace? = null): String? =
+    attributes?.getNamedItemNS(namespace?.uri, attributeName)?.textContent?.trim()
+
+/** Returns true if the [NodeList] contains at least one node. */
+internal fun NodeList.isNotEmpty() = length > 0
+
+/** Converts this [NodeList] to a [List] of [Node]s. */
+internal fun NodeList.asListOfNodes(): List<Node> {
+    if (length == 0) return emptyList()
+    return NodeListWrapper(this)
+}
+
+/** Converts this [NamedNodeMap] to a [List] of [Attr]s. */
+internal fun NamedNodeMap.asListOfAttrs(): List<Attr> {
+    if (length == 0) return emptyList()
+    return (0 until length).map { index -> item(index) }
+        .filterIsInstance(Attr::class.java)
+}
+
+/** Casts the [Node] to an [Element]. */
 internal fun Node.asElement() = this as Element
 
-internal fun NodeList.isNotEmpty() = length > 0
+/**
+ * Appends a new `<namespace:image href="..."/>` with the given [namespace] to this [Element].
+ * Currently the only supported [FeedNamespace] values are:
+ *  * [FeedNamespace.ITUNES]
+ *  * [FeedNamespace.GOOGLE_PLAY]
+ *
+ * Note that only the [Image.url] is written (as an `href="..."` attribute). Other
+ * [Image] properties are ignored.
+ *
+ * @param image The image to represent with the new element.
+ * @param namespace The namespace to use for the new element.
+ */
+internal fun Node.appendImageWithHrefElement(image: Image, namespace: FeedNamespace): Element {
+    require(namespace == FeedNamespace.ITUNES || namespace == FeedNamespace.GOOGLE_PLAY) {
+        "Only 'itunes:', or 'googleplay:' image tags are supported, but it was '${namespace.prefix}:'"
+    }
+    return appendElement("image", namespace) {
+        setAttribute("href", image.url)
+    }
+}
+
+/**
+ * Appends an [RSS `<image>` tag][https://www.w3schools.com/XML/rss_tag_image.asp] to this [Element].
+ *
+ * @param image The image to represent with the new element.
+ */
+internal fun Node.appendRssImageElement(image: Image): Element = appendElement("image") {
+    require(image.title != null) { "The image title is mandatory for RSS images" }
+    require(image.link != null) { "The image link is mandatory for RSS images" }
+    appendElement("title") { textContent = image.title }
+    appendElement("link") { textContent = image.link }
+    appendElement("url") { textContent = image.url }
+    if (image.description != null) appendElement("description") { textContent = image.description }
+    if (image.height != null) appendElement("height") { textContent = image.height.toString() }
+    if (image.width != null) appendElement("width") { textContent = image.width.toString() }
+}
+
+/**
+ * Appends a new [Element] with the given [tag name][elementTagName] to this [Element].
+ * You can configure the new element by specifiying a lambda for [init].
+ *
+ * @param elementTagName The tag name for the new element.
+ * @param namespace The namespace to use for the new element.
+ * @param init A lambda used to configure the new element. By default, does nothing.
+ *
+ * @return Returns the newly created [Element].
+ */
+internal fun Node.appendElement(elementTagName: String, namespace: FeedNamespace? = null, init: Element.() -> Unit = {}): Element {
+    val tagName = if (namespace != null) "${namespace.prefix}:$elementTagName" else elementTagName
+    val element = getDocument().createElementNS(namespace?.uri, tagName)
+    init(element)
+    appendChild(element)
+    return element
+}
+
+private fun Node.getDocument(): Document = when {
+    this is Document -> this
+    ownerDocument != null -> ownerDocument
+    else -> throw IllegalStateException("Couldn't obtain document for node $this")
+}
+
+/**
+ * Sets an attribute with the given [attributeName] to this [Element].
+ * You can configure the new attribute by specifiying a lambda for [init].
+ *
+ * @param attributeName The name of the attribute to set.
+ * @param namespace The namespace to use for the new element.
+ * @param init A lambda used to configure the new element. By default, does nothing.
+ *
+ * @return Returns the newly created [Attr].
+ */
+internal fun Element.setAttributeWithNS(attributeName: String, namespace: FeedNamespace? = null, init: Attr.() -> Unit = {}): Attr {
+    val name = if (namespace != null) "${namespace.prefix}:$attributeName" else attributeName
+    val attr = ownerDocument.createAttributeNS(namespace?.uri, name)
+    init(attr)
+    setAttributeNodeNS(attr)
+    return attr
+}
+
+/**
+ * Appends a [tagName] element with text `yes` if the [value] is true.
+ *
+ * @param tagName The local name of the tag to append
+ * @param value The value to use
+ * @param namespace The namespace to use, if any
+ */
+internal fun Node.appendYesElementIfTrue(tagName: String, value: Boolean, namespace: FeedNamespace? = null) =
+    appendElement(tagName, namespace) {
+        val stringValue = value.asBooleanString(BooleanStringStyle.YES_NULL)
+            ?: return@appendElement
+
+        textContent = stringValue
+    }
+
+/**
+ * Appends a [tagName] element with text `true` if the [value] is true, `false` otherwise.
+ *
+ * @param tagName The local name of the tag to append
+ * @param value The value to use
+ * @param namespace The namespace to use, if any
+ */
+internal fun Node.appendTrueFalseElement(tagName: String, value: Boolean, namespace: FeedNamespace? = null) =
+    appendElement(tagName, namespace) {
+        textContent = value.asBooleanString(BooleanStringStyle.TRUE_FALSE)
+    }
+
+/**
+ * Appends a [tagName] element with the data from the provided [Person].
+ *
+ * @param tagName The local name of the tag to append
+ * @param person The person instance to use
+ * @param namespace The namespace to use, if any
+ */
+internal fun Element.appendPersonElement(tagName: String, person: Person, namespace: FeedNamespace? = null) {
+    appendElement(tagName, namespace) {
+        appendElement("name", namespace) { textContent = person.name }
+
+        if (person.email != null) {
+            appendElement("email", namespace) { textContent = person.email }
+        }
+
+        if (person.uri != null) {
+            appendElement("uri", namespace) { textContent = person.uri }
+        }
+    }
+}

--- a/src/main/kotlin/io/hemin/wien/util/FeedNamespace.kt
+++ b/src/main/kotlin/io/hemin/wien/util/FeedNamespace.kt
@@ -1,0 +1,15 @@
+package io.hemin.wien.util
+
+internal enum class FeedNamespace(
+    val prefix: String,
+    val uri: String
+) {
+    ATOM("atom", "http://www.w3.org/2005/Atom"),
+    BITLOVE("bitlove", "http://bitlove.org"),
+    CONTENT("content", "http://purl.org/rss/1.0/modules/content/"),
+    FEEDPRESS("feedpress", "https://feed.press/xmlns"),
+    FYYD("fyyd", "https://fyyd.de/fyyd-ns/"),
+    GOOGLE_PLAY("googleplay", "http://www.google.com/schemas/play-podcasts/1.0"),
+    ITUNES("itunes", "http://www.itunes.com/dtds/podcast-1.0.dtd"),
+    PODLOVE_SIMPLE_CHAPTER("psc", "http://podlove.org/simple-chapters")
+}

--- a/src/main/kotlin/io/hemin/wien/util/NodeListWrapper.kt
+++ b/src/main/kotlin/io/hemin/wien/util/NodeListWrapper.kt
@@ -4,27 +4,11 @@ import org.w3c.dom.Node
 import org.w3c.dom.NodeList
 
 /**
- * This class provides a [List] API for a [NodeList].
+ * Provides a [List] API for a [NodeList] by wrapping it.
  *
  * @property nodes The [NodeList] to provide a [List] API for.
  */
-class NodeListWrapper(private val nodes: NodeList) : AbstractList<Node>(), RandomAccess {
-
-    companion object {
-
-        /**
-         * Returns a [List] API for the argument.
-         *
-         * @param this@asList The instance holding the DOM node elements.
-         * @retunr The [List] API of the argument.
-         */
-        fun NodeList.asListOfNodes(): List<Node> {
-            return if (length == 0)
-                emptyList()
-            else
-                NodeListWrapper(this)
-        }
-    }
+internal class NodeListWrapper(private val nodes: NodeList) : AbstractList<Node>(), RandomAccess {
 
     /** Returns the number of elements in this nodes. */
     override val size: Int = nodes.length

--- a/src/main/kotlin/io/hemin/wien/writer/DateFormatter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/DateFormatter.kt
@@ -1,0 +1,11 @@
+package io.hemin.wien.writer
+
+import java.time.format.DateTimeFormatter
+import java.time.temporal.TemporalAccessor
+
+internal object DateFormatter {
+
+    private val formatter = DateTimeFormatter.RFC_1123_DATE_TIME
+
+    fun formatAsRfc2822(date: TemporalAccessor): String = formatter.format(date)
+}

--- a/src/main/kotlin/io/hemin/wien/writer/NamespaceWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/NamespaceWriter.kt
@@ -1,0 +1,77 @@
+package io.hemin.wien.writer
+
+import io.hemin.wien.model.Episode
+import io.hemin.wien.model.Podcast
+import io.hemin.wien.util.FeedNamespace
+import org.w3c.dom.Element
+import org.w3c.dom.Node
+import java.time.temporal.TemporalAccessor
+
+/** Base class for XML namespace writer implementations. */
+internal abstract class NamespaceWriter {
+
+    /** The URI of the namespace written to by this writer. */
+    abstract val namespace: FeedNamespace?
+
+    /**
+     * Writes data from the channel data model into the tags for the
+     * XML namespace defined by [namespace].
+     * This function will throw if the [element] does not satisfy
+     * the writer's [canWriteToNode], which checks if the element is
+     * really a `<channel>`.
+     *
+     * @param podcast The podcast data to write.
+     * @param element The element to append the data to.
+     */
+    fun tryWritingPodcastData(podcast: Podcast, element: Element) {
+        require(element.canWriteToNode("channel")) { "This function can only write data to <channel> nodes" }
+        writeChannelData(podcast, element)
+    }
+
+    /**
+     * Writes data from the channel data model into the tags for the
+     * XML namespace defined by [namespace].
+     * Note: the [element] has already been validated to be a `<channel>`.
+     *
+     * @param channel The podcast data to write.
+     */
+    protected abstract fun writeChannelData(channel: Podcast, element: Element)
+
+    /**
+     * Writes data from the item data model into the tags for the
+     * XML namespace defined by [namespace].
+     * This function will throw if the [element] does not satisfy
+     * the writer's [canWriteToNode], which checks if the element is
+     * really an `<item>`.
+     *
+     * @param episode The episode data to write.
+     * @param element The element to append the data to.
+     */
+    fun tryWritingEpisodeData(episode: Episode, element: Element) {
+        require(element.canWriteToNode("item")) { "This function can only write data to <item> nodes" }
+        writeItemData(episode, element)
+    }
+
+    /**
+     * Writes data from the item data model into the tags for the
+     * XML namespace defined by [namespace].
+     * Note: the [element] has already been validated to be a `<item>`.
+     *
+     * @param episode The episode data to write.
+     * @param element The element to append the data to.
+     */
+    protected abstract fun writeItemData(episode: Episode, element: Element)
+
+    /**
+     * Converts a [TemporalAccessor] value to a RFC2822 [String] representation.
+     *
+     * @return The string representing the value in the chosen style.
+     */
+    protected fun TemporalAccessor.asDateString() = DateFormatter.formatAsRfc2822(this)
+
+    /**
+     * Should return `true` when this writer can write to a given node. Returns true when the node
+     * name matches the [expectedNodeName], and its [Node.getNamespaceURI] is `null`.
+     */
+    private fun Node.canWriteToNode(expectedNodeName: String) = nodeName == expectedNodeName && namespaceURI == null
+}

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/AtomWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/AtomWriter.kt
@@ -1,0 +1,75 @@
+package io.hemin.wien.writer.namespace
+
+import io.hemin.wien.model.Episode
+import io.hemin.wien.model.Link
+import io.hemin.wien.model.Person
+import io.hemin.wien.model.Podcast
+import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.appendElement
+import io.hemin.wien.util.appendPersonElement
+import io.hemin.wien.writer.NamespaceWriter
+import org.w3c.dom.Element
+
+/**
+ * Writer implementation for the Atom namespace.
+ *
+ * The namespace URI is: `http://www.w3.org/2005/Atom`
+ */
+internal class AtomWriter : NamespaceWriter() {
+
+    override val namespace = FeedNamespace.ATOM
+
+    override fun writeChannelData(channel: Podcast, element: Element) {
+        val atom = channel.atom ?: return
+
+        element.appendPersonElements("contributor", atom.contributors)
+        element.appendPersonElements("author", atom.authors)
+        element.appendLinkElements(atom.links)
+    }
+
+    override fun writeItemData(episode: Episode, element: Element) {
+        val atom = episode.atom ?: return
+
+        element.appendPersonElements("contributor", atom.contributors)
+        element.appendPersonElements("author", atom.authors)
+        element.appendLinkElements(atom.links)
+    }
+
+    private fun Element.appendPersonElements(tagName: String, persons: List<Person>) {
+        for (person in persons) {
+            appendPersonElement(tagName, person, namespace)
+        }
+    }
+
+    private fun Element.appendLinkElements(links: List<Link>) {
+        for (link in links) {
+            appendElement("link", namespace) {
+                setAttribute("href", link.href)
+
+                if (link.hrefLang != null) {
+                    setAttribute("hrefLang", link.hrefLang)
+                }
+
+                if (link.hrefResolved != null) {
+                    setAttribute("hrefResolved", link.hrefResolved)
+                }
+
+                if (link.length != null) {
+                    setAttribute("length", link.length)
+                }
+
+                if (link.rel != null) {
+                    setAttribute("rel", link.rel)
+                }
+
+                if (link.title != null) {
+                    setAttribute("title", link.title)
+                }
+
+                if (link.type != null) {
+                    setAttribute("type", link.type)
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/BitloveWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/BitloveWriter.kt
@@ -1,0 +1,34 @@
+package io.hemin.wien.writer.namespace
+
+import io.hemin.wien.model.Episode
+import io.hemin.wien.model.Podcast
+import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.writer.NamespaceWriter
+import io.hemin.wien.util.asElement
+import io.hemin.wien.util.asListOfNodes
+import io.hemin.wien.util.findElementByName
+import io.hemin.wien.util.setAttributeWithNS
+import org.w3c.dom.Element
+
+/**
+ * Writer implementation for the Bitlove namespace.
+ *
+ * The namespace URI is: `http://bitlove.org`
+ */
+internal class BitloveWriter : NamespaceWriter() {
+
+    override val namespace = FeedNamespace.BITLOVE
+
+    override fun writeChannelData(channel: Podcast, element: Element) {
+        // Nothing to do here
+    }
+
+    override fun writeItemData(episode: Episode, element: Element) {
+        val guid = episode.bitlove?.guid ?: return
+
+        val enclosureElement = element.findElementByName("enclosure")
+        requireNotNull(enclosureElement) { "This writer must execute after the episode <enclosure> has been written" }
+
+        enclosureElement.setAttributeWithNS("guid", namespace) { value = guid }
+    }
+}

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/ContentWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/ContentWriter.kt
@@ -1,0 +1,28 @@
+package io.hemin.wien.writer.namespace
+
+import io.hemin.wien.model.Episode
+import io.hemin.wien.model.Podcast
+import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.writer.NamespaceWriter
+import io.hemin.wien.util.appendElement
+import org.w3c.dom.Element
+
+/**
+ * Writer implementation for the Content namespace.
+ *
+ * The namespace URI is: `http://purl.org/rss/1.0/modules/content/`
+ */
+internal class ContentWriter : NamespaceWriter() {
+
+    override val namespace = FeedNamespace.CONTENT
+
+    override fun writeChannelData(channel: Podcast, element: Element) {
+        // Nothing to do here
+    }
+
+    override fun writeItemData(episode: Episode, element: Element) {
+        if (episode.content?.encoded == null) return
+
+        element.appendElement("encoded", namespace) { textContent = episode.content.encoded }
+    }
+}

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/FeedpressWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/FeedpressWriter.kt
@@ -1,0 +1,46 @@
+package io.hemin.wien.writer.namespace
+
+import io.hemin.wien.model.Episode
+import io.hemin.wien.model.Podcast
+import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.writer.NamespaceWriter
+import io.hemin.wien.util.appendElement
+import org.w3c.dom.Element
+
+/**
+ * Writer implementation for the Feedpress namespace.
+ *
+ * The namespace URI is: `https://feed.press/xmlns`
+ */
+internal class FeedpressWriter : NamespaceWriter() {
+
+    override val namespace = FeedNamespace.FEEDPRESS
+
+    override fun writeChannelData(channel: Podcast, element: Element) {
+        val feedpress = channel.feedpress ?: return
+
+        if (feedpress.newsletterId != null) {
+            element.appendElement("newsletterId", namespace) { textContent = feedpress.newsletterId }
+        }
+
+        if (feedpress.locale != null) {
+            element.appendElement("locale", namespace) { textContent = feedpress.locale }
+        }
+
+        if (feedpress.podcastId != null) {
+            element.appendElement("podcastId", namespace) { textContent = feedpress.podcastId }
+        }
+
+        if (feedpress.cssFile != null) {
+            element.appendElement("cssFile", namespace) { textContent = feedpress.cssFile }
+        }
+
+        if (feedpress.link != null) {
+            element.appendElement("link", namespace) { textContent = feedpress.link }
+        }
+    }
+
+    override fun writeItemData(episode: Episode, element: Element) {
+        // Nothing to do here
+    }
+}

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/FyydWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/FyydWriter.kt
@@ -1,0 +1,28 @@
+package io.hemin.wien.writer.namespace
+
+import io.hemin.wien.model.Episode
+import io.hemin.wien.model.Podcast
+import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.writer.NamespaceWriter
+import io.hemin.wien.util.appendElement
+import org.w3c.dom.Element
+
+/**
+ * Writer implementation for the Fyyd namespace.
+ *
+ * The namespace URI is: `https://fyyd.de/fyyd-ns/`
+ */
+internal class FyydWriter : NamespaceWriter() {
+
+    override val namespace = FeedNamespace.FYYD
+
+    override fun writeChannelData(channel: Podcast, element: Element) {
+        val fyyd = channel.fyyd ?: return
+
+        element.appendElement("verify", namespace) { textContent = fyyd.verify }
+    }
+
+    override fun writeItemData(episode: Episode, element: Element) {
+        // Nothing to do here
+    }
+}

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/GooglePlayWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/GooglePlayWriter.kt
@@ -1,0 +1,73 @@
+package io.hemin.wien.writer.namespace
+
+import io.hemin.wien.model.Episode
+import io.hemin.wien.model.GooglePlayBase
+import io.hemin.wien.model.Podcast
+import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.writer.NamespaceWriter
+import io.hemin.wien.util.appendElement
+import io.hemin.wien.util.appendImageWithHrefElement
+import io.hemin.wien.util.appendYesElementIfTrue
+import org.w3c.dom.Element
+
+/**
+ * Writer implementation for the Google Play namespace.
+ *
+ * The namespace URI is: `http://www.google.com/schemas/play-podcasts/1.0`
+ */
+internal class GooglePlayWriter : NamespaceWriter() {
+
+    override val namespace = FeedNamespace.GOOGLE_PLAY
+
+    override fun writeChannelData(channel: Podcast, element: Element) {
+        val play = channel.googlePlay ?: return
+
+        if (play.author != null) {
+            element.appendElement("author", namespace) { textContent = play.author }
+        }
+
+        if (play.owner != null) {
+            element.appendElement("owner", namespace) { textContent = play.owner }
+        }
+
+        element.appendCategoryElements(play.categories)
+
+        element.appendCommonElements(play)
+    }
+
+    private fun Element.appendCategoryElements(categories: List<String>) {
+        for (category in categories) {
+            appendElement("category", namespace) {
+                setAttribute("text", category)
+            }
+        }
+    }
+
+    override fun writeItemData(episode: Episode, element: Element) {
+        val play = episode.googlePlay ?: return
+
+        element.appendCommonElements(play)
+    }
+
+    private fun Element.appendCommonElements(play: GooglePlayBase) {
+        val description = play.description
+        if (description != null) {
+            appendElement("description", namespace) { textContent = description }
+        }
+
+        val explicit = play.explicit
+        if (explicit != null) {
+            appendYesElementIfTrue("explicit", explicit, namespace)
+        }
+
+        val block = play.block
+        if (block != null) {
+            appendYesElementIfTrue("block", block, namespace)
+        }
+
+        val image = play.image
+        if (image != null) {
+            appendImageWithHrefElement(image, namespace)
+        }
+    }
+}

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/ITunesWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/ITunesWriter.kt
@@ -1,0 +1,112 @@
+package io.hemin.wien.writer.namespace
+
+import io.hemin.wien.model.Episode
+import io.hemin.wien.model.ITunesBase
+import io.hemin.wien.model.Podcast
+import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.writer.NamespaceWriter
+import io.hemin.wien.util.appendElement
+import io.hemin.wien.util.appendImageWithHrefElement
+import io.hemin.wien.util.appendPersonElement
+import io.hemin.wien.util.appendTrueFalseElement
+import io.hemin.wien.util.appendYesElementIfTrue
+import org.w3c.dom.Element
+
+/**
+ * Writer implementation for the iTunes namespace.
+ *
+ * The namespace URI is: `http://www.itunes.com/dtds/podcast-1.0.dtd`
+ */
+internal class ITunesWriter : NamespaceWriter() {
+
+    override val namespace = FeedNamespace.ITUNES
+
+    override fun writeChannelData(channel: Podcast, element: Element) {
+        val iTunes = channel.iTunes ?: return
+
+        element.appendCategoryElements(iTunes.categories)
+
+        if (iTunes.complete != null) {
+            element.appendYesElementIfTrue("complete", iTunes.complete, namespace)
+        }
+
+        if (iTunes.keywords != null) {
+            element.appendElement("keywords", namespace) { textContent = iTunes.keywords }
+        }
+
+        if (iTunes.owner != null) {
+            element.appendPersonElement("owner", iTunes.owner, namespace)
+        }
+
+        if (iTunes.type != null) {
+            element.appendElement("type", namespace) { textContent = iTunes.type.type }
+        }
+
+        if (iTunes.type != null) {
+            element.appendElement("new-feed-url", namespace) { textContent = iTunes.newFeedUrl }
+        }
+
+        element.appendCommonElements(channel.iTunes)
+    }
+
+    private fun Element.appendCategoryElements(categories: List<String>) {
+        for (category in categories) {
+            appendElement("category", namespace) {
+                setAttribute("text", category)
+            }
+        }
+    }
+
+    override fun writeItemData(episode: Episode, element: Element) {
+        val iTunes = episode.iTunes ?: return
+
+        if (iTunes.duration != null) {
+            element.appendElement("duration", namespace) { textContent = iTunes.duration }
+        }
+
+        if (iTunes.season != null) {
+            element.appendElement("season", namespace) { textContent = iTunes.season.toString() }
+        }
+
+        if (iTunes.episode != null) {
+            element.appendElement("episode", namespace) { textContent = iTunes.episode.toString() }
+        }
+
+        if (iTunes.episodeType != null) {
+            element.appendElement("episodeType", namespace) { textContent = iTunes.episodeType.type }
+        }
+
+        element.appendCommonElements(episode.iTunes)
+    }
+
+    private fun Element.appendCommonElements(iTunes: ITunesBase) {
+        val image = iTunes.image
+        if (image != null) appendImageWithHrefElement(image, namespace)
+
+        val explicit = iTunes.explicit
+        if (explicit != null) appendTrueFalseElement("explicit", explicit, namespace)
+
+        val title = iTunes.title
+        if (title != null) {
+            appendElement("title", namespace) { textContent = title }
+        }
+
+        val block = iTunes.block
+        if (block != null) appendYesElementIfTrue("block", block, namespace)
+
+        val author = iTunes.author
+        if (author != null) {
+            appendElement("author", namespace) { textContent = author }
+        }
+
+        val subtitle = iTunes.subtitle
+        if (subtitle != null) {
+            appendElement("subtitle", namespace) { textContent = subtitle }
+        }
+
+        val summary = iTunes.summary
+        if (summary != null) {
+            appendElement("summary", namespace) { textContent = summary }
+        }
+    }
+}

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/PodloveSimpleChapterWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/PodloveSimpleChapterWriter.kt
@@ -1,0 +1,42 @@
+package io.hemin.wien.writer.namespace
+
+import io.hemin.wien.model.Episode
+import io.hemin.wien.model.Podcast
+import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.writer.NamespaceWriter
+import io.hemin.wien.util.appendElement
+import org.w3c.dom.Element
+
+/**
+ * Writer implementation for the Podlove Simple Chapter namespace.
+ *
+ * The namespace URI is: `http://podlove.org/simple-chapters`
+ */
+internal class PodloveSimpleChapterWriter : NamespaceWriter() {
+
+    override val namespace = FeedNamespace.PODLOVE_SIMPLE_CHAPTER
+
+    override fun writeChannelData(channel: Podcast, element: Element) {
+        // Nothing to do here
+    }
+
+    override fun writeItemData(episode: Episode, element: Element) {
+        val chapters = episode.podlove?.simpleChapters ?: return
+
+        element.appendElement("chapters", namespace) {
+            for (chapter in chapters) {
+                appendChapterElement(chapter)
+            }
+        }
+    }
+
+    private fun Element.appendChapterElement(chapter: Episode.Podlove.SimpleChapter) {
+        appendElement("chapter", namespace) {
+            setAttribute("start", chapter.start)
+            setAttribute("title", chapter.title)
+
+            if (chapter.href != null) setAttribute("href", chapter.href)
+            if (chapter.image != null) setAttribute("image", chapter.image)
+        }
+    }
+}

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/RssWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/RssWriter.kt
@@ -1,0 +1,120 @@
+package io.hemin.wien.writer.namespace
+
+import io.hemin.wien.model.Episode
+import io.hemin.wien.model.Podcast
+import io.hemin.wien.util.BooleanStringStyle
+import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.appendElement
+import io.hemin.wien.util.appendImageWithHrefElement
+import io.hemin.wien.util.appendRssImageElement
+import io.hemin.wien.util.asBooleanString
+import io.hemin.wien.writer.NamespaceWriter
+import org.w3c.dom.Element
+
+/**
+ * Writer implementation for the RSS namespace.
+ *
+ * Note that RSS 2.0 feeds do not have a namespace URI specified. The document specification is described here:
+ *
+ * `http://www.rssboard.org/rss-2-0`
+ */
+internal class RssWriter : NamespaceWriter() {
+
+    /** Standard RSS 2.0 elements do not have a namespace. This value is therefore null. */
+    override val namespace: FeedNamespace? = null
+
+    override fun writeChannelData(channel: Podcast, element: Element) {
+        element.appendElement("title") { textContent = channel.title }
+        element.appendElement("link") { textContent = channel.link }
+        element.appendElement("description") { textContent = channel.description }
+
+        if (channel.pubDate != null) {
+            element.appendElement("pubDate") { textContent = channel.pubDate.asDateString() }
+        }
+
+        if (channel.lastBuildDate != null) {
+            element.appendElement("lastBuildDate") { textContent = channel.lastBuildDate.asDateString() }
+        }
+
+        if (channel.generator != null) {
+            element.appendElement("generator") { textContent = channel.generator }
+        }
+
+        element.appendElement("language") { textContent = channel.language }
+
+        if (channel.copyright != null) {
+            element.appendElement("copyright") { textContent = channel.copyright }
+        }
+
+        if (channel.docs != null) {
+            element.appendElement("docs") { textContent = channel.docs }
+        }
+
+        if (channel.managingEditor != null) {
+            element.appendElement("managingEditor") { textContent = channel.managingEditor }
+        }
+
+        if (channel.webMaster != null) {
+            element.appendElement("webMaster") { textContent = channel.webMaster }
+        }
+
+        if (channel.image != null) element.appendRssImageElement(channel.image)
+    }
+
+    override fun writeItemData(episode: Episode, element: Element) {
+        element.appendElement("title") { textContent = episode.title }
+
+        if (episode.link != null) {
+            element.appendElement("link") { textContent = episode.link }
+        }
+
+        if (episode.description != null) {
+            element.appendElement("description") { textContent = episode.description }
+        }
+
+        if (episode.author != null) {
+            element.appendElement("author") { textContent = episode.author }
+        }
+
+        if (episode.categories.isNotEmpty()) {
+            for (category in episode.categories) {
+                element.appendElement("category") { textContent = category }
+            }
+        }
+
+        if (episode.comments != null) {
+            element.appendElement("comments") { textContent = episode.comments }
+        }
+
+        element.appendEnclosureElement(episode.enclosure)
+
+        if (episode.guid != null) {
+            element.appendGuidElement(episode.guid)
+        }
+
+        if (episode.pubDate != null) {
+            element.appendElement("pubDate") { textContent = episode.pubDate.asDateString() }
+        }
+
+        if (episode.source != null) {
+            element.appendElement("source") { textContent = episode.source }
+        }
+    }
+
+    private fun Element.appendEnclosureElement(enclosure: Episode.Enclosure) {
+        appendElement("enclosure") {
+            setAttribute("url", enclosure.url)
+            setAttribute("length", enclosure.length.toString())
+            setAttribute("type", enclosure.type)
+        }
+    }
+
+    private fun Element.appendGuidElement(guid: Episode.Guid) {
+        appendElement("guid") {
+            if (guid.isPermalink != null) {
+                setAttribute("isPermalink", guid.isPermalink.asBooleanString(BooleanStringStyle.TRUE_FALSE))
+            }
+            textContent = guid.textContent
+        }
+    }
+}

--- a/src/test/kotlin/io/hemin/wien/Assertions.kt
+++ b/src/test/kotlin/io/hemin/wien/Assertions.kt
@@ -1,0 +1,57 @@
+package io.hemin.wien
+
+import assertk.Assert
+import assertk.assertions.support.expected
+import assertk.fail
+import io.hemin.wien.util.FeedNamespace
+import org.w3c.dom.Node
+import org.xmlunit.diff.Diff
+import java.io.File
+import javax.xml.transform.Source
+import javax.xml.transform.dom.DOMSource
+
+/** Asserts the diff is empty (the two DOMs are identical). */
+internal fun Assert<Diff>.hasNoDifferences() = given { diff ->
+    if (diff.hasDifferences()) expected(
+        message = buildString {
+            appendLine("to have no differences.")
+            appendLine()
+            appendLine("**** Actual (control) *****")
+            appendLine(diff.controlSource.getNode().asString())
+            appendLine()
+            appendLine("**** Expected (test) *****")
+            appendLine(diff.testSource.getNode().asString())
+        },
+        expected = emptyList<Diff>(),
+        actual = diff.differences.toList()
+    )
+}
+
+private fun Source.getNode() = when (this) {
+    is DOMSource -> this.node
+    else -> throw UnsupportedOperationException("Unable to get a DOM Node from a Source of type ${this::class.qualifiedName}")
+}
+
+/** Asserts the DOM node has no attribute with matching [localName] and [namespace]. */
+internal fun Assert<Node>.hasNoAttribute(localName: String, namespace: FeedNamespace? = null) = given { node ->
+    if (!node.hasAttributes()) return@given
+    val matchingAttribute = node.attributes.getNamedItemNS(namespace?.uri, localName)
+    if (matchingAttribute != null) {
+        expected(
+            message = "not to have an attribute with localName='$localName' and namespace='$namespace'",
+            expected = null,
+            actual = "Attr[name='${matchingAttribute.nodeName}', namespaceURI='${matchingAttribute.namespaceURI}', " +
+                    "value='${matchingAttribute.nodeValue}']"
+        )
+    }
+}
+
+/** Asserts the file is not empty. */
+internal fun Assert<File>.isNotEmpty() = given { file ->
+    if (file.length() > 0L) return@given
+    expected(
+        message = "not to be empty",
+        expected = "file.length() == 0 byte(s)",
+        actual = "file.length() == ${file.length()} byte(s)"
+    )
+}

--- a/src/test/kotlin/io/hemin/wien/PodcastRssParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/PodcastRssParserTest.kt
@@ -14,86 +14,86 @@ import io.hemin.wien.model.Episode
 import io.hemin.wien.model.Image
 import io.hemin.wien.model.Person
 import io.hemin.wien.model.Podcast
-import io.hemin.wien.util.findElementByTagName
+import io.hemin.wien.util.findElementByName
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
 import java.time.Month
 import javax.xml.parsers.DocumentBuilderFactory
 
-internal class WienParserTest {
+internal class PodcastRssParserTest {
 
     private val documentBuilder = DocumentBuilderFactory.newInstance()
         .newDocumentBuilder()
 
     @Test
     internal fun `should return null when parsing an empty document`() {
-        assertThat(WienParser.parse(createDocument())).isNull()
+        assertThat(PodcastRssParser.parse(createDocument())).isNull()
     }
 
     @Test
     internal fun `should return null when parsing a document with no 'rss' tag at top level`() {
-        assertThat(WienParser.parse(createDocumentWithNode("banana"))).isNull()
+        assertThat(PodcastRssParser.parse(createDocumentWithNode("banana"))).isNull()
     }
 
     @Test
     internal fun `should return null when parsing a document with an empty 'rss' tag`() {
-        assertThat(WienParser.parse(createDocumentWithNode("rss"))).isNull()
+        assertThat(PodcastRssParser.parse(createDocumentWithNode("rss"))).isNull()
     }
 
     @Test
     internal fun `should return null when parsing a document with no 'channel' tag in a non-empty 'rss'`() {
         val document = createDocumentWithNode("rss").apply {
-            val rssElement = findElementByTagName("rss") ?: fail("No rss element found")
+            val rssElement = findElementByName("rss") ?: fail("No rss element found")
             rssElement.appendChild(createElement("banana"))
         }
-        assertThat(WienParser.parse(document)).isNull()
+        assertThat(PodcastRssParser.parse(document)).isNull()
     }
 
     @Test
     internal fun `should return null when parsing a document with an empty 'channel' tag in 'rss'`() {
         val document = createDocumentWithNode("rss").apply {
-            val rssElement = findElementByTagName("rss") ?: fail("No rss element found")
+            val rssElement = findElementByName("rss") ?: fail("No rss element found")
             rssElement.appendChild(createElement("channel"))
         }
-        assertThat(WienParser.parse(document)).isNull()
+        assertThat(PodcastRssParser.parse(document)).isNull()
     }
 
     @Test
     internal fun `should pick up the first non empty 'channel' tag in 'rss'`() {
         val document = validRssDocument().apply {
-            val rssElement = findElementByTagName("rss") ?: fail("No rss element found")
-            val channelElement = rssElement.findElementByTagName("channel") ?: fail("No channel element found")
+            val rssElement = findElementByName("rss") ?: fail("No rss element found")
+            val channelElement = rssElement.findElementByName("channel") ?: fail("No channel element found")
             rssElement.insertBefore(createElement("channel"), channelElement)
         }
-        assertThat(WienParser.parse(document)).isNotNull()
+        assertThat(PodcastRssParser.parse(document)).isNotNull()
     }
 
     @Test
     internal fun `should return null when parsing a document with no 'item' tag in a non-empty 'channel'`() {
         val document = createDocumentWithNode("rss").apply {
-            val rssElement = findElementByTagName("rss") ?: fail("No rss element found")
+            val rssElement = findElementByName("rss") ?: fail("No rss element found")
             val channelElement = rssElement.appendChild(createElement("channel"))
             channelElement.appendChild(createElement("banana"))
         }
-        assertThat(WienParser.parse(document)).isNull()
+        assertThat(PodcastRssParser.parse(document)).isNull()
     }
 
     @Test
     internal fun `should skip empty 'item' tags in 'channel' when parsing a valid document`() {
         val document = validRssDocument().apply {
-            val rssElement = findElementByTagName("rss") ?: fail("No rss element found")
-            val channelElement = rssElement.findElementByTagName("channel") ?: fail("No channel element found")
-            val firstItemElement = channelElement.findElementByTagName("item") ?: fail("No item element found")
+            val rssElement = findElementByName("rss") ?: fail("No rss element found")
+            val channelElement = rssElement.findElementByName("channel") ?: fail("No channel element found")
+            val firstItemElement = channelElement.findElementByName("item") ?: fail("No item element found")
             channelElement.insertBefore(createElement("item"), firstItemElement)
         }
-        assertThat(WienParser.parse(document)).isNotNull()
+        assertThat(PodcastRssParser.parse(document)).isNotNull()
             .prop(Podcast::episodes).hasSize(2) // Two in the xml — the empty one we inserted is skipped
     }
 
     @Test
     internal fun `should parse a basic feed correctly`() {
         val document = validRssDocument()
-        assertThat(WienParser.parse(document)).isNotNull().all {
+        assertThat(PodcastRssParser.parse(document)).isNotNull().all {
             prop(Podcast::title).isEqualTo("Lorem Ipsum title")
             prop(Podcast::description).isEqualTo("Lorem Ipsum description")
             prop(Podcast::link).isEqualTo("http://example.org")
@@ -128,7 +128,7 @@ internal class WienParserTest {
     @Test
     internal fun `should parse a complex feed correctly`() {
         val document = validRssDocument("/xml/rss-complex.xml")
-        assertThat(WienParser.parse(document)).isNotNull().all {
+        assertThat(PodcastRssParser.parse(document)).isNotNull().all {
             prop(Podcast::generator).isEqualTo("Fireside (https://fireside.fm)")
             prop(Podcast::title).isEqualTo("Smashing Security")
             prop(Podcast::link).isEqualTo("http://www.smashingsecurity.com")

--- a/src/test/kotlin/io/hemin/wien/PodcastRssWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/PodcastRssWriterTest.kt
@@ -1,0 +1,28 @@
+package io.hemin.wien
+
+import assertk.assertThat
+import assertk.assertions.exists
+import assertk.assertions.isEqualTo
+import io.hemin.wien.model.podcast.aPodcast
+import org.junit.jupiter.api.Test
+import java.io.File
+
+internal class PodcastRssWriterTest {
+
+    @Test
+    internal fun `should write a feed to a file correctly`() {
+        val file = File.createTempFile("wien_test", "writer_output")
+
+        val podcast = aPodcast()
+        PodcastRssWriter.writeRssFeed(podcast, file)
+
+        assertk.assertAll {
+            assertThat(file, "written file").exists()
+            assertThat(file, "written file").isNotEmpty()
+
+            assertThat(PodcastRssParser.parse(file), "written file matches original Podcast").isEqualTo(podcast)
+
+            file.delete()
+        }
+    }
+}

--- a/src/test/kotlin/io/hemin/wien/model/Fixtures.kt
+++ b/src/test/kotlin/io/hemin/wien/model/Fixtures.kt
@@ -1,0 +1,26 @@
+package io.hemin.wien.model
+
+internal fun anImage(
+    url: String = "image url",
+    title: String? = "image title",
+    link: String? = "image link",
+    width: Int? = 123,
+    height: Int? = 456,
+    description: String? = "image description"
+) = Image(url, title, link, width, height, description)
+
+internal fun aPerson(
+    name: String = "person name",
+    email: String? = "person email",
+    uri: String? = "person uri"
+) = Person(name, email, uri)
+
+internal fun aLink(
+    href: String = "link href",
+    hrefLang: String? = "link hrefLang",
+    hrefResolved: String? = "link hrefResolved",
+    length: String? = "link length",
+    rel: String? = "link rel",
+    title: String? = "link title",
+    type: String? = "link type"
+) = Link(href, hrefLang, hrefResolved, length, rel, title, type)

--- a/src/test/kotlin/io/hemin/wien/model/episode/EpisodeFixtures.kt
+++ b/src/test/kotlin/io/hemin/wien/model/episode/EpisodeFixtures.kt
@@ -1,0 +1,105 @@
+package io.hemin.wien.model.episode
+
+import io.hemin.wien.dateTime
+import io.hemin.wien.model.Episode
+import io.hemin.wien.model.Image
+import io.hemin.wien.model.Link
+import io.hemin.wien.model.Person
+import io.hemin.wien.model.aLink
+import io.hemin.wien.model.aPerson
+import io.hemin.wien.model.anImage
+import java.time.Month
+import java.time.temporal.TemporalAccessor
+
+internal fun anEpisode(
+    title: String = "episode title",
+    link: String? = "episode link",
+    description: String? = "episode description",
+    author: String? = "episode author",
+    categories: List<String> = listOf("episode category"),
+    comments: String? = "episode comments",
+    enclosure: Episode.Enclosure = anEpisodeEnclosure(),
+    guid: Episode.Guid? = anEpisodeGuid(),
+    pubDate: TemporalAccessor? = dateTime(year = 2020, month = Month.DECEMBER, day = 20, hour = 12, minute = 11, second = 10),
+    source: String? = "episode source",
+    content: Episode.Content? = anEpisodeContent(),
+    iTunes: Episode.ITunes? = anEpisodeITunes(),
+    atom: Episode.Atom? = anEpisodeAtom(),
+    podlove: Episode.Podlove? = anEpisodePodlove(),
+    googlePlay: Episode.GooglePlay? = anEpisodeGooglePlay(),
+    bitlove: Episode.Bitlove? = anEpisodeBitlove()
+) = Episode(
+    title,
+    link,
+    description,
+    author,
+    categories,
+    comments,
+    enclosure,
+    guid,
+    pubDate,
+    source,
+    content,
+    iTunes,
+    atom,
+    podlove,
+    googlePlay,
+    bitlove
+)
+
+internal fun anEpisodeEnclosure(
+    url: String = "episode enclosure url",
+    length: Long = 777,
+    type: String = "episode enclosure type"
+) = Episode.Enclosure(url, length, type)
+
+internal fun anEpisodeGuid(
+    textContent: String = "episode guid textContent",
+    isPermalink: Boolean? = false
+) = Episode.Guid(textContent, isPermalink)
+
+internal fun anEpisodeContent(
+    encoded: String = "episode content encoded"
+) = Episode.Content(encoded)
+
+internal fun anEpisodeITunes(
+    title: String? = "episode itunes title",
+    duration: String? = "episode itunes duration",
+    image: Image? = anImage(url = "episode itunes image url", title = null, link = null, width = null, height = null, description = null),
+    explicit: Boolean? = true,
+    block: Boolean? = true,
+    season: Int? = 2,
+    episode: Int? = 3,
+    episodeType: Episode.ITunes.EpisodeType? = Episode.ITunes.EpisodeType.FULL,
+    author: String? = "episode itunes author",
+    subtitle: String? = "episode itunes subtitle",
+    summary: String? = "episode itunes summary"
+) = Episode.ITunes(title, duration, image, explicit, block, season, episode, episodeType, author, subtitle, summary)
+
+internal fun anEpisodeAtom(
+    authors: List<Person> = listOf(aPerson("episode atom author name")),
+    contributors: List<Person> = listOf(aPerson("episode atom contributor name")),
+    links: List<Link> = listOf(aLink("episode atom link href"))
+) = Episode.Atom(authors, contributors, links)
+
+internal fun anEpisodePodlove(
+    simpleChapters: List<Episode.Podlove.SimpleChapter> = listOf(aPodloveSimpleChapter())
+) = Episode.Podlove(simpleChapters)
+
+internal fun aPodloveSimpleChapter(
+    start: String = "episode podlove simple chapter start",
+    title: String = "episode podlove simple chapter title",
+    href: String? = "episode podlove simple chapter href",
+    image: String? = "episode podlove simple chapter image"
+) = Episode.Podlove.SimpleChapter(start, title, href, image)
+
+internal fun anEpisodeGooglePlay(
+    description: String? = "episode googleplay description",
+    explicit: Boolean? = true,
+    block: Boolean? = true,
+    image: Image? = anImage(url = "episode googleplay image url", title = null, link = null, width = null, height = null, description = null)
+) = Episode.GooglePlay(description, explicit, block, image)
+
+internal fun anEpisodeBitlove(
+    guid: String = "episode bitlove guid"
+) = Episode.Bitlove(guid)

--- a/src/test/kotlin/io/hemin/wien/model/podcast/PodcastFixtures.kt
+++ b/src/test/kotlin/io/hemin/wien/model/podcast/PodcastFixtures.kt
@@ -1,0 +1,98 @@
+package io.hemin.wien.model.podcast
+
+import io.hemin.wien.dateTime
+import io.hemin.wien.model.Episode
+import io.hemin.wien.model.Image
+import io.hemin.wien.model.Link
+import io.hemin.wien.model.Person
+import io.hemin.wien.model.Podcast
+import io.hemin.wien.model.aLink
+import io.hemin.wien.model.aPerson
+import io.hemin.wien.model.anImage
+import io.hemin.wien.model.episode.anEpisode
+import java.time.Month
+import java.time.temporal.TemporalAccessor
+
+internal fun aPodcast(
+    title: String = "podcast title",
+    link: String = "podcast link",
+    description: String = "podcast description",
+    pubDate: TemporalAccessor? = dateTime(year = 2020, month = Month.DECEMBER, day = 26, hour = 15, minute = 32, second = 22),
+    lastBuildDate: TemporalAccessor? = dateTime(year = 2020, month = Month.DECEMBER, day = 22, hour = 8, minute = 11, second = 4),
+    language: String = "language",
+    generator: String? = "generator",
+    copyright: String? = "copyright",
+    docs: String? = "docs",
+    managingEditor: String? = "managing editor",
+    webMaster: String? = "web master",
+    image: Image? = anImage(url = "podcast image url"),
+    episodes: List<Episode> = listOf(anEpisode()),
+    iTunes: Podcast.ITunes? = aPodcastItunes(),
+    atom: Podcast.Atom? = aPodcastAtom(),
+    fyyd: Podcast.Fyyd? = aPodcastFyyd(),
+    feedpress: Podcast.Feedpress? = aPodcastFeedpress(),
+    googlePlay: Podcast.GooglePlay? = aPodcastGooglePlay()
+) = Podcast(
+    title,
+    link,
+    description,
+    pubDate,
+    lastBuildDate,
+    language,
+    generator,
+    copyright,
+    docs,
+    managingEditor,
+    webMaster,
+    image,
+    episodes,
+    iTunes,
+    atom,
+    fyyd,
+    feedpress,
+    googlePlay
+)
+
+internal fun aPodcastItunes(
+    subtitle: String? = "podcast itunes subtitle",
+    summary: String? = "podcast itunes summary",
+    image: Image = anImage(url = "podcast itunes image url", title = null, link = null, width = null, height = null, description = null),
+    keywords: String? = "podcast itunes keywords",
+    author: String? = "podcast itunes author",
+    categories: List<String> = listOf("podcast itunes category"),
+    explicit: Boolean = true,
+    block: Boolean? = true,
+    complete: Boolean? = true,
+    type: Podcast.ITunes.ShowType? = Podcast.ITunes.ShowType.EPISODIC,
+    owner: Person? = aPerson("podcast itunes owner name", uri = null),
+    title: String? = "podcast itunes title",
+    newFeedUrl: String? = "podcast itunes newFeedUrl"
+) = Podcast.ITunes(subtitle, summary, image, keywords, author, categories, explicit, block, complete, type, owner, title, newFeedUrl)
+
+internal fun aPodcastAtom(
+    authors: List<Person> = listOf(aPerson("podcast atom author name")),
+    contributors: List<Person> = listOf(aPerson("podcast atom contributor name")),
+    links: List<Link> = listOf(aLink("podcast atom link href"))
+) = Podcast.Atom(authors, contributors, links)
+
+internal fun aPodcastFyyd(
+    verify: String = "podcast fyyd verify"
+) = Podcast.Fyyd(verify)
+
+internal fun aPodcastFeedpress(
+    newsletterId: String? = "podcast feedpress newsletterId",
+    locale: String? = "podcast feedpress locale",
+    podcastId: String? = "podcast feedpress podcastId",
+    cssFile: String? = "podcast feedpress cssFile",
+    link: String? = "podcast feedpress link"
+) = Podcast.Feedpress(newsletterId, locale, podcastId, cssFile, link)
+
+internal fun aPodcastGooglePlay(
+    author: String? = "podcast googleplay author",
+    owner: String? = "podcast googleplay owner",
+    categories: List<String> = listOf("podcast googleplay category"),
+    description: String? = "podcast googleplay description",
+    explicit: Boolean? = true,
+    block: Boolean? = true,
+    image: Image? = anImage(url = "podcast googleplay image url", title = null, link = null, width = null, height = null, description = null)
+) = Podcast.GooglePlay(author, owner, categories, description, explicit, block, image)

--- a/src/test/kotlin/io/hemin/wien/parser/AtomParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/AtomParserTest.kt
@@ -35,7 +35,7 @@ internal class AtomParserTest : NamespaceParserTest() {
     fun `should extract all atom fields from channel when present`() {
         val channel: Node = nodeFromResource("channel", "/xml/channel.xml")
         val builder = FakePodcastBuilder()
-        parseChannelChildNodes(builder, channel)
+        channel.parseChannelChildNodes(builder)
 
         assertThat(builder.atom, "atom podcast data").all {
             prop(FakePodcastAtomBuilder::authorBuilders).containsExactly(expectedPersonBuilder)
@@ -48,7 +48,7 @@ internal class AtomParserTest : NamespaceParserTest() {
     fun `should extract nothing from channel when no atom data is present`() {
         val channel: Node = nodeFromResource("channel", "/xml/channel-incomplete.xml")
         val builder = FakePodcastBuilder()
-        parseChannelChildNodes(builder, channel)
+        channel.parseChannelChildNodes(builder)
 
         assertThat(builder.atom, "atom episode data").all {
             prop(FakePodcastAtomBuilder::authorBuilders).isEmpty()
@@ -61,7 +61,7 @@ internal class AtomParserTest : NamespaceParserTest() {
     fun `should extract all atom fields from item when present`() {
         val item: Node = nodeFromResource("item", "/xml/item.xml")
         val builder = FakeEpisodeBuilder()
-        parseItemChildNodes(builder, item)
+        item.parseItemChildNodes(builder)
 
         assertThat(builder.atom, "atom item data").all {
             prop(FakeEpisodeAtomBuilder::authorBuilders).containsExactly(expectedPersonBuilder)
@@ -74,7 +74,7 @@ internal class AtomParserTest : NamespaceParserTest() {
     fun `should extract nothing from item when no atom data is present`() {
         val item: Node = nodeFromResource("item", "/xml/item-incomplete.xml")
         val builder = FakeEpisodeBuilder()
-        parseItemChildNodes(builder, item)
+        item.parseItemChildNodes(builder)
 
         assertThat(builder.atom, "atom item data").all {
             prop(FakeEpisodeAtomBuilder::authorBuilders).isEmpty()

--- a/src/test/kotlin/io/hemin/wien/parser/BitloveParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/BitloveParserTest.kt
@@ -19,7 +19,7 @@ internal class BitloveParserTest : NamespaceParserTest() {
     fun `should not extract the Bitlove guid attribute from enclosure nodes when it's absent`() {
         val node: Node = nodeFromResource("item", "/xml/item-incomplete.xml")
         val builder = FakeEpisodeBuilder()
-        parseItemChildNodes(builder, node)
+        node.parseItemChildNodes(builder)
 
         assertThat(builder.bitlove, "item bitlove data")
             .prop(FakeEpisodeBitloveBuilder::guid).isNull()
@@ -29,7 +29,7 @@ internal class BitloveParserTest : NamespaceParserTest() {
     fun `should extract the Bitlove guid attribute from enclosure nodes when it's present`() {
         val node: Node = nodeFromResource("item", "/xml/item.xml")
         val builder = FakeEpisodeBuilder()
-        parseItemChildNodes(builder, node)
+        node.parseItemChildNodes(builder)
 
         assertThat(builder.bitlove, "item bitlove data")
             .prop(FakeEpisodeBitloveBuilder::guid).isEqualTo("abcdefg")

--- a/src/test/kotlin/io/hemin/wien/parser/ContentParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/ContentParserTest.kt
@@ -19,7 +19,7 @@ internal class ContentParserTest : NamespaceParserTest() {
     fun `should not extract content data from item when absent`() {
         val node: Node = nodeFromResource("item", "/xml/item-incomplete.xml")
         val builder = FakeEpisodeBuilder()
-        parseItemChildNodes(builder, node)
+        node.parseItemChildNodes(builder)
 
         assertThat(builder.content, "item content data")
             .prop(FakeEpisodeContentBuilder::encoded).isNull()
@@ -29,7 +29,7 @@ internal class ContentParserTest : NamespaceParserTest() {
     fun `should extract content data from item when present`() {
         val node: Node = nodeFromResource("item", "/xml/item.xml")
         val builder = FakeEpisodeBuilder()
-        parseItemChildNodes(builder, node)
+        node.parseItemChildNodes(builder)
 
         assertThat(builder.content, "item content data")
             .prop(FakeEpisodeContentBuilder::encoded).isEqualTo("Lorem Ipsum")

--- a/src/test/kotlin/io/hemin/wien/parser/FeedpressParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/FeedpressParserTest.kt
@@ -19,7 +19,7 @@ internal class FeedpressParserTest : NamespaceParserTest() {
     fun `should extract feedpress data from channel when present`() {
         val node = nodeFromResource("channel", "/xml/channel.xml")
         val builder = FakePodcastBuilder()
-        parseChannelChildNodes(builder, node)
+        node.parseChannelChildNodes(builder)
 
         assertThat(builder.feedpress, "channel feedpress data").all {
             prop(FakePodcastFeedpressBuilder::newsletterIdValue).isEqualTo("abc123")
@@ -34,7 +34,7 @@ internal class FeedpressParserTest : NamespaceParserTest() {
     fun `should not extract feedpress data from channel when present`() {
         val node = nodeFromResource("channel", "/xml/channel-incomplete.xml")
         val builder = FakePodcastBuilder()
-        parseChannelChildNodes(builder, node)
+        node.parseChannelChildNodes(builder)
 
         assertThat(builder.feedpress, "channel feedpress data").all {
             prop(FakePodcastFeedpressBuilder::newsletterIdValue).isNull()

--- a/src/test/kotlin/io/hemin/wien/parser/FyydParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/FyydParserTest.kt
@@ -18,7 +18,7 @@ internal class FyydParserTest : NamespaceParserTest() {
     fun `should extract fyyd data from channel when present`() {
         val node = nodeFromResource("channel", "/xml/channel.xml")
         val builder = FakePodcastBuilder()
-        parseChannelChildNodes(builder, node)
+        node.parseChannelChildNodes(builder)
 
         assertThat(builder.fyyd, "channel.fyyd")
             .prop(FakePodcastFyydBuilder::verifyValue).isEqualTo("abcdefg")
@@ -28,7 +28,7 @@ internal class FyydParserTest : NamespaceParserTest() {
     fun `should not extract fyyd data from channel when absent`() {
         val node = nodeFromResource("channel", "/xml/channel-incomplete.xml")
         val builder = FakePodcastBuilder()
-        parseChannelChildNodes(builder, node)
+        node.parseChannelChildNodes(builder)
 
         assertThat(builder.fyyd, "channel.fyyd")
             .prop(FakePodcastFyydBuilder::verifyValue).isNull()

--- a/src/test/kotlin/io/hemin/wien/parser/GooglePlayParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/GooglePlayParserTest.kt
@@ -22,15 +22,15 @@ internal class GooglePlayParserTest : NamespaceParserTest() {
 
     override val parser: NamespaceParser = GooglePlayParser()
 
-    private val expectedPodcastImage = FakeImageBuilder().url("http://example.org/podcast-cover.jpg")
+    private val expectedPodcastImageBuilder = FakeImageBuilder().url("http://example.org/podcast-cover.jpg")
 
-    private val expectedEpisodeImage = FakeImageBuilder().url("http://example.org/episode-cover.jpg")
+    private val expectedEpisodeImageBuilder = FakeImageBuilder().url("http://example.org/episode-cover.jpg")
 
     @Test
     fun `should extract all google play fields from channel when present`() {
         val node = nodeFromResource("channel", "/xml/channel.xml")
         val builder = FakePodcastBuilder()
-        parseChannelChildNodes(builder, node)
+        node.parseChannelChildNodes(builder)
 
         assertThat(builder.googlePlay, "channel.googleplay").all {
             prop(FakePodcastGooglePlayBuilder::author).isEqualTo("Lorem Ipsum")
@@ -39,7 +39,7 @@ internal class GooglePlayParserTest : NamespaceParserTest() {
             prop(FakePodcastGooglePlayBuilder::description).isEqualTo("Lorem Ipsum")
             prop(FakePodcastGooglePlayBuilder::explicit).isNotNull().isFalse()
             prop(FakePodcastGooglePlayBuilder::block).isNotNull().isFalse()
-            prop(FakePodcastGooglePlayBuilder::imageBuilder).isEqualTo(expectedPodcastImage)
+            prop(FakePodcastGooglePlayBuilder::imageBuilder).isEqualTo(expectedPodcastImageBuilder)
         }
     }
 
@@ -47,7 +47,7 @@ internal class GooglePlayParserTest : NamespaceParserTest() {
     fun `should not extract google play fields from channel when absent`() {
         val node = nodeFromResource("channel", "/xml/channel-incomplete.xml")
         val builder = FakePodcastBuilder()
-        parseChannelChildNodes(builder, node)
+        node.parseChannelChildNodes(builder)
 
         assertThat(builder.googlePlay, "channel.googleplay").all {
             prop(FakePodcastGooglePlayBuilder::author).isNull()
@@ -64,13 +64,13 @@ internal class GooglePlayParserTest : NamespaceParserTest() {
     fun `should extract all google play fields from item when present`() {
         val node = nodeFromResource("item", "/xml/item.xml")
         val builder = FakeEpisodeBuilder()
-        parseItemChildNodes(builder, node)
+        node.parseItemChildNodes(builder)
 
         assertThat(builder.googlePlay, "item.googleplay").all {
             prop(FakeEpisodeGooglePlayBuilder::description).isEqualTo("Lorem Ipsum")
             prop(FakeEpisodeGooglePlayBuilder::explicit).isNotNull().isFalse()
             prop(FakeEpisodeGooglePlayBuilder::block).isNotNull().isFalse()
-            prop(FakeEpisodeGooglePlayBuilder::imageBuilder).isEqualTo(expectedEpisodeImage)
+            prop(FakeEpisodeGooglePlayBuilder::imageBuilder).isEqualTo(expectedEpisodeImageBuilder)
         }
     }
 
@@ -78,7 +78,7 @@ internal class GooglePlayParserTest : NamespaceParserTest() {
     fun `should not extract google play fields from item when absent`() {
         val node = nodeFromResource("item", "/xml/item-incomplete.xml")
         val builder = FakeEpisodeBuilder()
-        parseItemChildNodes(builder, node)
+        node.parseItemChildNodes(builder)
 
         assertThat(builder.googlePlay, "item.googleplay").all {
             prop(FakeEpisodeGooglePlayBuilder::description).isNull()

--- a/src/test/kotlin/io/hemin/wien/parser/ITunesParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/ITunesParserTest.kt
@@ -37,7 +37,7 @@ internal class ITunesParserTest : NamespaceParserTest() {
     fun `should extract all itunes fields from channel when present`() {
         val node = nodeFromResource("channel", "/xml/channel.xml")
         val builder = FakePodcastBuilder()
-        parseChannelChildNodes(builder, node)
+        node.parseChannelChildNodes(builder)
 
         assertThat(builder.iTunes, "channel.itunes").all {
             prop(FakePodcastITunesBuilder::author).isEqualTo("Lorem Ipsum")
@@ -58,7 +58,7 @@ internal class ITunesParserTest : NamespaceParserTest() {
     fun `should not extract itunes fields from channel when absent`() {
         val node = nodeFromResource("channel", "/xml/channel-incomplete.xml")
         val builder = FakePodcastBuilder()
-        parseChannelChildNodes(builder, node)
+        node.parseChannelChildNodes(builder)
 
         assertThat(builder.iTunes, "channel.itunes").all {
             prop(FakePodcastITunesBuilder::author).isNull()
@@ -79,7 +79,7 @@ internal class ITunesParserTest : NamespaceParserTest() {
     fun `should extract all itunes fields from item when present`() {
         val node = nodeFromResource("item", "/xml/item.xml")
         val builder = FakeEpisodeBuilder()
-        parseItemChildNodes(builder, node)
+        node.parseItemChildNodes(builder)
 
         assertThat(builder.iTunes, "item.itunes").all {
             prop(FakeEpisodeITunesBuilder::title).isEqualTo("Lorem Ipsum")
@@ -100,7 +100,7 @@ internal class ITunesParserTest : NamespaceParserTest() {
     fun `should not extract itunes fields from item when absent`() {
         val node = nodeFromResource("item", "/xml/item-incomplete.xml")
         val builder = FakeEpisodeBuilder()
-        parseItemChildNodes(builder, node)
+        node.parseItemChildNodes(builder)
 
         assertThat(builder.iTunes, "item.itunes").all {
             prop(FakeEpisodeITunesBuilder::title).isNull()

--- a/src/test/kotlin/io/hemin/wien/parser/NamespaceParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/NamespaceParserTest.kt
@@ -2,21 +2,21 @@ package io.hemin.wien.parser
 
 import io.hemin.wien.builder.fake.episode.FakeEpisodeBuilder
 import io.hemin.wien.builder.fake.podcast.FakePodcastBuilder
-import io.hemin.wien.util.NodeListWrapper.Companion.asListOfNodes
+import io.hemin.wien.util.asListOfNodes
 import org.w3c.dom.Node
 
 internal abstract class NamespaceParserTest {
 
     abstract val parser: NamespaceParser
 
-    protected fun parseChannelChildNodes(builder: FakePodcastBuilder, channel: Node) {
-        for (element in channel.childNodes.asListOfNodes()) {
+    protected fun Node.parseChannelChildNodes(builder: FakePodcastBuilder) {
+        for (element in childNodes.asListOfNodes()) {
             parser.tryParsingChannelChildNode(builder, element)
         }
     }
 
-    protected fun parseItemChildNodes(builder: FakeEpisodeBuilder, item: Node) {
-        for (element in item.childNodes.asListOfNodes()) {
+    protected fun Node.parseItemChildNodes(builder: FakeEpisodeBuilder) {
+        for (element in childNodes.asListOfNodes()) {
             parser.tryParsingItemChildNode(builder, element)
         }
     }

--- a/src/test/kotlin/io/hemin/wien/parser/PodloveSimpleChapterParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/PodloveSimpleChapterParserTest.kt
@@ -17,7 +17,7 @@ internal class PodloveSimpleChapterParserTest : NamespaceParserTest() {
     fun `should not extract podlove chapter data from item when absent`() {
         val node = nodeFromResource("item", "/xml/item-incomplete.xml")
         val builder = FakeEpisodeBuilder()
-        parseItemChildNodes(builder, node)
+        node.parseItemChildNodes(builder)
 
         assertThat(builder.podlove.chapterBuilders, "item.podlove_simple_chapters").isEmpty()
     }
@@ -26,7 +26,7 @@ internal class PodloveSimpleChapterParserTest : NamespaceParserTest() {
     fun `should extract podlove chapter data from item when present`() {
         val node = nodeFromResource("item", "/xml/item.xml")
         val builder = FakeEpisodeBuilder()
-        parseItemChildNodes(builder, node)
+        node.parseItemChildNodes(builder)
 
         assertThat(builder.podlove.chapterBuilders, "item.podlove_simple_chapters")
             .containsExactly(

--- a/src/test/kotlin/io/hemin/wien/parser/RssParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/RssParserTest.kt
@@ -49,7 +49,7 @@ internal class RssParserTest : NamespaceParserTest() {
     fun `should extract all RSS fields from channel when present`() {
         val node = nodeFromResource("channel", "/xml/channel.xml")
         val builder = FakePodcastBuilder()
-        parseChannelChildNodes(builder, node)
+        node.parseChannelChildNodes(builder)
 
         assertThat(builder, "channel").all {
             prop(FakePodcastBuilder::titleValue).isEqualTo("Lorem Ipsum")
@@ -71,7 +71,7 @@ internal class RssParserTest : NamespaceParserTest() {
     fun `should not extract RSS fields from channel when absent`() {
         val node = nodeFromResource("channel", "/xml/channel-incomplete.xml")
         val builder = FakePodcastBuilder()
-        parseChannelChildNodes(builder, node)
+        node.parseChannelChildNodes(builder)
 
         assertThat(builder, "channel").all {
             prop(FakePodcastBuilder::titleValue).isEqualTo("Lorem Ipsum")
@@ -93,7 +93,7 @@ internal class RssParserTest : NamespaceParserTest() {
     fun `should extract all RSS fields from item when present`() {
         val node = nodeFromResource("item", "/xml/item.xml")
         val builder = FakeEpisodeBuilder()
-        parseItemChildNodes(builder, node)
+        node.parseItemChildNodes(builder)
 
         assertThat(builder, "item").all {
             prop(FakeEpisodeBuilder::titleValue).isEqualTo("Lorem Ipsum")
@@ -113,7 +113,7 @@ internal class RssParserTest : NamespaceParserTest() {
     fun `should not extract RSS fields from item when absent`() {
         val node = nodeFromResource("item", "/xml/item-incomplete.xml")
         val builder = FakeEpisodeBuilder()
-        parseItemChildNodes(builder, node)
+        node.parseItemChildNodes(builder)
 
         assertThat(builder, "item").all {
             prop(FakeEpisodeBuilder::titleValue).isEqualTo("Lorem Ipsum")

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/AtomWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/AtomWriterTest.kt
@@ -1,0 +1,67 @@
+package io.hemin.wien.writer.namespace
+
+import assertk.assertAll
+import assertk.assertThat
+import io.hemin.wien.hasNoDifferences
+import io.hemin.wien.model.episode.anEpisode
+import io.hemin.wien.model.podcast.aPodcast
+import org.junit.jupiter.api.Test
+
+internal class AtomWriterTest : NamespaceWriterTest() {
+
+    override val writer = AtomWriter()
+
+    @Test
+    internal fun `should write the correct atom tags to the channel when there is data to write`() {
+        assertAll {
+            writePodcastData("author") { element ->
+                val diff = element.diffFromExpected("/rss/channel/atom:author[1]")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("contributor") { element ->
+                val diff = element.diffFromExpected("/rss/channel/atom:contributor[1]")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("link") { element ->
+                val diff = element.diffFromExpected("/rss/channel/atom:link[1]")
+                assertThat(diff).hasNoDifferences()
+            }
+        }
+    }
+
+    @Test
+    internal fun `should not write atom tags to the channel when there is no data to write`() {
+        assertAll {
+            assertTagIsNotWrittenToPodcast(aPodcast(atom = null), "author")
+            assertTagIsNotWrittenToPodcast(aPodcast(atom = null), "contributor")
+            assertTagIsNotWrittenToPodcast(aPodcast(atom = null), "link")
+        }
+    }
+
+    @Test
+    internal fun `should write the correct atom tags to the item when there is data to write`() {
+        assertAll {
+            writeEpisodeData("author") { element ->
+                val diff = element.diffFromExpected("/rss/channel/item[1]/atom:author[1]")
+                assertThat(diff).hasNoDifferences()
+            }
+            writeEpisodeData("contributor") { element ->
+                val diff = element.diffFromExpected("/rss/channel/item[1]/atom:contributor[1]")
+                assertThat(diff).hasNoDifferences()
+            }
+            writeEpisodeData("link") { element ->
+                val diff = element.diffFromExpected("/rss/channel/item[1]/atom:link[1]")
+                assertThat(diff).hasNoDifferences()
+            }
+        }
+    }
+
+    @Test
+    internal fun `should not write atom tags to the item when there is no data to write`() {
+        assertAll {
+            assertTagIsNotWrittenToEpisode(anEpisode(atom = null), "author")
+            assertTagIsNotWrittenToEpisode(anEpisode(atom = null), "contributor")
+            assertTagIsNotWrittenToEpisode(anEpisode(atom = null), "link")
+        }
+    }
+}

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/BitloveWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/BitloveWriterTest.kt
@@ -1,0 +1,47 @@
+package io.hemin.wien.writer.namespace
+
+import assertk.Assert
+import assertk.assertAll
+import assertk.assertThat
+import assertk.fail
+import io.hemin.wien.hasNoAttribute
+import io.hemin.wien.hasNoDifferences
+import io.hemin.wien.model.episode.anEpisode
+import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.appendElement
+import io.hemin.wien.util.findElementByName
+import org.junit.jupiter.api.Test
+import org.w3c.dom.Node
+
+internal class BitloveWriterTest : NamespaceWriterTest() {
+
+    override val writer = BitloveWriter()
+
+    @Test
+    internal fun `should write a the correct bitlove_guid attribute to the item enclosure tag when there is data to write`() {
+        val itemElement = createChannelElement().createItemElement()
+
+        // We need to run the RSS writer first, to create the <enclosure> tag (among others)
+        val episode = anEpisode()
+        RssWriter().tryWritingEpisodeData(episode, itemElement)
+        val enclosureItem = itemElement.findElementByName("enclosure")
+            ?: throw IllegalStateException("The RssWriter did not create an <enclosure> tag, but was expected to")
+
+        writer.tryWritingEpisodeData(episode, itemElement)
+        val diff = enclosureItem.diffFromExpected("/rss/channel/item[1]/enclosure")
+        assertThat(diff).hasNoDifferences()
+    }
+
+    @Test
+    internal fun `should not write a bitlove_guid attribute to the item enclosure tag when there is no data to write`() {
+        assertAll {
+            val episodeWithoutBitlove = anEpisode(bitlove = null)
+            assertTagIsNotWrittenToEpisode(episodeWithoutBitlove, "encoded")
+
+            val itemElement = createChannelElement().createItemElement()
+            val enclosureItem = itemElement.appendElement("enclosure")
+            writer.tryWritingEpisodeData(episodeWithoutBitlove, itemElement)
+            assertThat(enclosureItem).hasNoAttribute("guid", writer.namespace)
+        }
+    }
+}

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/ContentWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/ContentWriterTest.kt
@@ -1,0 +1,24 @@
+package io.hemin.wien.writer.namespace
+
+import assertk.assertThat
+import io.hemin.wien.hasNoDifferences
+import io.hemin.wien.model.episode.anEpisode
+import org.junit.jupiter.api.Test
+
+internal class ContentWriterTest : NamespaceWriterTest() {
+
+    override val writer = ContentWriter()
+
+    @Test
+    internal fun `should write a the correct content_encoded tag to the item when there is data to write`() {
+        writeEpisodeData("encoded") { element ->
+            val diff = element.diffFromExpected("/rss/channel/item[1]/content:encoded")
+            assertThat(diff).hasNoDifferences()
+        }
+    }
+
+    @Test
+    internal fun `should not write a content_encoded tag to the item when there is no data to write`() {
+        assertTagIsNotWrittenToEpisode(anEpisode(content = null), "encoded")
+    }
+}

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/FeedpressWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/FeedpressWriterTest.kt
@@ -1,0 +1,48 @@
+package io.hemin.wien.writer.namespace
+
+import assertk.assertThat
+import io.hemin.wien.hasNoDifferences
+import io.hemin.wien.model.podcast.aPodcast
+import org.junit.jupiter.api.Test
+
+internal class FeedpressWriterTest : NamespaceWriterTest() {
+
+    override val writer = FeedpressWriter()
+
+    @Test
+    internal fun `should write the correct feedpress tags to the channel when there is data to write`() {
+        assertk.assertAll {
+            writePodcastData("newsletterId") { element ->
+                val diff = element.diffFromExpected("/rss/channel/feedpress:newsletterId")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("locale") { element ->
+                val diff = element.diffFromExpected("/rss/channel/feedpress:locale")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("podcastId") { element ->
+                val diff = element.diffFromExpected("/rss/channel/feedpress:podcastId")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("cssFile") { element ->
+                val diff = element.diffFromExpected("/rss/channel/feedpress:cssFile")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("link") { element ->
+                val diff = element.diffFromExpected("/rss/channel/feedpress:link")
+                assertThat(diff).hasNoDifferences()
+            }
+        }
+    }
+
+    @Test
+    internal fun `should not write feedpress tags to the channel when there is no data to write`() {
+        assertk.assertAll {
+            assertTagIsNotWrittenToPodcast(aPodcast(feedpress = null), "newsletterId")
+            assertTagIsNotWrittenToPodcast(aPodcast(feedpress = null), "locale")
+            assertTagIsNotWrittenToPodcast(aPodcast(feedpress = null), "podcastId")
+            assertTagIsNotWrittenToPodcast(aPodcast(feedpress = null), "cssFile")
+            assertTagIsNotWrittenToPodcast(aPodcast(feedpress = null), "link")
+        }
+    }
+}

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/FyydWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/FyydWriterTest.kt
@@ -1,0 +1,25 @@
+package io.hemin.wien.writer.namespace
+
+import assertk.assertThat
+import io.hemin.wien.hasNoDifferences
+import io.hemin.wien.model.episode.anEpisode
+import io.hemin.wien.model.podcast.aPodcast
+import org.junit.jupiter.api.Test
+
+internal class FyydWriterTest : NamespaceWriterTest() {
+
+    override val writer = FyydWriter()
+
+    @Test
+    internal fun `should write a the correct fyyd_verify tag to the channel when there is data to write`() {
+        writePodcastData("verify") { element ->
+            val diff = element.diffFromExpected("/rss/channel/fyyd:verify")
+            assertThat(diff).hasNoDifferences()
+        }
+    }
+
+    @Test
+    internal fun `should not write a fyyd_verify tag to the item when there is no data to write`() {
+        assertTagIsNotWrittenToPodcast(aPodcast(fyyd = null), "verify")
+    }
+}

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/GooglePlayWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/GooglePlayWriterTest.kt
@@ -1,0 +1,92 @@
+package io.hemin.wien.writer.namespace
+
+import assertk.assertAll
+import assertk.assertThat
+import io.hemin.wien.hasNoDifferences
+import io.hemin.wien.model.episode.anEpisode
+import io.hemin.wien.model.podcast.aPodcast
+import org.junit.jupiter.api.Test
+
+internal class GooglePlayWriterTest: NamespaceWriterTest() {
+
+    override val writer = GooglePlayWriter()
+
+    @Test
+    internal fun `should write the correct googleplay tags to the channel when there is data to write`() {
+        assertAll {
+            writePodcastData("author") { element ->
+                val diff = element.diffFromExpected("/rss/channel/googleplay:author")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("owner") { element ->
+                val diff = element.diffFromExpected("/rss/channel/googleplay:owner")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("category") { element ->
+                val diff = element.diffFromExpected("/rss/channel/googleplay:category")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("description") { element ->
+                val diff = element.diffFromExpected("/rss/channel/googleplay:description")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("explicit") { element ->
+                val diff = element.diffFromExpected("/rss/channel/googleplay:explicit")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("block") { element ->
+                val diff = element.diffFromExpected("/rss/channel/googleplay:block")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("image") { element ->
+                val diff = element.diffFromExpected("/rss/channel/googleplay:image")
+                assertThat(diff).hasNoDifferences()
+            }
+        }
+    }
+
+    @Test
+    internal fun `should not write googleplay tags to the channel when there is no data to write`() {
+        assertAll {
+            assertTagIsNotWrittenToPodcast(aPodcast(googlePlay = null), "author")
+            assertTagIsNotWrittenToPodcast(aPodcast(googlePlay = null), "owner")
+            assertTagIsNotWrittenToPodcast(aPodcast(googlePlay = null), "category")
+            assertTagIsNotWrittenToPodcast(aPodcast(googlePlay = null), "description")
+            assertTagIsNotWrittenToPodcast(aPodcast(googlePlay = null), "explicit")
+            assertTagIsNotWrittenToPodcast(aPodcast(googlePlay = null), "block")
+            assertTagIsNotWrittenToPodcast(aPodcast(googlePlay = null), "image")
+        }
+    }
+
+    @Test
+    internal fun `should write the correct googleplay tags to the item when there is data to write`() {
+        assertAll {
+            writeEpisodeData("description") { element ->
+                val diff = element.diffFromExpected("/rss/channel/item[1]/googleplay:description")
+                assertThat(diff).hasNoDifferences()
+            }
+            writeEpisodeData("explicit") { element ->
+                val diff = element.diffFromExpected("/rss/channel/item[1]/googleplay:explicit")
+                assertThat(diff).hasNoDifferences()
+            }
+            writeEpisodeData("block") { element ->
+                val diff = element.diffFromExpected("/rss/channel/item[1]/googleplay:block")
+                assertThat(diff).hasNoDifferences()
+            }
+            writeEpisodeData("image") { element ->
+                val diff = element.diffFromExpected("/rss/channel/item[1]/googleplay:image")
+                assertThat(diff).hasNoDifferences()
+            }
+        }
+    }
+
+    @Test
+    internal fun `should not write googleplay tags to the item when there is no data to write`() {
+        assertAll {
+            assertTagIsNotWrittenToEpisode(anEpisode(googlePlay = null), "description")
+            assertTagIsNotWrittenToEpisode(anEpisode(googlePlay = null), "explicit")
+            assertTagIsNotWrittenToEpisode(anEpisode(googlePlay = null), "block")
+            assertTagIsNotWrittenToEpisode(anEpisode(googlePlay = null), "image")
+        }
+    }
+}

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/ITunesWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/ITunesWriterTest.kt
@@ -1,0 +1,137 @@
+package io.hemin.wien.writer.namespace
+
+import assertk.assertAll
+import assertk.assertThat
+import io.hemin.wien.hasNoDifferences
+import io.hemin.wien.model.episode.anEpisode
+import io.hemin.wien.model.podcast.aPodcast
+import org.junit.jupiter.api.Test
+
+internal class ITunesWriterTest: NamespaceWriterTest() {
+
+    override val writer = ITunesWriter()
+
+    @Test
+    internal fun `should write the correct itunes tags to the channel when there is data to write`() {
+        assertAll {
+            writePodcastData("author") { element ->
+                val diff = element.diffFromExpected("/rss/channel/itunes:author")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("category") { element ->
+                val diff = element.diffFromExpected("/rss/channel/itunes:category")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("complete") { element ->
+                val diff = element.diffFromExpected("/rss/channel/itunes:complete")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("keywords") { element ->
+                val diff = element.diffFromExpected("/rss/channel/itunes:keywords")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("owner") { element ->
+                val diff = element.diffFromExpected("/rss/channel/itunes:owner")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("subtitle") { element ->
+                val diff = element.diffFromExpected("/rss/channel/itunes:subtitle")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("summary") { element ->
+                val diff = element.diffFromExpected("/rss/channel/itunes:summary")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("type") { element ->
+                val diff = element.diffFromExpected("/rss/channel/itunes:type")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("image") { element ->
+                val diff = element.diffFromExpected("/rss/channel/itunes:image")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("explicit") { element ->
+                val diff = element.diffFromExpected("/rss/channel/itunes:explicit")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("title") { element ->
+                val diff = element.diffFromExpected("/rss/channel/itunes:title")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("block") { element ->
+                val diff = element.diffFromExpected("/rss/channel/itunes:block")
+                assertThat(diff).hasNoDifferences()
+            }
+        }
+    }
+
+    @Test
+    internal fun `should not write itunes tags to the channel when there is no data to write`() {
+        assertAll {
+            assertTagIsNotWrittenToPodcast(aPodcast(iTunes = null), "author")
+            assertTagIsNotWrittenToPodcast(aPodcast(iTunes = null), "category")
+            assertTagIsNotWrittenToPodcast(aPodcast(iTunes = null), "complete")
+            assertTagIsNotWrittenToPodcast(aPodcast(iTunes = null), "keywords")
+            assertTagIsNotWrittenToPodcast(aPodcast(iTunes = null), "owner")
+            assertTagIsNotWrittenToPodcast(aPodcast(iTunes = null), "subtitle")
+            assertTagIsNotWrittenToPodcast(aPodcast(iTunes = null), "summary")
+            assertTagIsNotWrittenToPodcast(aPodcast(iTunes = null), "type")
+            assertTagIsNotWrittenToPodcast(aPodcast(iTunes = null), "image")
+            assertTagIsNotWrittenToPodcast(aPodcast(iTunes = null), "explicit")
+            assertTagIsNotWrittenToPodcast(aPodcast(iTunes = null), "title")
+            assertTagIsNotWrittenToPodcast(aPodcast(iTunes = null), "block")
+        }
+    }
+
+    @Test
+    internal fun `should write the correct itunes tags to the item when there is data to write`() {
+        assertAll {
+            writeEpisodeData("duration") { element ->
+                val diff = element.diffFromExpected("/rss/channel/item[1]/itunes:duration")
+                assertThat(diff).hasNoDifferences()
+            }
+            writeEpisodeData("season") { element ->
+                val diff = element.diffFromExpected("/rss/channel/item[1]/itunes:season")
+                assertThat(diff).hasNoDifferences()
+            }
+            writeEpisodeData("episode") { element ->
+                val diff = element.diffFromExpected("/rss/channel/item[1]/itunes:episode")
+                assertThat(diff).hasNoDifferences()
+            }
+            writeEpisodeData("episodeType") { element ->
+                val diff = element.diffFromExpected("/rss/channel/item[1]/itunes:episodeType")
+                assertThat(diff).hasNoDifferences()
+            }
+            writeEpisodeData("image") { element ->
+                val diff = element.diffFromExpected("/rss/channel/item[1]/itunes:image")
+                assertThat(diff).hasNoDifferences()
+            }
+            writeEpisodeData("explicit") { element ->
+                val diff = element.diffFromExpected("/rss/channel/item[1]/itunes:explicit")
+                assertThat(diff).hasNoDifferences()
+            }
+            writeEpisodeData("title") { element ->
+                val diff = element.diffFromExpected("/rss/channel/item[1]/itunes:title")
+                assertThat(diff).hasNoDifferences()
+            }
+            writeEpisodeData("block") { element ->
+                val diff = element.diffFromExpected("/rss/channel/item[1]/itunes:block")
+                assertThat(diff).hasNoDifferences()
+            }
+        }
+    }
+
+    @Test
+    internal fun `should not write itunes tags to the item when there is no data to write`() {
+        assertAll {
+            assertTagIsNotWrittenToEpisode(anEpisode(iTunes = null), "duration")
+            assertTagIsNotWrittenToEpisode(anEpisode(iTunes = null), "season")
+            assertTagIsNotWrittenToEpisode(anEpisode(iTunes = null), "episode")
+            assertTagIsNotWrittenToEpisode(anEpisode(iTunes = null), "episodeType")
+            assertTagIsNotWrittenToEpisode(anEpisode(iTunes = null), "image")
+            assertTagIsNotWrittenToEpisode(anEpisode(iTunes = null), "explicit")
+            assertTagIsNotWrittenToEpisode(anEpisode(iTunes = null), "title")
+            assertTagIsNotWrittenToEpisode(anEpisode(iTunes = null), "block")
+        }
+    }
+}

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/NamespaceWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/NamespaceWriterTest.kt
@@ -1,0 +1,133 @@
+package io.hemin.wien.writer.namespace
+
+import assertk.assertThat
+import assertk.assertions.isNull
+import assertk.fail
+import io.hemin.wien.documentFromResource
+import io.hemin.wien.model.Episode
+import io.hemin.wien.model.Podcast
+import io.hemin.wien.model.episode.anEpisode
+import io.hemin.wien.model.podcast.aPodcast
+import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.appendElement
+import io.hemin.wien.util.findElementByName
+import io.hemin.wien.writer.NamespaceWriter
+import org.w3c.dom.Element
+import org.w3c.dom.Node
+import org.xmlunit.builder.DiffBuilder
+import org.xmlunit.builder.Input
+import org.xmlunit.diff.Diff
+import javax.xml.namespace.NamespaceContext
+import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.xpath.XPathConstants
+import javax.xml.xpath.XPathFactory
+
+internal abstract class NamespaceWriterTest {
+
+    private val xpath = XPathFactory.newDefaultInstance().newXPath()
+        .apply { namespaceContext = FeedNamespaceContext }
+
+    private val documentBuilder = DocumentBuilderFactory.newInstance()
+        .apply { isNamespaceAware = true }
+        .newDocumentBuilder()
+
+    protected abstract val writer: NamespaceWriter
+
+    protected fun Element.diffFromExpected(xpath: String, resourcePath: String = "/xml/writer-fixtures.xml"): Diff =
+        DiffBuilder.compare(Input.fromNode(this).build())
+            .withTest(Input.fromNode(expectedNode(xpath, resourcePath)))
+            .ignoreWhitespace()
+            .build()
+
+    private fun expectedNode(nodePath: String, resourcePath: String): Node {
+        val document = documentFromResource(resourcePath)
+        val node = xpath.evaluate(nodePath, document, XPathConstants.NODE) as? Node
+        requireNotNull(node) { "The node with XPath '$nodePath' could not be found in resource '$resourcePath'" }
+        return node
+    }
+
+    protected fun writePodcastData(
+        localName: String,
+        namespace: FeedNamespace? = writer.namespace,
+        podcast: Podcast = aPodcast(),
+        assertions: (element: Element) -> Unit
+    ) {
+        val itemElement = createChannelElement()
+        writer.tryWritingPodcastData(podcast, itemElement)
+
+        val actualElement = itemElement.findElementByName(localName, namespace)
+            ?: fail("The <${namespace?.prefix ?: ""}:$localName> tag was not written")
+
+        assertions(actualElement)
+    }
+
+    protected fun assertTagIsNotWrittenToPodcast(
+        podcast: Podcast,
+        localName: String,
+        namespace: FeedNamespace? = writer.namespace
+    ) {
+        val itemElement = createChannelElement()
+        writer.tryWritingPodcastData(podcast, itemElement)
+
+        assertThat(itemElement.findElementByName(localName, namespace)).isNull()
+    }
+
+    protected fun writeEpisodeData(
+        localName: String,
+        namespace: FeedNamespace? = writer.namespace,
+        episode: Episode = anEpisode(),
+        assertions: (element: Element) -> Unit
+    ) {
+        val itemElement = createChannelElement().createItemElement()
+        writer.tryWritingEpisodeData(episode, itemElement)
+
+        val actualElement = itemElement.findElementByName(localName, namespace)
+            ?: fail("The <${namespace?.prefix ?: ""}:$localName> tag was not written")
+
+        assertions(actualElement)
+    }
+
+    protected fun assertTagIsNotWrittenToEpisode(
+        episode: Episode,
+        localName: String,
+        namespace: FeedNamespace? = writer.namespace
+    ) {
+        val itemElement = createChannelElement().createItemElement()
+        writer.tryWritingEpisodeData(episode, itemElement)
+
+        assertThat(itemElement.findElementByName(localName, namespace)).isNull()
+    }
+
+    protected fun createChannelElement(): Element {
+        val document = documentBuilder.newDocument()
+
+        var channel: Element? = null
+        document.appendElement("rss") {
+            channel = appendElement("channel")
+        }
+        return channel!!
+    }
+
+    protected fun Element.createItemElement(): Element {
+        require(namespaceURI == null && nodeName == "channel") { " Only a <channel> can contain items" }
+        return appendElement("item")
+    }
+}
+
+private object FeedNamespaceContext : NamespaceContext {
+
+    override fun getNamespaceURI(prefix: String?): String? {
+        if (prefix == null) return null
+        return FeedNamespace.values().find { it.prefix == prefix }?.uri
+    }
+
+    override fun getPrefix(namespaceURI: String?): String? {
+        if (namespaceURI == null) return null
+        return FeedNamespace.values().find { it.uri == namespaceURI }?.prefix
+    }
+
+    override fun getPrefixes(namespaceURI: String?): Iterator<String> {
+        val prefix = getPrefix(namespaceURI) ?: return emptyList<String>().iterator()
+        return listOf(prefix).iterator()
+    }
+}

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/PodloveSimpleChapterWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/PodloveSimpleChapterWriterTest.kt
@@ -1,0 +1,24 @@
+package io.hemin.wien.writer.namespace
+
+import assertk.assertThat
+import io.hemin.wien.hasNoDifferences
+import io.hemin.wien.model.episode.anEpisode
+import org.junit.jupiter.api.Test
+
+internal class PodloveSimpleChapterWriterTest : NamespaceWriterTest() {
+
+    override val writer = PodloveSimpleChapterWriter()
+
+    @Test
+    internal fun `should write the correct psc tags to the item when there is data to write`() {
+        writeEpisodeData("chapters") { element ->
+            val diff = element.diffFromExpected("/rss/channel/item[1]/psc:chapters[1]")
+            assertThat(diff).hasNoDifferences()
+        }
+    }
+
+    @Test
+    internal fun `should not write psc tags to the item when there is no data to write`() {
+        assertTagIsNotWrittenToEpisode(anEpisode(podlove = null), "chapters")
+    }
+}

--- a/src/test/resources/xml/writer-fixtures.xml
+++ b/src/test/resources/xml/writer-fixtures.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" encoding="UTF-8"
+     xmlns:atom="http://www.w3.org/2005/Atom"
+     xmlns:bitlove="http://bitlove.org"
+     xmlns:content="http://purl.org/rss/1.0/modules/content/"
+     xmlns:feedpress="https://feed.press/xmlns"
+     xmlns:fyyd="https://fyyd.de/fyyd-ns/"
+     xmlns:googleplay="http://www.google.com/schemas/play-podcasts/1.0"
+     xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
+     xmlns:psc="http://podlove.org/simple-chapters">
+    <channel>
+        <title>podcast title</title>
+        <link>podcast link</link>
+        <description>podcast description</description>
+        <pubDate>Sat, 26 Dec 2020 15:32:22</pubDate>
+        <lastBuildDate>Tue, 22 Dec 2020 08:11:04</lastBuildDate>
+        <language>language</language>
+        <generator>generator</generator>
+        <copyright>copyright</copyright>
+        <docs>docs</docs>
+        <managingEditor>managingEditor</managingEditor>
+        <webMaster>webMaster</webMaster>
+        <image href="podcast image url" title="image title" link="image link" width="123" height="456" description="image description"/>
+        <itunes:subtitle>podcast itunes subtitle</itunes:subtitle>
+        <itunes:summary>podcast itunes summary</itunes:summary>
+        <itunes:image href="podcast itunes image url"/>
+        <itunes:keywords>podcast itunes keywords</itunes:keywords>
+        <itunes:author>podcast itunes author</itunes:author>
+        <itunes:category text="podcast itunes category"/>
+        <itunes:explicit>true</itunes:explicit>
+        <itunes:block>yes</itunes:block>
+        <itunes:complete>yes</itunes:complete>
+        <itunes:type>episodic</itunes:type>
+        <itunes:owner>
+            <itunes:name>podcast itunes owner name</itunes:name>
+            <itunes:email>person email</itunes:email>
+        </itunes:owner>
+        <itunes:title>podcast itunes title</itunes:title>
+        <itunes:new-feed-url>podcast itunes newFeedUrl</itunes:new-feed-url>
+        <atom:author>
+            <atom:name>podcast atom author name</atom:name>
+            <atom:email>person email</atom:email>
+            <atom:uri>person uri</atom:uri>
+        </atom:author>
+        <atom:contributor>
+            <atom:name>podcast atom contributor name</atom:name>
+            <atom:email>person email</atom:email>
+            <atom:uri>person uri</atom:uri>
+        </atom:contributor>
+        <atom:link href="podcast atom link href" hrefLang="link hrefLang" hrefResolved="link hrefResolved" length="link length" rel="link rel" title="link title" type="link type"/>
+        <fyyd:verify>podcast fyyd verify</fyyd:verify>
+        <feedpress:newsletterId>podcast feedpress newsletterId</feedpress:newsletterId>
+        <feedpress:locale>podcast feedpress locale</feedpress:locale>
+        <feedpress:podcastId>podcast feedpress podcastId</feedpress:podcastId>
+        <feedpress:cssFile>podcast feedpress cssFile</feedpress:cssFile>
+        <feedpress:link>podcast feedpress link</feedpress:link>
+        <googleplay:author>podcast googleplay author</googleplay:author>
+        <googleplay:owner>podcast googleplay owner</googleplay:owner>
+        <googleplay:category text="podcast googleplay category"/>
+        <googleplay:description>podcast googleplay description</googleplay:description>
+        <googleplay:explicit>yes</googleplay:explicit>
+        <googleplay:block>yes</googleplay:block>
+        <googleplay:image href="podcast googleplay image url"/>
+        <item>
+            <title>episode title</title>
+            <link>episode link</link>
+            <description>episode description</description>
+            <author>episode author</author>
+            <category text="episode category" />
+            <comments>episode comments</comments>
+            <enclosure url="episode enclosure url" length="777" type="episode enclosure type" bitlove:guid="episode bitlove guid"/>
+            <guid isPermaLink="false">episode guid textContent</guid>
+            <pubDate>Sun, 20 Dec 2020 12:11:10</pubDate>
+            <source>episode source</source>
+            <content:encoded>episode content encoded</content:encoded>
+            <itunes:title>episode itunes title</itunes:title>
+            <itunes:duration>episode itunes duration</itunes:duration>
+            <itunes:image href="episode itunes image url"/>
+            <itunes:explicit>true</itunes:explicit>
+            <itunes:block>yes</itunes:block>
+            <itunes:duration>episode itunes duration</itunes:duration>
+            <itunes:season>2</itunes:season>
+            <itunes:episode>3</itunes:episode>
+            <itunes:episodeType>full</itunes:episodeType>
+            <itunes:author>episode itunes author</itunes:author>
+            <itunes:subtitle>episode itunes subtitle</itunes:subtitle>
+            <itunes:summary>episode itunes summary</itunes:summary>
+            <atom:author>
+                <atom:name>episode atom author name</atom:name>
+                <atom:email>person email</atom:email>
+                <atom:uri>person uri</atom:uri>
+            </atom:author>
+            <atom:contributor>
+                <atom:name>episode atom contributor name</atom:name>
+                <atom:email>person email</atom:email>
+                <atom:uri>person uri</atom:uri>
+            </atom:contributor>
+            <atom:link href="episode atom link href" hrefLang="link hrefLang" hrefResolved="link hrefResolved" length="link length" rel="link rel" title="link title" type="link type" />
+            <psc:chapters>
+                <psc:chapter start="episode podlove simple chapter start" title="episode podlove simple chapter title" href="episode podlove simple chapter href" image="episode podlove simple chapter image"/>
+            </psc:chapters>
+            <googleplay:description>episode googleplay description</googleplay:description>
+            <googleplay:image href="episode googleplay image url"/>
+            <googleplay:explicit>yes</googleplay:explicit>
+            <googleplay:block>yes</googleplay:block>
+        </item>
+    </channel>
+</rss>


### PR DESCRIPTION
This PR does mainly one thing: it adds an RSS feed writer. For now there's only one "high level" test, but it does the full round, checking that we can write a `Podcast` to file, read it back into a `Podcast`, and that the two are identical.

I may add more end-to-end tests in the future, but this is a solid start, I think. Of course there are unit tests for every single writer, as well, so coverage's good. We're up to 95% of global test coverage:

![Code coverage is now 95%](https://user-images.githubusercontent.com/153802/103681575-f2588980-4f87-11eb-92f5-9741f91927cb.png)

This calls for a minor celebration, I believe 🙌 

![clap clap](https://user-images.githubusercontent.com/153802/103682075-a9550500-4f88-11eb-8a8e-3d0bc2d93c25.gif)

As usual, a ton of test data inflating the LoC count, but there's substance to this PR. This includes some refactorings, and fixes, in the parsing code as well.

Should be the last large one, at least :) I plan on making much smaller ones next, or at least large ones where it's mostly test data which needs no review.