### PR TITLE
Tweak APIs, reorganize code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-    - openjdk8
+    - openjdk11
 
 before_install:
     - chmod -R +x src
@@ -10,6 +10,9 @@ before_install:
 script:
     - ./gradlew clean build check jacocoTestReport coveralls
 
+before_cache:
+    - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+    - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 cache:
     bundler: true
     directories:

--- a/src/main/kotlin/io/hemin/wien/PodcastRssParser.kt
+++ b/src/main/kotlin/io/hemin/wien/PodcastRssParser.kt
@@ -120,7 +120,7 @@ object PodcastRssParser {
                 }
                 else -> {
                     for (parser in parsers) {
-                        parser.tryParsingChannelChildNode(builder, element)
+                        parser.tryParsingChannelChildNode(element, builder)
                     }
                 }
             }
@@ -132,7 +132,7 @@ object PodcastRssParser {
         val builder: EpisodeBuilder = ValidatingEpisodeBuilder()
         for (element in childNodes.asListOfNodes()) {
             for (parser in parsers) {
-                parser.tryParsingItemChildNode(builder, element)
+                parser.tryParsingItemChildNode(element, builder)
             }
         }
         builder

--- a/src/main/kotlin/io/hemin/wien/parser/NamespaceParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/NamespaceParser.kt
@@ -20,13 +20,13 @@ internal abstract class NamespaceParser {
      * matches this parser's [namespace].
      *
      * @see canParse
-     * @param builder The builder where all parsed data is added to.
      * @param node The DOM node from which all data is extracted from.
+     * @param builder The builder where all parsed data is added to.
      */
-    fun tryParsingChannelChildNode(builder: PodcastBuilder, node: Node) {
+    fun tryParsingChannelChildNode(node: Node, builder: PodcastBuilder) {
         if (!canParse(node)) return
         require(node.isDirectChildOf("channel")) { "This function can only parse nodes that are direct children of <channel>" }
-        parseChannelNode(builder, node)
+        node.parseChannelData(builder)
     }
 
     /**
@@ -35,9 +35,9 @@ internal abstract class NamespaceParser {
      * **Note:** this method is only ever called when the node
      *
      * @param builder The builder where all parsed data is added to.
-     * @param node The DOM node from which all data is extracted from.
+     * @param this@parseChannelNode The DOM node from which all data is extracted from.
      */
-    protected abstract fun parseChannelNode(builder: PodcastBuilder, node: Node)
+    protected abstract fun Node.parseChannelData(builder: PodcastBuilder)
 
     /**
      * Extracts data from the XML namespace defined by [namespace]
@@ -49,27 +49,24 @@ internal abstract class NamespaceParser {
      * such as [io.hemin.wien.parser.namespace.BitloveParser].
      *
      * @see canParse
-     * @param builder The builder where all parsed data is added to.
      * @param node The DOM node from which all data is extracted from.
+     * @param builder The builder where all parsed data is added to.
      */
-    fun tryParsingItemChildNode(builder: EpisodeBuilder, node: Node) {
+    fun tryParsingItemChildNode(node: Node, builder: EpisodeBuilder) {
         if (!canParse(node)) return
         require(node.isDirectChildOf("item")) { "This function can only parse nodes that are direct children of <item>" }
-        parseItemNode(builder, node)
+        node.parseItemData(builder)
     }
 
     /**
      * Extract all the data from a `<channel>` node for the [namespace],
      * adding it to the provided builder as it goes.
-     * **Note:** this method is only ever called when the node has the correct
-     * namespace, and it is indeed a direct child of `<item>`.
+     * **Note:** this method is only ever called when the [Node] receiver has
+     * the correct namespace, and it is indeed a direct child of `<item>`.
      *
      * @param builder The builder where all parsed data is added to.
-     *
-     * @param node The DOM node from which all data is extracted from.
-     *
      */
-    protected abstract fun parseItemNode(builder: EpisodeBuilder, node: Node)
+    protected abstract fun Node.parseItemData(builder: EpisodeBuilder)
 
     /**
      * Executes a block of code on the DOM node if the node has the same [namespace] of this parser.

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/AtomParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/AtomParser.kt
@@ -18,36 +18,36 @@ internal class AtomParser : NamespaceParser() {
 
     override val namespace = FeedNamespace.ATOM
 
-    override fun parseChannelNode(builder: PodcastBuilder, node: Node) {
-        when (node.localName) {
+    override fun Node.parseChannelData(builder: PodcastBuilder) {
+        when (localName) {
             "contributor" -> {
-                val personBuilder = node.ifCanBeParsed { toPersonBuilder(builder.createPersonBuilder(), namespace) } ?: return
+                val personBuilder = ifCanBeParsed { toPersonBuilder(builder.createPersonBuilder(), namespace) } ?: return
                 builder.atom.addContributorBuilder(personBuilder)
             }
             "author" -> {
-                val personBuilder = node.ifCanBeParsed { toPersonBuilder(builder.createPersonBuilder(), namespace) } ?: return
+                val personBuilder = ifCanBeParsed { toPersonBuilder(builder.createPersonBuilder(), namespace) } ?: return
                 builder.atom.addAuthorBuilder(personBuilder)
             }
             "link" -> {
-                val linkBuilder = node.ifCanBeParsed { toLinkBuilder(builder.createLinkBuilder()) } ?: return
+                val linkBuilder = ifCanBeParsed { toLinkBuilder(builder.createLinkBuilder()) } ?: return
                 builder.atom.addLinkBuilder(linkBuilder)
             }
             else -> pass
         }
     }
 
-    override fun parseItemNode(builder: EpisodeBuilder, node: Node) {
-        when (node.localName) {
+    override fun Node.parseItemData(builder: EpisodeBuilder) {
+        when (localName) {
             "contributor" -> {
-                val personBuilder = node.ifCanBeParsed { toPersonBuilder(builder.createPersonBuilder(), namespace) } ?: return
+                val personBuilder = ifCanBeParsed { toPersonBuilder(builder.createPersonBuilder(), namespace) } ?: return
                 builder.atom.addContributorBuilder(personBuilder)
             }
             "author" -> {
-                val personBuilder = node.ifCanBeParsed { toPersonBuilder(builder.createPersonBuilder(), namespace) } ?: return
+                val personBuilder = ifCanBeParsed { toPersonBuilder(builder.createPersonBuilder(), namespace) } ?: return
                 builder.atom.addAuthorBuilder(personBuilder)
             }
             "link" -> {
-                val linkBuilder = node.ifCanBeParsed { toLinkBuilder(builder.createLinkBuilder()) } ?: return
+                val linkBuilder = ifCanBeParsed { toLinkBuilder(builder.createLinkBuilder()) } ?: return
                 builder.atom.addLinkBuilder(linkBuilder)
             }
             else -> pass

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/BitloveParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/BitloveParser.kt
@@ -17,12 +17,12 @@ internal class BitloveParser : NamespaceParser() {
 
     override val namespace = FeedNamespace.BITLOVE
 
-    override fun parseChannelNode(builder: PodcastBuilder, node: Node) {
+    override fun Node.parseChannelData(builder: PodcastBuilder) {
         // No-op
     }
 
-    override fun parseItemNode(builder: EpisodeBuilder, node: Node) {
-        val guid = node.findGuid() ?: return
+    override fun Node.parseItemData(builder: EpisodeBuilder) {
+        val guid = findGuid() ?: return
         builder.bitlove.guid(guid)
     }
 

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/ContentParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/ContentParser.kt
@@ -16,14 +16,14 @@ internal class ContentParser : NamespaceParser() {
 
     override val namespace = FeedNamespace.CONTENT
 
-    override fun parseChannelNode(builder: PodcastBuilder, node: Node) {
+    override fun Node.parseChannelData(builder: PodcastBuilder) {
         // No-op
     }
 
-    override fun parseItemNode(builder: EpisodeBuilder, node: Node) {
-        when (node.localName) {
+    override fun Node.parseItemData(builder: EpisodeBuilder) {
+        when (localName) {
             "encoded" -> {
-                val encoded = node.ifCanBeParsed { textOrNull() } ?: return
+                val encoded = ifCanBeParsed { textOrNull() } ?: return
                 builder.content.encoded(encoded)
             }
             else -> pass

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/FeedpressParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/FeedpressParser.kt
@@ -16,18 +16,18 @@ internal class FeedpressParser : NamespaceParser() {
 
     override val namespace = FeedNamespace.FEEDPRESS
 
-    override fun parseChannelNode(builder: PodcastBuilder, node: Node) {
-        when (node.localName) {
-            "newsletterId" -> builder.feedpress.newsletterId(node.ifCanBeParsed { textOrNull() })
-            "locale" -> builder.feedpress.locale(node.ifCanBeParsed { textOrNull() })
-            "podcastId" -> builder.feedpress.podcastId(node.ifCanBeParsed { textOrNull() })
-            "cssFile" -> builder.feedpress.cssFile(node.ifCanBeParsed { textOrNull() })
-            "link" -> builder.feedpress.link(node.ifCanBeParsed { textOrNull() })
+    override fun Node.parseChannelData(builder: PodcastBuilder) {
+        when (localName) {
+            "newsletterId" -> builder.feedpress.newsletterId(ifCanBeParsed { textOrNull() })
+            "locale" -> builder.feedpress.locale(ifCanBeParsed { textOrNull() })
+            "podcastId" -> builder.feedpress.podcastId(ifCanBeParsed { textOrNull() })
+            "cssFile" -> builder.feedpress.cssFile(ifCanBeParsed { textOrNull() })
+            "link" -> builder.feedpress.link(ifCanBeParsed { textOrNull() })
             else -> pass
         }
     }
 
-    override fun parseItemNode(builder: EpisodeBuilder, node: Node) {
+    override fun Node.parseItemData(builder: EpisodeBuilder) {
         // No-op
     }
 }

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/FyydParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/FyydParser.kt
@@ -16,17 +16,17 @@ internal class FyydParser : NamespaceParser() {
 
     override val namespace = FeedNamespace.FYYD
 
-    override fun parseChannelNode(builder: PodcastBuilder, node: Node) {
-        when (node.localName) {
+    override fun Node.parseChannelData(builder: PodcastBuilder) {
+        when (localName) {
             "verify" -> {
-                val verify = node.ifCanBeParsed { textOrNull() } ?: return
+                val verify = ifCanBeParsed { textOrNull() } ?: return
                 builder.fyyd.verify(verify)
             }
             else -> pass
         }
     }
 
-    override fun parseItemNode(builder: EpisodeBuilder, node: Node) {
+    override fun Node.parseItemData(builder: EpisodeBuilder) {
         // No-op
     }
 }

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/GooglePlayParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/GooglePlayParser.kt
@@ -19,33 +19,33 @@ internal class GooglePlayParser : NamespaceParser() {
 
     override val namespace = FeedNamespace.GOOGLE_PLAY
 
-    override fun parseChannelNode(builder: PodcastBuilder, node: Node) {
-        when (node.localName) {
-            "author" -> builder.googlePlay.author(node.ifCanBeParsed { textOrNull() })
-            "owner" -> builder.googlePlay.owner(node.ifCanBeParsed { textOrNull() })
+    override fun Node.parseChannelData(builder: PodcastBuilder) {
+        when (localName) {
+            "author" -> builder.googlePlay.author(ifCanBeParsed { textOrNull() })
+            "owner" -> builder.googlePlay.owner(ifCanBeParsed { textOrNull() })
             "category" -> {
                 val categoryBuilder = builder.createITunesCategoryBuilder()
-                val category = node.ifCanBeParsed { toITunesCategoryBuilder(categoryBuilder, namespace) } ?: return
+                val category = ifCanBeParsed { toITunesCategoryBuilder(categoryBuilder, namespace) } ?: return
                 builder.googlePlay.addCategoryBuilder(category)
             }
-            "description" -> builder.googlePlay.description(node.ifCanBeParsed { textOrNull() })
-            "explicit" -> builder.googlePlay.explicit(node.ifCanBeParsed { textAsBooleanOrNull() })
-            "block" -> builder.googlePlay.block(node.ifCanBeParsed { textAsBooleanOrNull() })
+            "description" -> builder.googlePlay.description(ifCanBeParsed { textOrNull() })
+            "explicit" -> builder.googlePlay.explicit(ifCanBeParsed { textAsBooleanOrNull() })
+            "block" -> builder.googlePlay.block(ifCanBeParsed { textAsBooleanOrNull() })
             "image" -> {
-                val imageBuilder = node.ifCanBeParsed { toHrefOnlyImageBuilder(builder.createHrefOnlyImageBuilder()) }
+                val imageBuilder = ifCanBeParsed { toHrefOnlyImageBuilder(builder.createHrefOnlyImageBuilder()) }
                 builder.googlePlay.imageBuilder(imageBuilder)
             }
             else -> pass
         }
     }
 
-    override fun parseItemNode(builder: EpisodeBuilder, node: Node) {
-        when (node.localName) {
-            "description" -> builder.googlePlay.description(node.ifCanBeParsed { textOrNull() })
-            "explicit" -> builder.googlePlay.explicit(node.ifCanBeParsed { textAsBooleanOrNull() })
-            "block" -> builder.googlePlay.block(node.ifCanBeParsed { textAsBooleanOrNull() })
+    override fun Node.parseItemData(builder: EpisodeBuilder) {
+        when (localName) {
+            "description" -> builder.googlePlay.description(ifCanBeParsed { textOrNull() })
+            "explicit" -> builder.googlePlay.explicit(ifCanBeParsed { textAsBooleanOrNull() })
+            "block" -> builder.googlePlay.block(ifCanBeParsed { textAsBooleanOrNull() })
             "image" -> {
-                val imageBuilder = node.ifCanBeParsed { toHrefOnlyImageBuilder(builder.createHrefOnlyImageBuilder()) }
+                val imageBuilder = ifCanBeParsed { toHrefOnlyImageBuilder(builder.createHrefOnlyImageBuilder()) }
                 builder.googlePlay.imageBuilder(imageBuilder)
             }
             else -> pass

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/ITunesParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/ITunesParser.kt
@@ -22,35 +22,35 @@ internal class ITunesParser : NamespaceParser() {
 
     override val namespace = FeedNamespace.ITUNES
 
-    override fun parseChannelNode(builder: PodcastBuilder, node: Node) {
-        when (node.localName) {
-            "author" -> builder.iTunes.author(node.ifCanBeParsed { textOrNull() })
-            "block" -> builder.iTunes.block(node.ifCanBeParsed { textAsBooleanOrNull() })
+    override fun Node.parseChannelData(builder: PodcastBuilder) {
+        when (localName) {
+            "author" -> builder.iTunes.author(ifCanBeParsed { textOrNull() })
+            "block" -> builder.iTunes.block(ifCanBeParsed { textAsBooleanOrNull() })
             "category" -> {
-                val categoryBuilder = node.ifCanBeParsed {
+                val categoryBuilder = ifCanBeParsed {
                     toITunesCategoryBuilder(builder.createITunesCategoryBuilder(), namespace)
                 } ?: return
                 builder.iTunes.addCategoryBuilder(categoryBuilder)
             }
-            "complete" -> builder.iTunes.complete(node.ifCanBeParsed { textAsBooleanOrNull() })
+            "complete" -> builder.iTunes.complete(ifCanBeParsed { textAsBooleanOrNull() })
             "explicit" -> {
-                val explicit = node.ifCanBeParsed { textAsBooleanOrNull() } ?: return
+                val explicit = ifCanBeParsed { textAsBooleanOrNull() } ?: return
                 builder.iTunes.explicit(explicit)
             }
             "image" -> {
-                val image = node.ifCanBeParsed { toHrefOnlyImageBuilder(builder.createHrefOnlyImageBuilder()) } ?: return
+                val image = ifCanBeParsed { toHrefOnlyImageBuilder(builder.createHrefOnlyImageBuilder()) } ?: return
                 builder.iTunes.imageBuilder(image)
             }
-            "keywords" -> builder.iTunes.keywords(node.ifCanBeParsed { textOrNull() })
+            "keywords" -> builder.iTunes.keywords(ifCanBeParsed { textOrNull() })
             "owner" -> {
-                val ownerBuilder = node.ifCanBeParsed { toOwnerBuilder(builder.createPersonBuilder()) }
+                val ownerBuilder = ifCanBeParsed { toOwnerBuilder(builder.createPersonBuilder()) }
                 builder.iTunes.ownerBuilder(ownerBuilder)
             }
-            "subtitle" -> builder.iTunes.subtitle(node.ifCanBeParsed { textOrNull() })
-            "summary" -> builder.iTunes.summary(node.ifCanBeParsed { textOrNull() })
-            "type" -> builder.iTunes.type(node.ifCanBeParsed { textOrNull() })
-            "title" -> builder.iTunes.title(node.ifCanBeParsed { textOrNull() })
-            "new-feed-url" -> builder.iTunes.newFeedUrl(node.ifCanBeParsed { textOrNull() })
+            "subtitle" -> builder.iTunes.subtitle(ifCanBeParsed { textOrNull() })
+            "summary" -> builder.iTunes.summary(ifCanBeParsed { textOrNull() })
+            "type" -> builder.iTunes.type(ifCanBeParsed { textOrNull() })
+            "title" -> builder.iTunes.title(ifCanBeParsed { textOrNull() })
+            "new-feed-url" -> builder.iTunes.newFeedUrl(ifCanBeParsed { textOrNull() })
             else -> pass
         }
     }
@@ -61,22 +61,22 @@ internal class ITunesParser : NamespaceParser() {
         return personBuilder
     }
 
-    override fun parseItemNode(builder: EpisodeBuilder, node: Node) {
-        when (node.localName) {
-            "block" -> builder.iTunes.block(node.ifCanBeParsed { textAsBooleanOrNull() })
-            "duration" -> builder.iTunes.duration(node.ifCanBeParsed { textOrNull() })
-            "episode" -> builder.iTunes.episode(node.ifCanBeParsed { parseAsInt() })
-            "episodeType" -> builder.iTunes.episodeType(node.ifCanBeParsed { textOrNull() })
-            "explicit" -> builder.iTunes.explicit(node.ifCanBeParsed { textAsBooleanOrNull() })
+    override fun Node.parseItemData(builder: EpisodeBuilder) {
+        when (localName) {
+            "block" -> builder.iTunes.block(ifCanBeParsed { textAsBooleanOrNull() })
+            "duration" -> builder.iTunes.duration(ifCanBeParsed { textOrNull() })
+            "episode" -> builder.iTunes.episode(ifCanBeParsed { parseAsInt() })
+            "episodeType" -> builder.iTunes.episodeType(ifCanBeParsed { textOrNull() })
+            "explicit" -> builder.iTunes.explicit(ifCanBeParsed { textAsBooleanOrNull() })
             "image" -> {
-                val imageBuilder = node.toHrefOnlyImageBuilder(builder.createHrefOnlyImageBuilder())
+                val imageBuilder = toHrefOnlyImageBuilder(builder.createHrefOnlyImageBuilder())
                 builder.iTunes.imageBuilder(imageBuilder)
             }
-            "season" -> builder.iTunes.season(node.ifCanBeParsed { parseAsInt() })
-            "title" -> builder.iTunes.title(node.ifCanBeParsed { textOrNull() })
-            "author" -> builder.iTunes.author(node.ifCanBeParsed { textOrNull() })
-            "subtitle" -> builder.iTunes.subtitle(node.ifCanBeParsed { textOrNull() })
-            "summary" -> builder.iTunes.summary(node.ifCanBeParsed { textOrNull() })
+            "season" -> builder.iTunes.season(ifCanBeParsed { parseAsInt() })
+            "title" -> builder.iTunes.title(ifCanBeParsed { textOrNull() })
+            "author" -> builder.iTunes.author(ifCanBeParsed { textOrNull() })
+            "subtitle" -> builder.iTunes.subtitle(ifCanBeParsed { textOrNull() })
+            "summary" -> builder.iTunes.summary(ifCanBeParsed { textOrNull() })
             else -> pass
         }
     }

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/PodloveSimpleChapterParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/PodloveSimpleChapterParser.kt
@@ -18,14 +18,14 @@ internal class PodloveSimpleChapterParser : NamespaceParser() {
 
     override val namespace = FeedNamespace.PODLOVE_SIMPLE_CHAPTER
 
-    override fun parseChannelNode(builder: PodcastBuilder, node: Node) {
+    override fun Node.parseChannelData(builder: PodcastBuilder) {
         // No-op
     }
 
-    override fun parseItemNode(builder: EpisodeBuilder, node: Node) {
-        when (node.localName) {
+    override fun Node.parseItemData(builder: EpisodeBuilder) {
+        when (localName) {
             "chapters" -> {
-                val chapters = node.ifCanBeParsed { toPodloveSimpleChapterBuilders(builder) } ?: return
+                val chapters = ifCanBeParsed { toPodloveSimpleChapterBuilders(builder) } ?: return
                 builder.podlove.addSimpleChapterBuilders(chapters)
             }
             else -> pass

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/RssParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/RssParser.kt
@@ -26,59 +26,59 @@ internal class RssParser : NamespaceParser() {
 
     override val namespace: FeedNamespace? = null
 
-    override fun parseChannelNode(builder: PodcastBuilder, node: Node) {
-        if (node !is Element) return
+    override fun Node.parseChannelData(builder: PodcastBuilder) {
+        if (this !is Element) return
 
-        when (node.localName) {
-            "copyright" -> builder.copyright(node.ifCanBeParsed { textOrNull() })
+        when (localName) {
+            "copyright" -> builder.copyright(ifCanBeParsed { textOrNull() })
             "description" -> {
-                val description = node.ifCanBeParsed { textOrNull() } ?: return
+                val description = ifCanBeParsed { textOrNull() } ?: return
                 builder.description(description)
             }
-            "docs" -> builder.docs(node.ifCanBeParsed { textOrNull() })
-            "generator" -> builder.generator(node.ifCanBeParsed { textOrNull() })
-            "image" -> builder.imageBuilder(node.ifCanBeParsed { toRssImageBuilder(builder.createRssImageBuilder()) })
+            "docs" -> builder.docs(ifCanBeParsed { textOrNull() })
+            "generator" -> builder.generator(ifCanBeParsed { textOrNull() })
+            "image" -> builder.imageBuilder(ifCanBeParsed { toRssImageBuilder(builder.createRssImageBuilder()) })
             "language" -> {
-                val language = node.ifCanBeParsed { textOrNull() } ?: return
+                val language = ifCanBeParsed { textOrNull() } ?: return
                 builder.language(language)
             }
-            "lastBuildDate" -> builder.lastBuildDate(node.ifCanBeParsed { parseAsTemporalAccessor() })
+            "lastBuildDate" -> builder.lastBuildDate(ifCanBeParsed { parseAsTemporalAccessor() })
             "link" -> {
-                val link = node.ifCanBeParsed { textOrNull() } ?: return
+                val link = ifCanBeParsed { textOrNull() } ?: return
                 builder.link(link)
             }
-            "managingEditor" -> builder.managingEditor(node.ifCanBeParsed { textOrNull() })
-            "pubDate" -> builder.pubDate(node.ifCanBeParsed { parseAsTemporalAccessor() })
+            "managingEditor" -> builder.managingEditor(ifCanBeParsed { textOrNull() })
+            "pubDate" -> builder.pubDate(ifCanBeParsed { parseAsTemporalAccessor() })
             "title" -> {
-                val title = node.ifCanBeParsed { textOrNull() } ?: return
+                val title = ifCanBeParsed { textOrNull() } ?: return
                 builder.title(title)
             }
-            "webMaster" -> builder.webMaster(node.ifCanBeParsed { textOrNull() })
+            "webMaster" -> builder.webMaster(ifCanBeParsed { textOrNull() })
             "item" -> pass // Items are parsed by the root parser direcly
         }
     }
 
-    override fun parseItemNode(builder: EpisodeBuilder, node: Node) {
-        if (node !is Element) return
+    override fun Node.parseItemData(builder: EpisodeBuilder) {
+        if (this !is Element) return
 
-        when (node.localName) {
-            "author" -> builder.author(node.ifCanBeParsed { textOrNull() })
+        when (localName) {
+            "author" -> builder.author(ifCanBeParsed { textOrNull() })
             "category" -> {
-                val categoryBuilder = node.ifCanBeParsed { toRssCategoryBuilder(builder.createRssCategoryBuilder()) } ?: return
+                val categoryBuilder = ifCanBeParsed { toRssCategoryBuilder(builder.createRssCategoryBuilder()) } ?: return
                 builder.addCategoryBuilder(categoryBuilder)
             }
-            "comments" -> builder.comments(node.ifCanBeParsed { textOrNull() })
-            "description" -> builder.description(node.ifCanBeParsed { textOrNull() })
+            "comments" -> builder.comments(ifCanBeParsed { textOrNull() })
+            "description" -> builder.description(ifCanBeParsed { textOrNull() })
             "enclosure" -> {
-                val enclosure = node.ifCanBeParsed { toEnclosureBuilder(builder.createEnclosureBuilder()) } ?: return
+                val enclosure = ifCanBeParsed { toEnclosureBuilder(builder.createEnclosureBuilder()) } ?: return
                 builder.enclosureBuilder(enclosure)
             }
-            "guid" -> builder.guidBuilder(node.ifCanBeParsed { toGuidBuilder(builder.createGuidBuilder()) })
-            "link" -> builder.link(node.ifCanBeParsed { textOrNull() })
-            "pubDate" -> builder.pubDate(node.ifCanBeParsed { parseAsTemporalAccessor() })
-            "source" -> builder.source(node.ifCanBeParsed { textOrNull() })
+            "guid" -> builder.guidBuilder(ifCanBeParsed { toGuidBuilder(builder.createGuidBuilder()) })
+            "link" -> builder.link(ifCanBeParsed { textOrNull() })
+            "pubDate" -> builder.pubDate(ifCanBeParsed { parseAsTemporalAccessor() })
+            "source" -> builder.source(ifCanBeParsed { textOrNull() })
             "title" -> {
-                val title = node.ifCanBeParsed { textOrNull() } ?: return
+                val title = ifCanBeParsed { textOrNull() } ?: return
                 builder.title(title)
             }
         }

--- a/src/main/kotlin/io/hemin/wien/writer/NamespaceWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/NamespaceWriter.kt
@@ -14,7 +14,7 @@ internal abstract class NamespaceWriter {
     abstract val namespace: FeedNamespace?
 
     /**
-     * Writes data from the channel data model into the tags for the
+     * Writes data from the [Podcast] data model into the tags for the
      * XML namespace defined by [namespace].
      * This function will throw if the [element] does not satisfy
      * the writer's [canWriteToNode], which checks if the element is
@@ -25,20 +25,20 @@ internal abstract class NamespaceWriter {
      */
     fun tryWritingPodcastData(podcast: Podcast, element: Element) {
         require(element.canWriteToNode("channel")) { "This function can only write data to <channel> nodes" }
-        writeChannelData(podcast, element)
+        element.appendPodcastData(podcast)
     }
 
     /**
-     * Writes data from the channel data model into the tags for the
+     * Appends data from the [Podcast] data model into the tags for the
      * XML namespace defined by [namespace].
-     * Note: the [element] has already been validated to be a `<channel>`.
+     * Note: the [this@appendPodcastData] has already been validated to be a `<channel>`.
      *
-     * @param channel The podcast data to write.
+     * @param podcast The podcast data to write.
      */
-    protected abstract fun writeChannelData(channel: Podcast, element: Element)
+    protected abstract fun Element.appendPodcastData(podcast: Podcast)
 
     /**
-     * Writes data from the item data model into the tags for the
+     * Writes data from the [Episode] data model into the tags for the
      * XML namespace defined by [namespace].
      * This function will throw if the [element] does not satisfy
      * the writer's [canWriteToNode], which checks if the element is
@@ -49,18 +49,18 @@ internal abstract class NamespaceWriter {
      */
     fun tryWritingEpisodeData(episode: Episode, element: Element) {
         require(element.canWriteToNode("item")) { "This function can only write data to <item> nodes" }
-        writeItemData(episode, element)
+        element.appendEpisodeData(episode)
     }
 
     /**
-     * Writes data from the item data model into the tags for the
+     * Appends data from the [Episode] data model into the tags for the
      * XML namespace defined by [namespace].
-     * Note: the [element] has already been validated to be a `<item>`.
+     * Note: the [this@appendEpisodeData] has already been validated to be a `<item>`.
      *
      * @param episode The episode data to write.
-     * @param element The element to append the data to.
+     * @param this@appendEpisodeData The element to append the data to.
      */
-    protected abstract fun writeItemData(episode: Episode, element: Element)
+    protected abstract fun Element.appendEpisodeData(episode: Episode)
 
     /**
      * Converts a [TemporalAccessor] value to a RFC2822 [String] representation.

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/AtomWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/AtomWriter.kt
@@ -19,20 +19,20 @@ internal class AtomWriter : NamespaceWriter() {
 
     override val namespace = FeedNamespace.ATOM
 
-    override fun writeChannelData(channel: Podcast, element: Element) {
-        val atom = channel.atom ?: return
+    override fun Element.appendPodcastData(podcast: Podcast) {
+        val atom = podcast.atom ?: return
 
-        element.appendPersonElements("contributor", atom.contributors)
-        element.appendPersonElements("author", atom.authors)
-        element.appendLinkElements(atom.links)
+        appendPersonElements("contributor", atom.contributors)
+        appendPersonElements("author", atom.authors)
+        appendLinkElements(atom.links)
     }
 
-    override fun writeItemData(episode: Episode, element: Element) {
+    override fun Element.appendEpisodeData(episode: Episode) {
         val atom = episode.atom ?: return
 
-        element.appendPersonElements("contributor", atom.contributors)
-        element.appendPersonElements("author", atom.authors)
-        element.appendLinkElements(atom.links)
+        appendPersonElements("contributor", atom.contributors)
+        appendPersonElements("author", atom.authors)
+        appendLinkElements(atom.links)
     }
 
     private fun Element.appendPersonElements(tagName: String, persons: List<Person>) {

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/BitloveWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/BitloveWriter.kt
@@ -17,14 +17,14 @@ internal class BitloveWriter : NamespaceWriter() {
 
     override val namespace = FeedNamespace.BITLOVE
 
-    override fun writeChannelData(channel: Podcast, element: Element) {
+    override fun Element.appendPodcastData(podcast: Podcast) {
         // Nothing to do here
     }
 
-    override fun writeItemData(episode: Episode, element: Element) {
+    override fun Element.appendEpisodeData(episode: Episode) {
         val guid = episode.bitlove?.guid ?: return
 
-        val enclosureElement = element.findElementByName("enclosure")
+        val enclosureElement = findElementByName("enclosure")
         requireNotNull(enclosureElement) { "This writer must execute after the episode <enclosure> has been written" }
 
         enclosureElement.setAttributeWithNS("guid", namespace) { value = guid }

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/ContentWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/ContentWriter.kt
@@ -16,13 +16,13 @@ internal class ContentWriter : NamespaceWriter() {
 
     override val namespace = FeedNamespace.CONTENT
 
-    override fun writeChannelData(channel: Podcast, element: Element) {
+    override fun Element.appendPodcastData(podcast: Podcast) {
         // Nothing to do here
     }
 
-    override fun writeItemData(episode: Episode, element: Element) {
+    override fun Element.appendEpisodeData(episode: Episode) {
         if (episode.content?.encoded == null) return
 
-        element.appendElement("encoded", namespace) { textContent = episode.content.encoded }
+        appendElement("encoded", namespace) { textContent = episode.content.encoded }
     }
 }

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/FeedpressWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/FeedpressWriter.kt
@@ -16,31 +16,31 @@ internal class FeedpressWriter : NamespaceWriter() {
 
     override val namespace = FeedNamespace.FEEDPRESS
 
-    override fun writeChannelData(channel: Podcast, element: Element) {
-        val feedpress = channel.feedpress ?: return
+    override fun Element.appendPodcastData(podcast: Podcast) {
+        val feedpress = podcast.feedpress ?: return
 
         if (feedpress.newsletterId != null) {
-            element.appendElement("newsletterId", namespace) { textContent = feedpress.newsletterId }
+            appendElement("newsletterId", namespace) { textContent = feedpress.newsletterId }
         }
 
         if (feedpress.locale != null) {
-            element.appendElement("locale", namespace) { textContent = feedpress.locale }
+            appendElement("locale", namespace) { textContent = feedpress.locale }
         }
 
         if (feedpress.podcastId != null) {
-            element.appendElement("podcastId", namespace) { textContent = feedpress.podcastId }
+            appendElement("podcastId", namespace) { textContent = feedpress.podcastId }
         }
 
         if (feedpress.cssFile != null) {
-            element.appendElement("cssFile", namespace) { textContent = feedpress.cssFile }
+            appendElement("cssFile", namespace) { textContent = feedpress.cssFile }
         }
 
         if (feedpress.link != null) {
-            element.appendElement("link", namespace) { textContent = feedpress.link }
+            appendElement("link", namespace) { textContent = feedpress.link }
         }
     }
 
-    override fun writeItemData(episode: Episode, element: Element) {
+    override fun Element.appendEpisodeData(episode: Episode) {
         // Nothing to do here
     }
 }

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/FyydWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/FyydWriter.kt
@@ -16,13 +16,13 @@ internal class FyydWriter : NamespaceWriter() {
 
     override val namespace = FeedNamespace.FYYD
 
-    override fun writeChannelData(channel: Podcast, element: Element) {
-        val fyyd = channel.fyyd ?: return
+    override fun Element.appendPodcastData(podcast: Podcast) {
+        val fyyd = podcast.fyyd ?: return
 
-        element.appendElement("verify", namespace) { textContent = fyyd.verify }
+        appendElement("verify", namespace) { textContent = fyyd.verify }
     }
 
-    override fun writeItemData(episode: Episode, element: Element) {
+    override fun Element.appendEpisodeData(episode: Episode) {
         // Nothing to do here
     }
 }

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/GooglePlayWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/GooglePlayWriter.kt
@@ -20,26 +20,26 @@ internal class GooglePlayWriter : NamespaceWriter() {
 
     override val namespace = FeedNamespace.GOOGLE_PLAY
 
-    override fun writeChannelData(channel: Podcast, element: Element) {
-        val play = channel.googlePlay ?: return
+    override fun Element.appendPodcastData(podcast: Podcast) {
+        val play = podcast.googlePlay ?: return
 
         if (play.author != null) {
-            element.appendElement("author", namespace) { textContent = play.author }
+            appendElement("author", namespace) { textContent = play.author }
         }
 
         if (play.owner != null) {
-            element.appendElement("owner", namespace) { textContent = play.owner }
+            appendElement("owner", namespace) { textContent = play.owner }
         }
 
-        element.appendITunesCategoryElements(play.categories, namespace)
+        appendITunesCategoryElements(play.categories, namespace)
 
-        element.appendCommonElements(play)
+        appendCommonElements(play)
     }
 
-    override fun writeItemData(episode: Episode, element: Element) {
+    override fun Element.appendEpisodeData(episode: Episode) {
         val play = episode.googlePlay ?: return
 
-        element.appendCommonElements(play)
+        appendCommonElements(play)
     }
 
     private fun Element.appendCommonElements(play: GooglePlayBase) {

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/ITunesWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/ITunesWriter.kt
@@ -22,54 +22,54 @@ internal class ITunesWriter : NamespaceWriter() {
 
     override val namespace = FeedNamespace.ITUNES
 
-    override fun writeChannelData(channel: Podcast, element: Element) {
-        val iTunes = channel.iTunes ?: return
+    override fun Element.appendPodcastData(podcast: Podcast) {
+        val iTunes = podcast.iTunes ?: return
 
-        element.appendITunesCategoryElements(iTunes.categories, namespace)
+        appendITunesCategoryElements(iTunes.categories, namespace)
 
         if (iTunes.complete != null) {
-            element.appendYesElementIfTrue("complete", iTunes.complete, namespace)
+            appendYesElementIfTrue("complete", iTunes.complete, namespace)
         }
 
         if (iTunes.keywords != null) {
-            element.appendElement("keywords", namespace) { textContent = iTunes.keywords }
+            appendElement("keywords", namespace) { textContent = iTunes.keywords }
         }
 
         if (iTunes.owner != null) {
-            element.appendPersonElement("owner", iTunes.owner, namespace)
+            appendPersonElement("owner", iTunes.owner, namespace)
         }
 
         if (iTunes.type != null) {
-            element.appendElement("type", namespace) { textContent = iTunes.type.type }
+            appendElement("type", namespace) { textContent = iTunes.type.type }
         }
 
         if (iTunes.type != null) {
-            element.appendElement("new-feed-url", namespace) { textContent = iTunes.newFeedUrl }
+            appendElement("new-feed-url", namespace) { textContent = iTunes.newFeedUrl }
         }
 
-        element.appendCommonElements(channel.iTunes)
+        appendCommonElements(podcast.iTunes)
     }
 
-    override fun writeItemData(episode: Episode, element: Element) {
+    override fun Element.appendEpisodeData(episode: Episode) {
         val iTunes = episode.iTunes ?: return
 
         if (iTunes.duration != null) {
-            element.appendElement("duration", namespace) { textContent = iTunes.duration }
+            appendElement("duration", namespace) { textContent = iTunes.duration }
         }
 
         if (iTunes.season != null) {
-            element.appendElement("season", namespace) { textContent = iTunes.season.toString() }
+            appendElement("season", namespace) { textContent = iTunes.season.toString() }
         }
 
         if (iTunes.episode != null) {
-            element.appendElement("episode", namespace) { textContent = iTunes.episode.toString() }
+            appendElement("episode", namespace) { textContent = iTunes.episode.toString() }
         }
 
         if (iTunes.episodeType != null) {
-            element.appendElement("episodeType", namespace) { textContent = iTunes.episodeType.type }
+            appendElement("episodeType", namespace) { textContent = iTunes.episodeType.type }
         }
 
-        element.appendCommonElements(episode.iTunes)
+        appendCommonElements(episode.iTunes)
     }
 
     private fun Element.appendCommonElements(iTunes: ITunesBase) {

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/PodloveSimpleChapterWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/PodloveSimpleChapterWriter.kt
@@ -16,14 +16,14 @@ internal class PodloveSimpleChapterWriter : NamespaceWriter() {
 
     override val namespace = FeedNamespace.PODLOVE_SIMPLE_CHAPTER
 
-    override fun writeChannelData(channel: Podcast, element: Element) {
+    override fun Element.appendPodcastData(podcast: Podcast) {
         // Nothing to do here
     }
 
-    override fun writeItemData(episode: Episode, element: Element) {
+    override fun Element.appendEpisodeData(episode: Episode) {
         val chapters = episode.podlove?.simpleChapters ?: return
 
-        element.appendElement("chapters", namespace) {
+        appendElement("chapters", namespace) {
             for (chapter in chapters) {
                 appendChapterElement(chapter)
             }

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/RssWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/RssWriter.kt
@@ -23,77 +23,77 @@ internal class RssWriter : NamespaceWriter() {
     /** Standard RSS 2.0 elements do not have a namespace. This value is therefore null. */
     override val namespace: FeedNamespace? = null
 
-    override fun writeChannelData(channel: Podcast, element: Element) {
-        element.appendElement("title") { textContent = channel.title }
-        element.appendElement("link") { textContent = channel.link }
-        element.appendElement("description") { textContent = channel.description }
+    override fun Element.appendPodcastData(podcast: Podcast) {
+        appendElement("title") { textContent = podcast.title }
+        appendElement("link") { textContent = podcast.link }
+        appendElement("description") { textContent = podcast.description }
 
-        if (channel.pubDate != null) {
-            element.appendElement("pubDate") { textContent = channel.pubDate.asDateString() }
+        if (podcast.pubDate != null) {
+            appendElement("pubDate") { textContent = podcast.pubDate.asDateString() }
         }
 
-        if (channel.lastBuildDate != null) {
-            element.appendElement("lastBuildDate") { textContent = channel.lastBuildDate.asDateString() }
+        if (podcast.lastBuildDate != null) {
+            appendElement("lastBuildDate") { textContent = podcast.lastBuildDate.asDateString() }
         }
 
-        if (channel.generator != null) {
-            element.appendElement("generator") { textContent = channel.generator }
+        if (podcast.generator != null) {
+            appendElement("generator") { textContent = podcast.generator }
         }
 
-        element.appendElement("language") { textContent = channel.language }
+        appendElement("language") { textContent = podcast.language }
 
-        if (channel.copyright != null) {
-            element.appendElement("copyright") { textContent = channel.copyright }
+        if (podcast.copyright != null) {
+            appendElement("copyright") { textContent = podcast.copyright }
         }
 
-        if (channel.docs != null) {
-            element.appendElement("docs") { textContent = channel.docs }
+        if (podcast.docs != null) {
+            appendElement("docs") { textContent = podcast.docs }
         }
 
-        if (channel.managingEditor != null) {
-            element.appendElement("managingEditor") { textContent = channel.managingEditor }
+        if (podcast.managingEditor != null) {
+            appendElement("managingEditor") { textContent = podcast.managingEditor }
         }
 
-        if (channel.webMaster != null) {
-            element.appendElement("webMaster") { textContent = channel.webMaster }
+        if (podcast.webMaster != null) {
+            appendElement("webMaster") { textContent = podcast.webMaster }
         }
 
-        if (channel.image != null) element.appendRssImageElement(channel.image)
+        if (podcast.image != null) appendRssImageElement(podcast.image)
     }
 
-    override fun writeItemData(episode: Episode, element: Element) {
-        element.appendElement("title") { textContent = episode.title }
+    override fun Element.appendEpisodeData(episode: Episode) {
+        appendElement("title") { textContent = episode.title }
 
         if (episode.link != null) {
-            element.appendElement("link") { textContent = episode.link }
+            appendElement("link") { textContent = episode.link }
         }
 
         if (episode.description != null) {
-            element.appendElement("description") { textContent = episode.description }
+            appendElement("description") { textContent = episode.description }
         }
 
         if (episode.author != null) {
-            element.appendElement("author") { textContent = episode.author }
+            appendElement("author") { textContent = episode.author }
         }
 
-        element.appendRssCategoryElements(episode.categories)
+        appendRssCategoryElements(episode.categories)
 
         if (episode.comments != null) {
-            element.appendElement("comments") { textContent = episode.comments }
+            appendElement("comments") { textContent = episode.comments }
         }
 
-        element.appendEnclosureElement(episode.enclosure)
+        appendEnclosureElement(episode.enclosure)
 
         if (episode.guid != null) {
-            element.appendGuidElement(episode.guid)
+            appendGuidElement(episode.guid)
         }
 
         if (episode.pubDate != null) {
-            element.appendElement("pubDate") { textContent = episode.pubDate.asDateString() }
+            appendElement("pubDate") { textContent = episode.pubDate.asDateString() }
         }
 
         if (episode.source != null) {
-            element.appendElement("source") { textContent = episode.source }
+            appendElement("source") { textContent = episode.source }
         }
     }
 

--- a/src/test/kotlin/io/hemin/wien/parser/NamespaceParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/NamespaceParserTest.kt
@@ -11,13 +11,13 @@ internal abstract class NamespaceParserTest {
 
     protected fun Node.parseChannelChildNodes(builder: FakePodcastBuilder) {
         for (element in childNodes.asListOfNodes()) {
-            parser.tryParsingChannelChildNode(builder, element)
+            parser.tryParsingChannelChildNode(element, builder)
         }
     }
 
     protected fun Node.parseItemChildNodes(builder: FakeEpisodeBuilder) {
         for (element in childNodes.asListOfNodes()) {
-            parser.tryParsingItemChildNode(builder, element)
+            parser.tryParsingItemChildNode(element, builder)
         }
     }
 }


### PR DESCRIPTION
This PR mostly does some minor tweaks to some internal APIs, by changing a couple of method signatures to make them more idiomatic, and reorganizes some code. In particular, the DOM-related extensions, utils and helpers are now grouped in the `io.hemin.wien.dom` package. No behaviour changes.