### PR TITLE
Fake builders: add equals()/hashCode()/toString()

### DIFF
--- a/src/test/kotlin/io/hemin/wien/builder/fake/FakeImageBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/FakeImageBuilder.kt
@@ -49,4 +49,7 @@ internal class FakeImageBuilder : FakeBuilder<Image>(), ImageBuilder {
         result = 31 * result + (description?.hashCode() ?: 0)
         return result
     }
+
+    override fun toString() =
+        "FakeImageBuilder(urlValue='$urlValue', title=$title, link=$link, width=$width, height=$height, description=$description)"
 }

--- a/src/test/kotlin/io/hemin/wien/builder/fake/FakeLinkBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/FakeLinkBuilder.kt
@@ -53,4 +53,7 @@ internal class FakeLinkBuilder : FakeBuilder<Link>(), LinkBuilder {
         result = 31 * result + (type?.hashCode() ?: 0)
         return result
     }
+
+    override fun toString() =
+        "FakeLinkBuilder(hrefValue='$hrefValue', hrefLang=$hrefLang, hrefResolved=$hrefResolved, length=$length, rel=$rel, title=$title, type=$type)"
 }

--- a/src/test/kotlin/io/hemin/wien/builder/fake/FakePersonBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/FakePersonBuilder.kt
@@ -33,4 +33,6 @@ internal class FakePersonBuilder : FakeBuilder<Person>(), PersonBuilder {
         result = 31 * result + (uri?.hashCode() ?: 0)
         return result
     }
+
+    override fun toString() = "FakePersonBuilder(nameValue='$nameValue', email=$email, uri=$uri)"
 }

--- a/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodeAtomBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodeAtomBuilder.kt
@@ -24,4 +24,25 @@ internal class FakeEpisodeAtomBuilder : FakeBuilder<Episode.Atom>(), EpisodeAtom
     override fun addLinkBuilder(linkBuilder: LinkBuilder): EpisodeAtomBuilder = apply {
         linkBuilders.add(linkBuilder)
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is FakeEpisodeAtomBuilder) return false
+
+        if (authorBuilders != other.authorBuilders) return false
+        if (contributorBuilders != other.contributorBuilders) return false
+        if (linkBuilders != other.linkBuilders) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = authorBuilders.hashCode()
+        result = 31 * result + contributorBuilders.hashCode()
+        result = 31 * result + linkBuilders.hashCode()
+        return result
+    }
+
+    override fun toString() =
+        "FakeEpisodeAtomBuilder(authorBuilders=$authorBuilders, contributorBuilders=$contributorBuilders, linkBuilders=$linkBuilders)"
 }

--- a/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodeBitloveBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodeBitloveBuilder.kt
@@ -10,4 +10,19 @@ internal class FakeEpisodeBitloveBuilder : FakeBuilder<Episode.Bitlove>(), Episo
     var guid: String? = null
 
     override fun guid(guid: String): EpisodeBitloveBuilder = apply { this.guid = guid }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is FakeEpisodeBitloveBuilder) return false
+
+        if (guid != other.guid) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return guid?.hashCode() ?: 0
+    }
+
+    override fun toString() = "FakeEpisodeBitloveBuilder(guid=$guid)"
 }

--- a/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodeBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodeBuilder.kt
@@ -76,4 +76,53 @@ internal class FakeEpisodeBuilder : FakeBuilder<Episode>(), EpisodeBuilder {
     override fun createImageBuilder(): ImageBuilder = FakeImageBuilder()
 
     override fun createPodloveSimpleChapterBuilder(): EpisodePodloveSimpleChapterBuilder = FakeEpisodePodloveSimpleChapterBuilder()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is FakeEpisodeBuilder) return false
