### PR TITLE
Configure DomBuilderFactory for XXE attacks prevention

### DIFF
--- a/src/main/kotlin/io/hemin/wien/PodcastRssParser.kt
+++ b/src/main/kotlin/io/hemin/wien/PodcastRssParser.kt
@@ -1,7 +1,6 @@
 package io.hemin.wien
 
 import io.hemin.wien.builder.episode.EpisodeBuilder
-import io.hemin.wien.builder.podcast.PodcastBuilder
 import io.hemin.wien.builder.validating.episode.ValidatingEpisodeBuilder
 import io.hemin.wien.builder.validating.podcast.ValidatingPodcastBuilder
 import io.hemin.wien.model.Podcast
@@ -47,7 +46,7 @@ object PodcastRssParser {
     val supportedNamespaces: Set<String> = parsers.mapNotNull { parser -> parser.namespace?.uri }
         .toSet()
 
-    private val builder: DocumentBuilder = DomBuilderFactory.newBuilder()
+    private val builder: DocumentBuilder = DomBuilderFactory.newDocumentBuilder()
 
     /**
      * Parse the content of the given URI as an XML document

--- a/src/main/kotlin/io/hemin/wien/PodcastRssWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/PodcastRssWriter.kt
@@ -1,6 +1,7 @@
 package io.hemin.wien
 
 import io.hemin.wien.model.Podcast
+import io.hemin.wien.util.DomBuilderFactory
 import io.hemin.wien.writer.namespace.AtomWriter
 import io.hemin.wien.writer.namespace.BitloveWriter
 import io.hemin.wien.writer.namespace.ContentWriter
@@ -17,7 +18,6 @@ import org.w3c.dom.Document
 import org.w3c.dom.Element
 import java.io.File
 import java.io.OutputStream
-import javax.xml.parsers.DocumentBuilderFactory
 import javax.xml.transform.OutputKeys
 import javax.xml.transform.TransformerFactory
 import javax.xml.transform.dom.DOMSource
@@ -40,9 +40,7 @@ object PodcastRssWriter {
 
     private val supportedNamespaces = writers.mapNotNull { it.namespace }
 
-    private val documentBuilder = DocumentBuilderFactory.newInstance()
-        .apply { isNamespaceAware = true }
-        .newDocumentBuilder()
+    private val documentBuilder = DomBuilderFactory.newDocumentBuilder()
 
     private val transformer = TransformerFactory.newInstance()
         .newTransformer()

--- a/src/main/kotlin/io/hemin/wien/util/DomBuilderFactory.kt
+++ b/src/main/kotlin/io/hemin/wien/util/DomBuilderFactory.kt
@@ -2,33 +2,42 @@ package io.hemin.wien.util
 
 import javax.xml.parsers.DocumentBuilder
 import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.parsers.ParserConfigurationException
 
 /**
  * Factory for the API to obtain DOM Document instances from
  * XML documents. This factory applies required configuration
  * to the API instance, for consistent usage in this library.
  */
-class DomBuilderFactory {
-
-    /** Static factory object for [DomBuilderFactory] instances DOM document builder instances */
-    companion object Factory {
-        private val factory = DomBuilderFactory()
-
-        /**
-         * Instantiates a new API instance to obtain DOM Documents from
-         * XML documents with the required configuration settings.
-         *
-         * @return The created API instance.
-         */
-        fun newBuilder(): DocumentBuilder = factory.newBuilder()
-    }
+internal object DomBuilderFactory {
 
     private val factory: DocumentBuilderFactory = DocumentBuilderFactory.newInstance()
 
     init {
         // Apply the required configuration
         factory.isNamespaceAware = true
+        factory.preventXxe()
     }
 
-    private fun newBuilder(): DocumentBuilder = factory.newDocumentBuilder()
+    /**
+     *
+     * See http://bit.ly/owasp-xxe-java-dom (shortened URL on https://cheatsheetseries.owasp.org/)
+     */
+    private fun DocumentBuilderFactory.preventXxe() = try {
+        // Disallowing DTDs prevents most XXE entity attacks. Xerces 2 only.
+        setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+
+        // Disallow external entities. Xerces 1, 2 and JDK 7+.
+        setFeature("http://xml.org/sax/features/external-general-entities", false)
+        setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+
+        // Disable external DTDs, XIncludes, and entity reference expansion.
+        setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+        isXIncludeAware = false
+        isExpandEntityReferences = false
+    } catch (e: ParserConfigurationException) {
+        // We tried setting a feature that isn't supported by the current parser
+    }
+
+    fun newBuilder(): DocumentBuilder = factory.newDocumentBuilder()
 }

--- a/src/main/kotlin/io/hemin/wien/util/DomBuilderFactory.kt
+++ b/src/main/kotlin/io/hemin/wien/util/DomBuilderFactory.kt
@@ -39,5 +39,5 @@ internal object DomBuilderFactory {
         // We tried setting a feature that isn't supported by the current parser
     }
 
-    fun newBuilder(): DocumentBuilder = factory.newDocumentBuilder()
+    fun newDocumentBuilder(): DocumentBuilder = factory.newDocumentBuilder()
 }

--- a/src/test/kotlin/io/hemin/wien/PodcastRssParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/PodcastRssParserTest.kt
@@ -14,6 +14,7 @@ import io.hemin.wien.model.Episode
 import io.hemin.wien.model.Image
 import io.hemin.wien.model.Person
 import io.hemin.wien.model.Podcast
+import io.hemin.wien.util.DomBuilderFactory
 import io.hemin.wien.util.findElementByName
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
@@ -22,8 +23,7 @@ import javax.xml.parsers.DocumentBuilderFactory
 
 internal class PodcastRssParserTest {
 
-    private val documentBuilder = DocumentBuilderFactory.newInstance()
-        .newDocumentBuilder()
+    private val documentBuilder = DomBuilderFactory.newDocumentBuilder()
 
     @Test
     internal fun `should return null when parsing an empty document`() {

--- a/src/test/kotlin/io/hemin/wien/TestUtil.kt
+++ b/src/test/kotlin/io/hemin/wien/TestUtil.kt
@@ -20,7 +20,7 @@ import javax.xml.transform.TransformerFactory
 import javax.xml.transform.dom.DOMSource
 import javax.xml.transform.stream.StreamResult
 
-private val domBuilder: DocumentBuilder = DomBuilderFactory.newBuilder()
+private val domBuilder: DocumentBuilder = DomBuilderFactory.newDocumentBuilder()
 
 private val transformerFactory = TransformerFactory.newInstance()
 

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/NamespaceWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/NamespaceWriterTest.kt
@@ -8,6 +8,7 @@ import io.hemin.wien.model.Episode
 import io.hemin.wien.model.Podcast
 import io.hemin.wien.model.episode.anEpisode
 import io.hemin.wien.model.podcast.aPodcast
+import io.hemin.wien.util.DomBuilderFactory
 import io.hemin.wien.util.FeedNamespace
 import io.hemin.wien.util.appendElement
 import io.hemin.wien.util.findElementByName
@@ -27,9 +28,7 @@ internal abstract class NamespaceWriterTest {
     private val xpath = XPathFactory.newDefaultInstance().newXPath()
         .apply { namespaceContext = FeedNamespaceContext }
 
-    private val documentBuilder = DocumentBuilderFactory.newInstance()
-        .apply { isNamespaceAware = true }
-        .newDocumentBuilder()
+    private val documentBuilder = DomBuilderFactory.newDocumentBuilder()
 
     protected abstract val writer: NamespaceWriter
 


### PR DESCRIPTION
Since this library will be parsing arbitrary XML from who knows where, it's important we set up the XML parser to offer the smallest attack surface area possible. To do this, we follow the OWASP recommendations to prevent (most if not all) XXE attacks. More details can be found on the [OWASP website](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html).