+
+        if (titleValue != other.titleValue) return false
+        if (enclosureBuilderValue != other.enclosureBuilderValue) return false
+        if (link != other.link) return false
+        if (description != other.description) return false
+        if (author != other.author) return false
+        if (categories != other.categories) return false
+        if (comments != other.comments) return false
+        if (guidBuilder != other.guidBuilder) return false
+        if (pubDate != other.pubDate) return false
+        if (source != other.source) return false
+        if (content != other.content) return false
+        if (iTunes != other.iTunes) return false
+        if (atom != other.atom) return false
+        if (podlove != other.podlove) return false
+        if (googlePlay != other.googlePlay) return false
+        if (bitlove != other.bitlove) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = titleValue?.hashCode() ?: 0
+        result = 31 * result + (enclosureBuilderValue?.hashCode() ?: 0)
+        result = 31 * result + (link?.hashCode() ?: 0)
+        result = 31 * result + (description?.hashCode() ?: 0)
+        result = 31 * result + (author?.hashCode() ?: 0)
+        result = 31 * result + categories.hashCode()
+        result = 31 * result + (comments?.hashCode() ?: 0)
+        result = 31 * result + (guidBuilder?.hashCode() ?: 0)
+        result = 31 * result + (pubDate?.hashCode() ?: 0)
+        result = 31 * result + (source?.hashCode() ?: 0)
+        result = 31 * result + content.hashCode()
+        result = 31 * result + iTunes.hashCode()
+        result = 31 * result + atom.hashCode()
+        result = 31 * result + podlove.hashCode()
+        result = 31 * result + googlePlay.hashCode()
+        result = 31 * result + bitlove.hashCode()
+        return result
+    }
+
+    override fun toString(): String =
+        "FakeEpisodeBuilder(titleValue=$titleValue, enclosureBuilderValue=$enclosureBuilderValue, link=$link, description=$description, " +
+                "author=$author, categories=$categories, comments=$comments, guidBuilder=$guidBuilder, pubDate=$pubDate, source=$source, " +
+                "content=$content, iTunes=$iTunes, atom=$atom, podlove=$podlove, googlePlay=$googlePlay, bitlove=$bitlove)"
 }

--- a/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodeContentBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodeContentBuilder.kt
@@ -10,4 +10,19 @@ internal class FakeEpisodeContentBuilder : FakeBuilder<Episode.Content>(), Episo
     var encoded: String? = null
 
     override fun encoded(encoded: String): EpisodeContentBuilder = apply { this.encoded = encoded }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is FakeEpisodeContentBuilder) return false
+
+        if (encoded != other.encoded) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return encoded?.hashCode() ?: 0
+    }
+
+    override fun toString() = "FakeEpisodeContentBuilder(encoded=$encoded)"
 }

--- a/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodeEnclosureBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodeEnclosureBuilder.kt
@@ -34,4 +34,6 @@ internal class FakeEpisodeEnclosureBuilder : FakeBuilder<Episode.Enclosure>(), E
         result = 31 * result + (typeValue?.hashCode() ?: 0)
         return result
     }
+
+    override fun toString() = "FakeEpisodeEnclosureBuilder(urlValue=$urlValue, lengthValue=$lengthValue, typeValue=$typeValue)"
 }

--- a/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodeGooglePlayBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodeGooglePlayBuilder.kt
@@ -20,4 +20,27 @@ internal class FakeEpisodeGooglePlayBuilder : FakeBuilder<Episode.GooglePlay>(),
     override fun block(block: Boolean?): EpisodeGooglePlayBuilder = apply { this.block = block }
 
     override fun imageBuilder(imageBuilder: ImageBuilder?): EpisodeGooglePlayBuilder = apply { this.imageBuilder = imageBuilder }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is FakeEpisodeGooglePlayBuilder) return false
+
+        if (description != other.description) return false
+        if (explicit != other.explicit) return false
+        if (block != other.block) return false
+        if (imageBuilder != other.imageBuilder) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = description?.hashCode() ?: 0
+        result = 31 * result + (explicit?.hashCode() ?: 0)
+        result = 31 * result + (block?.hashCode() ?: 0)
+        result = 31 * result + (imageBuilder?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString() =
+        "FakeEpisodeGooglePlayBuilder(description=$description, explicit=$explicit, block=$block, imageBuilder=$imageBuilder)"
 }

--- a/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodeGuidBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodeGuidBuilder.kt
@@ -29,4 +29,6 @@ internal class FakeEpisodeGuidBuilder : FakeBuilder<Episode.Guid>(), EpisodeGuid
         result = 31 * result + (isPermalink?.hashCode() ?: 0)
         return result
     }
+
+    override fun toString() = "FakeEpisodeGuidBuilder(textContent=$textContent, isPermalink=$isPermalink)"
 }

--- a/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodeITunesBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodeITunesBuilder.kt
@@ -41,4 +41,42 @@ internal class FakeEpisodeITunesBuilder : FakeBuilder<Episode.ITunes>(), Episode
     override fun subtitle(subtitle: String?): EpisodeITunesBuilder = apply { this.subtitle = subtitle }
 
     override fun summary(summary: String?): EpisodeITunesBuilder = apply { this.summary = summary }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is FakeEpisodeITunesBuilder) return false
+
+        if (title != other.title) return false
+        if (duration != other.duration) return false
+        if (imageBuilder != other.imageBuilder) return false
+        if (explicit != other.explicit) return false
+        if (block != other.block) return false
+        if (season != other.season) return false
+        if (episode != other.episode) return false
+        if (episodeType != other.episodeType) return false
+        if (author != other.author) return false
+        if (subtitle != other.subtitle) return false
+        if (summary != other.summary) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = title?.hashCode() ?: 0
+        result = 31 * result + (duration?.hashCode() ?: 0)
+        result = 31 * result + (imageBuilder?.hashCode() ?: 0)
+        result = 31 * result + (explicit?.hashCode() ?: 0)
+        result = 31 * result + (block?.hashCode() ?: 0)
+        result = 31 * result + (season ?: 0)
+        result = 31 * result + (episode ?: 0)
+        result = 31 * result + (episodeType?.hashCode() ?: 0)
+        result = 31 * result + (author?.hashCode() ?: 0)
+        result = 31 * result + (subtitle?.hashCode() ?: 0)
+        result = 31 * result + (summary?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString() =
+        "FakeEpisodeITunesBuilder(title=$title, duration=$duration, imageBuilder=$imageBuilder, explicit=$explicit, block=$block, " +
+                "season=$season, episode=$episode, episodeType=$episodeType, author=$author, subtitle=$subtitle, summary=$summary)"
 }

--- a/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodePodloveBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodePodloveBuilder.kt
@@ -17,4 +17,19 @@ internal class FakeEpisodePodloveBuilder : FakeBuilder<Episode.Podlove>(), Episo
     override fun addSimpleChapterBuilders(chapterBuilders: List<EpisodePodloveSimpleChapterBuilder>): EpisodePodloveBuilder = apply {
         this.chapterBuilders.addAll(chapterBuilders)
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is FakeEpisodePodloveBuilder) return false
+
+        if (chapterBuilders != other.chapterBuilders) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return chapterBuilders.hashCode()
+    }
+
+    override fun toString() = "FakeEpisodePodloveBuilder(chapterBuilders=$chapterBuilders)"
 }

--- a/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodePodloveSimpleChapterBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodePodloveSimpleChapterBuilder.kt
@@ -40,4 +40,7 @@ internal class FakeEpisodePodloveSimpleChapterBuilder : FakeBuilder<Episode.Podl
         result = 31 * result + (image?.hashCode() ?: 0)
         return result
     }
+
+    override fun toString() =
+        "FakeEpisodePodloveSimpleChapterBuilder(startValue='$startValue', titleValue='$titleValue', href=$href, image=$image)"
 }

--- a/src/test/kotlin/io/hemin/wien/builder/fake/podcast/FakePodcastAtomBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/podcast/FakePodcastAtomBuilder.kt
@@ -24,4 +24,25 @@ internal class FakePodcastAtomBuilder : FakeBuilder<Podcast.Atom>(), PodcastAtom
     override fun addLinkBuilder(linkBuilder: LinkBuilder): PodcastAtomBuilder = apply {
         linkBuilders.add(linkBuilder)
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is FakePodcastAtomBuilder) return false
+
+        if (authorBuilders != other.authorBuilders) return false
+        if (contributorBuilders != other.contributorBuilders) return false
+        if (linkBuilders != other.linkBuilders) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = authorBuilders.hashCode()
+        result = 31 * result + contributorBuilders.hashCode()
+        result = 31 * result + linkBuilders.hashCode()
+        return result
+    }
+
+    override fun toString() =
+        "FakePodcastAtomBuilder(authorBuilders=$authorBuilders, contributorBuilders=$contributorBuilders, linkBuilders=$linkBuilders)"
 }

--- a/src/test/kotlin/io/hemin/wien/builder/fake/podcast/FakePodcastBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/podcast/FakePodcastBuilder.kt
@@ -74,4 +74,59 @@ internal class FakePodcastBuilder : FakeBuilder<Podcast>(), PodcastBuilder {
     override fun createLinkBuilder(): LinkBuilder = FakeLinkBuilder()
 
     override fun createPersonBuilder(): PersonBuilder = FakePersonBuilder()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is FakePodcastBuilder) return false
+
+        if (titleValue != other.titleValue) return false
+        if (linkValue != other.linkValue) return false
+        if (descriptionValue != other.descriptionValue) return false
+        if (languageValue != other.languageValue) return false
+        if (pubDate != other.pubDate) return false
+        if (lastBuildDate != other.lastBuildDate) return false
+        if (generator != other.generator) return false
+        if (copyright != other.copyright) return false
+        if (docs != other.docs) return false
+        if (managingEditor != other.managingEditor) return false
+        if (webMaster != other.webMaster) return false
+        if (imageBuilder != other.imageBuilder) return false
+        if (episodeBuilders != other.episodeBuilders) return false
+        if (iTunes != other.iTunes) return false
+        if (atom != other.atom) return false
+        if (fyyd != other.fyyd) return false
+        if (feedpress != other.feedpress) return false
+        if (googlePlay != other.googlePlay) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = titleValue?.hashCode() ?: 0
+        result = 31 * result + (linkValue?.hashCode() ?: 0)
+        result = 31 * result + (descriptionValue?.hashCode() ?: 0)
+        result = 31 * result + (languageValue?.hashCode() ?: 0)
+        result = 31 * result + (pubDate?.hashCode() ?: 0)
+        result = 31 * result + (lastBuildDate?.hashCode() ?: 0)
+        result = 31 * result + (generator?.hashCode() ?: 0)
+        result = 31 * result + (copyright?.hashCode() ?: 0)
+        result = 31 * result + (docs?.hashCode() ?: 0)
+        result = 31 * result + (managingEditor?.hashCode() ?: 0)
+        result = 31 * result + (webMaster?.hashCode() ?: 0)
+        result = 31 * result + (imageBuilder?.hashCode() ?: 0)
+        result = 31 * result + episodeBuilders.hashCode()
+        result = 31 * result + iTunes.hashCode()
+        result = 31 * result + atom.hashCode()
+        result = 31 * result + fyyd.hashCode()
+        result = 31 * result + feedpress.hashCode()
+        result = 31 * result + googlePlay.hashCode()
+        return result
+    }
+
+    override fun toString() =
+        "FakePodcastBuilder(titleValue=$titleValue, linkValue=$linkValue, descriptionValue=$descriptionValue, languageValue=$languageValue, " +
+                "pubDate=$pubDate, lastBuildDate=$lastBuildDate, generator=$generator, copyright=$copyright, docs=$docs, " +
+                "managingEditor=$managingEditor, webMaster=$webMaster, imageBuilder=$imageBuilder, " +
+                "episodeBuilders=$episodeBuilders, iTunes=$iTunes, atom=$atom, fyyd=$fyyd, feedpress=$feedpress, googlePlay=$googlePlay)"
+
 }

--- a/src/test/kotlin/io/hemin/wien/builder/fake/podcast/FakePodcastFeedpressBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/podcast/FakePodcastFeedpressBuilder.kt
@@ -22,4 +22,30 @@ internal class FakePodcastFeedpressBuilder : FakeBuilder<Podcast.Feedpress>(), P
     override fun cssFile(cssFile: String?): PodcastFeedpressBuilder = apply { this.cssFileValue = cssFile }
 
     override fun link(link: String?): PodcastFeedpressBuilder = apply { this.linkValue = link }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is FakePodcastFeedpressBuilder) return false
+
+        if (newsletterIdValue != other.newsletterIdValue) return false
+        if (localeValue != other.localeValue) return false
+        if (podcastIdValue != other.podcastIdValue) return false
+        if (cssFileValue != other.cssFileValue) return false
+        if (linkValue != other.linkValue) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = newsletterIdValue?.hashCode() ?: 0
+        result = 31 * result + (localeValue?.hashCode() ?: 0)
+        result = 31 * result + (podcastIdValue?.hashCode() ?: 0)
+        result = 31 * result + (cssFileValue?.hashCode() ?: 0)
+        result = 31 * result + (linkValue?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString() =
+        "FakePodcastFeedpressBuilder(newsletterIdValue=$newsletterIdValue, localeValue=$localeValue, podcastIdValue=$podcastIdValue, " +
+                "cssFileValue=$cssFileValue, linkValue=$linkValue)"
 }

--- a/src/test/kotlin/io/hemin/wien/builder/fake/podcast/FakePodcastFyydBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/podcast/FakePodcastFyydBuilder.kt
@@ -10,4 +10,19 @@ internal class FakePodcastFyydBuilder : FakeBuilder<Podcast.Fyyd>(), PodcastFyyd
     var verifyValue: String? = null
 
     override fun verify(verify: String): PodcastFyydBuilder = apply { this.verifyValue = verify }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is FakePodcastFyydBuilder) return false
+
+        if (verifyValue != other.verifyValue) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return verifyValue?.hashCode() ?: 0
+    }
+
+    override fun toString() = "FakePodcastFyydBuilder(verifyValue=$verifyValue)"
 }

--- a/src/test/kotlin/io/hemin/wien/builder/fake/podcast/FakePodcastGooglePlayBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/podcast/FakePodcastGooglePlayBuilder.kt
@@ -31,4 +31,35 @@ internal class FakePodcastGooglePlayBuilder : FakeBuilder<Podcast.GooglePlay>(),
     override fun block(block: Boolean?): PodcastGooglePlayBuilder = apply { this.block = block }
 
     override fun imageBuilder(imageBuilder: ImageBuilder?): PodcastGooglePlayBuilder = apply { this.imageBuilder = imageBuilder }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is FakePodcastGooglePlayBuilder) return false
+
+        if (author != other.author) return false
+        if (owner != other.owner) return false
+        if (categories != other.categories) return false
+        if (description != other.description) return false
+        if (explicit != other.explicit) return false
+        if (block != other.block) return false
+        if (imageBuilder != other.imageBuilder) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = author?.hashCode() ?: 0
+        result = 31 * result + (owner?.hashCode() ?: 0)
+        result = 31 * result + categories.hashCode()
+        result = 31 * result + (description?.hashCode() ?: 0)
+        result = 31 * result + (explicit?.hashCode() ?: 0)
+        result = 31 * result + (block?.hashCode() ?: 0)
+        result = 31 * result + (imageBuilder?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString() =
+        "FakePodcastGooglePlayBuilder(author=$author, owner=$owner, categories=$categories, description=$description, " +
+                "explicit=$explicit, block=$block, imageBuilder=$imageBuilder)"
+
 }

--- a/src/test/kotlin/io/hemin/wien/builder/fake/podcast/FakePodcastITunesBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/podcast/FakePodcastITunesBuilder.kt
@@ -55,4 +55,47 @@ internal class FakePodcastITunesBuilder : FakeBuilder<Podcast.ITunes>(), Podcast
     override fun newFeedUrl(newFeedUrl: String?): PodcastITunesBuilder = apply {
         this.newFeedUrl = newFeedUrl
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is FakePodcastITunesBuilder) return false
+
+        if (imageBuilderValue != other.imageBuilderValue) return false
+        if (explicit != other.explicit) return false
+        if (subtitle != other.subtitle) return false
+        if (summary != other.summary) return false
+        if (keywords != other.keywords) return false
+        if (author != other.author) return false
+        if (categories != other.categories) return false
+        if (block != other.block) return false
+        if (complete != other.complete) return false
+        if (type != other.type) return false
+        if (ownerBuilder != other.ownerBuilder) return false
+        if (title != other.title) return false
+        if (newFeedUrl != other.newFeedUrl) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = imageBuilderValue?.hashCode() ?: 0
+        result = 31 * result + (explicit?.hashCode() ?: 0)
+        result = 31 * result + (subtitle?.hashCode() ?: 0)
+        result = 31 * result + (summary?.hashCode() ?: 0)
+        result = 31 * result + (keywords?.hashCode() ?: 0)
+        result = 31 * result + (author?.hashCode() ?: 0)
+        result = 31 * result + categories.hashCode()
+        result = 31 * result + (block?.hashCode() ?: 0)
+        result = 31 * result + (complete?.hashCode() ?: 0)
+        result = 31 * result + (type?.hashCode() ?: 0)
+        result = 31 * result + (ownerBuilder?.hashCode() ?: 0)
+        result = 31 * result + (title?.hashCode() ?: 0)
+        result = 31 * result + (newFeedUrl?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString() =
+        "FakePodcastITunesBuilder(imageBuilderValue=$imageBuilderValue, explicit=$explicit, subtitle=$subtitle, summary=$summary, " +
+                "keywords=$keywords, author=$author, categories=$categories, block=$block, complete=$complete, type=$type, " +
+                "ownerBuilder=$ownerBuilder, title=$title, newFeedUrl=$newFeedUrl)"
 }


### PR DESCRIPTION
This small PR adds `equals()`, `hashCode()`, and `toString()` to the `Fake*Builder` classes. So far only some of those classes had the `equals()` and `hashCode()` implemented, so this now makes them all the same. The `toString()` implementation is useful when testing to get better error messages.