### PR TITLE
Ensure writers don't write empty values

### DIFF
--- a/src/main/kotlin/io/hemin/wien/dom/DomExtensions.kt
+++ b/src/main/kotlin/io/hemin/wien/dom/DomExtensions.kt
@@ -48,6 +48,9 @@ internal fun Node.getAttributeValueByName(attributeName: String, namespace: Feed
 internal fun Node.getAttributeByName(attributeName: String, namespace: FeedNamespace? = null): Attr? =
     attributes?.getNamedItemNS(namespace?.uri, attributeName) as? Attr
 
+/** Returns true if the [NodeList] is empty. */
+internal fun NodeList.isEmpty() = length == 0
+
 /** Returns true if the [NodeList] contains at least one node. */
 internal fun NodeList.isNotEmpty() = length > 0
 

--- a/src/main/kotlin/io/hemin/wien/dom/DomExtensions.kt
+++ b/src/main/kotlin/io/hemin/wien/dom/DomExtensions.kt
@@ -36,7 +36,17 @@ internal fun Node.isDirectChildOf(tagName: String) =
  * @return The textContent of the node's attribute.
  */
 internal fun Node.getAttributeValueByName(attributeName: String, namespace: FeedNamespace? = null): String? =
-    attributes?.getNamedItemNS(namespace?.uri, attributeName)?.textContent?.trimmedOrNullIfBlank()
+    getAttributeByName(attributeName, namespace)?.value?.trimmedOrNullIfBlank()
+
+/**
+ * Extract the [`textContent`][Node.getTextContent] of a DOM node attribute identified by name.
+ *
+ * @param attributeName The name of the node's attribute.
+ * @param namespace The namespace to use, if any.
+ * @return The textContent of the node's attribute.
+ */
+internal fun Node.getAttributeByName(attributeName: String, namespace: FeedNamespace? = null): Attr? =
+    attributes?.getNamedItemNS(namespace?.uri, attributeName) as? Attr
 
 /** Returns true if the [NodeList] contains at least one node. */
 internal fun NodeList.isNotEmpty() = length > 0

--- a/src/main/kotlin/io/hemin/wien/dom/DomWritingExtensions.kt
+++ b/src/main/kotlin/io/hemin/wien/dom/DomWritingExtensions.kt
@@ -29,7 +29,7 @@ internal fun Node.appendHrefOnlyImageElement(image: HrefOnlyImage, namespace: Fe
     }
     if (image.href.isBlank()) return null
     return appendElement("image", namespace) {
-        setAttribute("href", image.href)
+        setAttribute("href", image.href.trim())
     }
 }
 
@@ -38,13 +38,26 @@ internal fun Node.appendHrefOnlyImageElement(image: HrefOnlyImage, namespace: Fe
  *
  * @param image The image to represent with the new element.
  */
-internal fun Node.appendRssImageElement(image: RssImage): Element = appendElement("image") {
-    appendElement("title") { textContent = image.title }
-    appendElement("link") { textContent = image.link }
-    appendElement("url") { textContent = image.url }
-    if (image.description != null) appendElement("description") { textContent = image.description }
-    if (image.height != null) appendElement("height") { textContent = image.height.toString() }
-    if (image.width != null) appendElement("width") { textContent = image.width.toString() }
+internal fun Node.appendRssImageElement(image: RssImage): Element? {
+    if (image.url.isBlank()) return null
+    return appendElement("image") {
+        appendElement("url") { textContent = image.url.trim() }
+        if (image.title.isNotBlank()) {
+            appendElement("title") { textContent = image.title.trim() }
+        }
+        if (image.link.isNotBlank()) {
+            appendElement("link") { textContent = image.link.trim() }
+        }
+        if (image.description.isNeitherNullNorBlank()) {
+            appendElement("description") { textContent = image.description?.trim() }
+        }
+        if (image.height != null) {
+            appendElement("height") { textContent = image.height.toString() }
+        }
+        if (image.width != null) {
+            appendElement("width") { textContent = image.width.toString() }
+        }
+    }
 }
 
 /**
@@ -127,14 +140,14 @@ internal fun Node.appendPersonElement(tagName: String, person: Person, namespace
     if (person.name.isBlank()) return
 
     appendElement(tagName, namespace) {
-        appendElement("name", namespace) { textContent = person.name }
+        appendElement("name", namespace) { textContent = person.name.trim() }
 
         if (person.email.isNeitherNullNorBlank()) {
-            appendElement("email", namespace) { textContent = person.email }
+            appendElement("email", namespace) { textContent = person.email?.trim() }
         }
 
         if (person.uri.isNeitherNullNorBlank()) {
-            appendElement("uri", namespace) { textContent = person.uri }
+            appendElement("uri", namespace) { textContent = person.uri?.trim() }
         }
     }
 }
@@ -149,11 +162,11 @@ internal fun Node.appendITunesCategoryElements(categories: List<ITunesStyleCateg
     for (category in categories) {
         if (category.name.isBlank()) continue
         appendElement("category", namespace) {
-            setAttribute("text", category.name)
+            setAttribute("text", category.name.trim())
 
             if (category is ITunesStyleCategory.Nested && category.subcategory.name.isNotBlank()) {
                 appendElement("category", namespace) {
-                    setAttribute("text", category.subcategory.name)
+                    setAttribute("text", category.subcategory.name.trim())
                 }
             }
         }
@@ -168,9 +181,12 @@ internal fun Node.appendITunesCategoryElements(categories: List<ITunesStyleCateg
  */
 internal fun Node.appendRssCategoryElements(categories: List<RssCategory>, namespace: FeedNamespace? = null) {
     for (category in categories) {
+        if (category.name.isBlank()) continue
         appendElement("category", namespace) {
-            textContent = category.name
-            setAttribute("domain", category.domain)
+            textContent = category.name.trim()
+            if (category.domain.isNeitherNullNorBlank()) {
+                setAttribute("domain", category.domain?.trim())
+            }
         }
     }
 }

--- a/src/main/kotlin/io/hemin/wien/dom/DomWritingExtensions.kt
+++ b/src/main/kotlin/io/hemin/wien/dom/DomWritingExtensions.kt
@@ -8,6 +8,7 @@ import io.hemin.wien.model.RssImage
 import io.hemin.wien.util.BooleanStringStyle
 import io.hemin.wien.util.FeedNamespace
 import io.hemin.wien.util.asBooleanString
+import io.hemin.wien.util.isNeitherNullNorBlank
 import org.w3c.dom.Attr
 import org.w3c.dom.Document
 import org.w3c.dom.Element
@@ -22,10 +23,11 @@ import org.w3c.dom.Node
  * @param image The image to represent with the new element.
  * @param namespace The namespace to use for the new element.
  */
-internal fun Node.appendHrefOnlyImageElement(image: HrefOnlyImage, namespace: FeedNamespace): Element {
+internal fun Node.appendHrefOnlyImageElement(image: HrefOnlyImage, namespace: FeedNamespace): Element? {
     require(namespace == FeedNamespace.ITUNES || namespace == FeedNamespace.GOOGLE_PLAY) {
         "Only 'itunes:image' and 'googleplay:image' tags are supported, but the desired prefix was '${namespace.prefix}:'"
     }
+    if (image.href.isBlank()) return null
     return appendElement("image", namespace) {
         setAttribute("href", image.href)
     }
@@ -122,14 +124,16 @@ internal fun Node.appendTrueFalseElement(tagName: String, value: Boolean, namesp
  * @param namespace The namespace to use, if any
  */
 internal fun Node.appendPersonElement(tagName: String, person: Person, namespace: FeedNamespace? = null) {
+    if (person.name.isBlank()) return
+
     appendElement(tagName, namespace) {
         appendElement("name", namespace) { textContent = person.name }
 
-        if (person.email != null) {
+        if (person.email.isNeitherNullNorBlank()) {
             appendElement("email", namespace) { textContent = person.email }
         }
 
-        if (person.uri != null) {
+        if (person.uri.isNeitherNullNorBlank()) {
             appendElement("uri", namespace) { textContent = person.uri }
         }
     }
@@ -143,10 +147,11 @@ internal fun Node.appendPersonElement(tagName: String, person: Person, namespace
  */
 internal fun Node.appendITunesCategoryElements(categories: List<ITunesStyleCategory>, namespace: FeedNamespace? = null) {
     for (category in categories) {
+        if (category.name.isBlank()) continue
         appendElement("category", namespace) {
             setAttribute("text", category.name)
 
-            if (category is ITunesStyleCategory.Nested) {
+            if (category is ITunesStyleCategory.Nested && category.subcategory.name.isNotBlank()) {
                 appendElement("category", namespace) {
                     setAttribute("text", category.subcategory.name)
                 }

--- a/src/main/kotlin/io/hemin/wien/model/Episode.kt
+++ b/src/main/kotlin/io/hemin/wien/model/Episode.kt
@@ -59,11 +59,11 @@ data class Episode(
     /**
      * Model class for `<guid>` elements within RSS `<item>` elements.
      *
-     * @property textContent The text content of the element.
+     * @property guid The text content of the element.
      * @property isPermalink The boolean interpretation of the `isPermalink` attribute.
      */
     data class Guid(
-        val textContent: String,
+        val guid: String,
         val isPermalink: Boolean? = null
     )
 

--- a/src/main/kotlin/io/hemin/wien/util/DateTimeExtensions.kt
+++ b/src/main/kotlin/io/hemin/wien/util/DateTimeExtensions.kt
@@ -1,0 +1,11 @@
+package io.hemin.wien.util
+
+import io.hemin.wien.writer.DateFormatter
+import java.time.temporal.TemporalAccessor
+
+/**
+ * Converts a [TemporalAccessor] value to a RFC2822 [String] representation.
+ *
+ * @return The string representing the value in the chosen style.
+ */
+internal fun TemporalAccessor.asDateString() = DateFormatter.formatAsRfc2822(this)

--- a/src/main/kotlin/io/hemin/wien/util/StringExtensions.kt
+++ b/src/main/kotlin/io/hemin/wien/util/StringExtensions.kt
@@ -5,3 +5,6 @@ internal fun String.trimmedOrNullIfBlank(): String? {
     val trimmed = trim()
     return if (trimmed.isNotEmpty()) trimmed else null
 }
+
+/** Returns `true` when this string is neither `null` nor blank. */
+internal fun String?.isNeitherNullNorBlank(): Boolean = this != null && isNotBlank()

--- a/src/main/kotlin/io/hemin/wien/writer/NamespaceWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/NamespaceWriter.kt
@@ -58,16 +58,8 @@ internal abstract class NamespaceWriter {
      * Note: the [this@appendEpisodeData] has already been validated to be a `<item>`.
      *
      * @param episode The episode data to write.
-     * @param this@appendEpisodeData The element to append the data to.
      */
     protected abstract fun Element.appendEpisodeData(episode: Episode)
-
-    /**
-     * Converts a [TemporalAccessor] value to a RFC2822 [String] representation.
-     *
-     * @return The string representing the value in the chosen style.
-     */
-    protected fun TemporalAccessor.asDateString() = DateFormatter.formatAsRfc2822(this)
 
     /**
      * Should return `true` when this writer can write to a given node. Returns true when the node

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/AtomWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/AtomWriter.kt
@@ -47,30 +47,30 @@ internal class AtomWriter : NamespaceWriter() {
             if (link.href.isBlank()) continue
 
             appendElement("link", namespace) {
-                setAttribute("href", link.href)
+                setAttribute("href", link.href.trim())
 
                 if (link.hrefLang.isNeitherNullNorBlank()) {
-                    setAttribute("hrefLang", link.hrefLang)
+                    setAttribute("hrefLang", link.hrefLang?.trim())
                 }
 
                 if (link.hrefResolved.isNeitherNullNorBlank()) {
-                    setAttribute("hrefResolved", link.hrefResolved)
+                    setAttribute("hrefResolved", link.hrefResolved?.trim())
                 }
 
                 if (link.length.isNeitherNullNorBlank()) {
-                    setAttribute("length", link.length)
+                    setAttribute("length", link.length?.trim())
                 }
 
                 if (link.rel.isNeitherNullNorBlank()) {
-                    setAttribute("rel", link.rel)
+                    setAttribute("rel", link.rel?.trim())
                 }
 
                 if (link.title.isNeitherNullNorBlank()) {
-                    setAttribute("title", link.title)
+                    setAttribute("title", link.title?.trim())
                 }
 
                 if (link.type.isNeitherNullNorBlank()) {
-                    setAttribute("type", link.type)
+                    setAttribute("type", link.type?.trim())
                 }
             }
         }

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/AtomWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/AtomWriter.kt
@@ -7,6 +7,7 @@ import io.hemin.wien.model.Link
 import io.hemin.wien.model.Person
 import io.hemin.wien.model.Podcast
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.isNeitherNullNorBlank
 import io.hemin.wien.writer.NamespaceWriter
 import org.w3c.dom.Element
 
@@ -43,30 +44,32 @@ internal class AtomWriter : NamespaceWriter() {
 
     private fun Element.appendLinkElements(links: List<Link>) {
         for (link in links) {
+            if (link.href.isBlank()) continue
+
             appendElement("link", namespace) {
                 setAttribute("href", link.href)
 
-                if (link.hrefLang != null) {
+                if (link.hrefLang.isNeitherNullNorBlank()) {
                     setAttribute("hrefLang", link.hrefLang)
                 }
 
-                if (link.hrefResolved != null) {
+                if (link.hrefResolved.isNeitherNullNorBlank()) {
                     setAttribute("hrefResolved", link.hrefResolved)
                 }
 
-                if (link.length != null) {
+                if (link.length.isNeitherNullNorBlank()) {
                     setAttribute("length", link.length)
                 }
 
-                if (link.rel != null) {
+                if (link.rel.isNeitherNullNorBlank()) {
                     setAttribute("rel", link.rel)
                 }
 
-                if (link.title != null) {
+                if (link.title.isNeitherNullNorBlank()) {
                     setAttribute("title", link.title)
                 }
 
-                if (link.type != null) {
+                if (link.type.isNeitherNullNorBlank()) {
                     setAttribute("type", link.type)
                 }
             }

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/BitloveWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/BitloveWriter.kt
@@ -28,6 +28,6 @@ internal class BitloveWriter : NamespaceWriter() {
         val enclosureElement = findElementByName("enclosure")
         requireNotNull(enclosureElement) { "This writer must execute after the episode <enclosure> has been written" }
 
-        enclosureElement.setAttributeWithNS("guid", namespace) { value = guid }
+        enclosureElement.setAttributeWithNS("guid", namespace) { value = guid.trim() }
     }
 }

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/BitloveWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/BitloveWriter.kt
@@ -23,6 +23,7 @@ internal class BitloveWriter : NamespaceWriter() {
 
     override fun Element.appendEpisodeData(episode: Episode) {
         val guid = episode.bitlove?.guid ?: return
+        if (guid.isBlank()) return
 
         val enclosureElement = findElementByName("enclosure")
         requireNotNull(enclosureElement) { "This writer must execute after the episode <enclosure> has been written" }

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/ContentWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/ContentWriter.kt
@@ -21,8 +21,9 @@ internal class ContentWriter : NamespaceWriter() {
     }
 
     override fun Element.appendEpisodeData(episode: Episode) {
-        if (episode.content?.encoded == null) return
+        val encoded = episode.content?.encoded
+        if (encoded.isNullOrBlank()) return
 
-        appendElement("encoded", namespace) { textContent = episode.content.encoded }
+        appendElement("encoded", namespace) { textContent = encoded }
     }
 }

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/ContentWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/ContentWriter.kt
@@ -24,6 +24,6 @@ internal class ContentWriter : NamespaceWriter() {
         val encoded = episode.content?.encoded
         if (encoded.isNullOrBlank()) return
 
-        appendElement("encoded", namespace) { textContent = encoded }
+        appendElement("encoded", namespace) { textContent = encoded.trim() }
     }
 }

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/FeedpressWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/FeedpressWriter.kt
@@ -4,6 +4,7 @@ import io.hemin.wien.dom.appendElement
 import io.hemin.wien.model.Episode
 import io.hemin.wien.model.Podcast
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.isNeitherNullNorBlank
 import io.hemin.wien.writer.NamespaceWriter
 import org.w3c.dom.Element
 
@@ -19,23 +20,23 @@ internal class FeedpressWriter : NamespaceWriter() {
     override fun Element.appendPodcastData(podcast: Podcast) {
         val feedpress = podcast.feedpress ?: return
 
-        if (feedpress.newsletterId != null) {
+        if (feedpress.newsletterId.isNeitherNullNorBlank()) {
             appendElement("newsletterId", namespace) { textContent = feedpress.newsletterId }
         }
 
-        if (feedpress.locale != null) {
+        if (feedpress.locale.isNeitherNullNorBlank()) {
             appendElement("locale", namespace) { textContent = feedpress.locale }
         }
 
-        if (feedpress.podcastId != null) {
+        if (feedpress.podcastId.isNeitherNullNorBlank()) {
             appendElement("podcastId", namespace) { textContent = feedpress.podcastId }
         }
 
-        if (feedpress.cssFile != null) {
+        if (feedpress.cssFile.isNeitherNullNorBlank()) {
             appendElement("cssFile", namespace) { textContent = feedpress.cssFile }
         }
 
-        if (feedpress.link != null) {
+        if (feedpress.link.isNeitherNullNorBlank()) {
             appendElement("link", namespace) { textContent = feedpress.link }
         }
     }

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/FeedpressWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/FeedpressWriter.kt
@@ -21,23 +21,23 @@ internal class FeedpressWriter : NamespaceWriter() {
         val feedpress = podcast.feedpress ?: return
 
         if (feedpress.newsletterId.isNeitherNullNorBlank()) {
-            appendElement("newsletterId", namespace) { textContent = feedpress.newsletterId }
+            appendElement("newsletterId", namespace) { textContent = feedpress.newsletterId?.trim() }
         }
 
         if (feedpress.locale.isNeitherNullNorBlank()) {
-            appendElement("locale", namespace) { textContent = feedpress.locale }
+            appendElement("locale", namespace) { textContent = feedpress.locale?.trim() }
         }
 
         if (feedpress.podcastId.isNeitherNullNorBlank()) {
-            appendElement("podcastId", namespace) { textContent = feedpress.podcastId }
+            appendElement("podcastId", namespace) { textContent = feedpress.podcastId?.trim() }
         }
 
         if (feedpress.cssFile.isNeitherNullNorBlank()) {
-            appendElement("cssFile", namespace) { textContent = feedpress.cssFile }
+            appendElement("cssFile", namespace) { textContent = feedpress.cssFile?.trim() }
         }
 
         if (feedpress.link.isNeitherNullNorBlank()) {
-            appendElement("link", namespace) { textContent = feedpress.link }
+            appendElement("link", namespace) { textContent = feedpress.link?.trim() }
         }
     }
 

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/FyydWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/FyydWriter.kt
@@ -17,9 +17,10 @@ internal class FyydWriter : NamespaceWriter() {
     override val namespace = FeedNamespace.FYYD
 
     override fun Element.appendPodcastData(podcast: Podcast) {
-        val fyyd = podcast.fyyd ?: return
+        val verify = podcast.fyyd?.verify ?: return
+        if (verify.isBlank()) return
 
-        appendElement("verify", namespace) { textContent = fyyd.verify }
+        appendElement("verify", namespace) { textContent = verify }
     }
 
     override fun Element.appendEpisodeData(episode: Episode) {

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/FyydWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/FyydWriter.kt
@@ -20,7 +20,7 @@ internal class FyydWriter : NamespaceWriter() {
         val verify = podcast.fyyd?.verify ?: return
         if (verify.isBlank()) return
 
-        appendElement("verify", namespace) { textContent = verify }
+        appendElement("verify", namespace) { textContent = verify.trim() }
     }
 
     override fun Element.appendEpisodeData(episode: Episode) {

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/GooglePlayWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/GooglePlayWriter.kt
@@ -25,11 +25,11 @@ internal class GooglePlayWriter : NamespaceWriter() {
         val play = podcast.googlePlay ?: return
 
         if (play.author.isNeitherNullNorBlank()) {
-            appendElement("author", namespace) { textContent = play.author }
+            appendElement("author", namespace) { textContent = play.author?.trim() }
         }
 
         if (play.owner.isNeitherNullNorBlank()) {
-            appendElement("owner", namespace) { textContent = play.owner }
+            appendElement("owner", namespace) { textContent = play.owner?.trim() }
         }
 
         appendITunesCategoryElements(play.categories, namespace)
@@ -46,7 +46,7 @@ internal class GooglePlayWriter : NamespaceWriter() {
     private fun Element.appendCommonElements(play: GooglePlayBase) {
         val description = play.description
         if (description.isNeitherNullNorBlank()) {
-            appendElement("description", namespace) { textContent = description }
+            appendElement("description", namespace) { textContent = description?.trim() }
         }
 
         val explicit = play.explicit

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/GooglePlayWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/GooglePlayWriter.kt
@@ -8,6 +8,7 @@ import io.hemin.wien.model.Episode
 import io.hemin.wien.model.GooglePlayBase
 import io.hemin.wien.model.Podcast
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.isNeitherNullNorBlank
 import io.hemin.wien.writer.NamespaceWriter
 import org.w3c.dom.Element
 
@@ -23,11 +24,11 @@ internal class GooglePlayWriter : NamespaceWriter() {
     override fun Element.appendPodcastData(podcast: Podcast) {
         val play = podcast.googlePlay ?: return
 
-        if (play.author != null) {
+        if (play.author.isNeitherNullNorBlank()) {
             appendElement("author", namespace) { textContent = play.author }
         }
 
-        if (play.owner != null) {
+        if (play.owner.isNeitherNullNorBlank()) {
             appendElement("owner", namespace) { textContent = play.owner }
         }
 
@@ -44,7 +45,7 @@ internal class GooglePlayWriter : NamespaceWriter() {
 
     private fun Element.appendCommonElements(play: GooglePlayBase) {
         val description = play.description
-        if (description != null) {
+        if (description.isNeitherNullNorBlank()) {
             appendElement("description", namespace) { textContent = description }
         }
 

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/ITunesWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/ITunesWriter.kt
@@ -10,6 +10,7 @@ import io.hemin.wien.model.Episode
 import io.hemin.wien.model.ITunesBase
 import io.hemin.wien.model.Podcast
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.isNeitherNullNorBlank
 import io.hemin.wien.writer.NamespaceWriter
 import org.w3c.dom.Element
 
@@ -31,7 +32,7 @@ internal class ITunesWriter : NamespaceWriter() {
             appendYesElementIfTrue("complete", iTunes.complete, namespace)
         }
 
-        if (iTunes.keywords != null) {
+        if (iTunes.keywords.isNeitherNullNorBlank()) {
             appendElement("keywords", namespace) { textContent = iTunes.keywords }
         }
 
@@ -43,7 +44,7 @@ internal class ITunesWriter : NamespaceWriter() {
             appendElement("type", namespace) { textContent = iTunes.type.type }
         }
 
-        if (iTunes.type != null) {
+        if (iTunes.newFeedUrl.isNeitherNullNorBlank()) {
             appendElement("new-feed-url", namespace) { textContent = iTunes.newFeedUrl }
         }
 
@@ -53,7 +54,7 @@ internal class ITunesWriter : NamespaceWriter() {
     override fun Element.appendEpisodeData(episode: Episode) {
         val iTunes = episode.iTunes ?: return
 
-        if (iTunes.duration != null) {
+        if (iTunes.duration.isNeitherNullNorBlank()) {
             appendElement("duration", namespace) { textContent = iTunes.duration }
         }
 
@@ -80,7 +81,7 @@ internal class ITunesWriter : NamespaceWriter() {
         if (explicit != null) appendTrueFalseElement("explicit", explicit, namespace)
 
         val title = iTunes.title
-        if (title != null) {
+        if (title.isNeitherNullNorBlank()) {
             appendElement("title", namespace) { textContent = title }
         }
 
@@ -88,17 +89,17 @@ internal class ITunesWriter : NamespaceWriter() {
         if (block != null) appendYesElementIfTrue("block", block, namespace)
 
         val author = iTunes.author
-        if (author != null) {
+        if (author.isNeitherNullNorBlank()) {
             appendElement("author", namespace) { textContent = author }
         }
 
         val subtitle = iTunes.subtitle
-        if (subtitle != null) {
+        if (subtitle.isNeitherNullNorBlank()) {
             appendElement("subtitle", namespace) { textContent = subtitle }
         }
 
         val summary = iTunes.summary
-        if (summary != null) {
+        if (summary.isNeitherNullNorBlank()) {
             appendElement("summary", namespace) { textContent = summary }
         }
     }

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/ITunesWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/ITunesWriter.kt
@@ -33,7 +33,7 @@ internal class ITunesWriter : NamespaceWriter() {
         }
 
         if (iTunes.keywords.isNeitherNullNorBlank()) {
-            appendElement("keywords", namespace) { textContent = iTunes.keywords }
+            appendElement("keywords", namespace) { textContent = iTunes.keywords?.trim() }
         }
 
         if (iTunes.owner != null) {
@@ -41,11 +41,11 @@ internal class ITunesWriter : NamespaceWriter() {
         }
 
         if (iTunes.type != null) {
-            appendElement("type", namespace) { textContent = iTunes.type.type }
+            appendElement("type", namespace) { textContent = iTunes.type.type.trim() }
         }
 
         if (iTunes.newFeedUrl.isNeitherNullNorBlank()) {
-            appendElement("new-feed-url", namespace) { textContent = iTunes.newFeedUrl }
+            appendElement("new-feed-url", namespace) { textContent = iTunes.newFeedUrl?.trim() }
         }
 
         appendCommonElements(podcast.iTunes)
@@ -55,7 +55,7 @@ internal class ITunesWriter : NamespaceWriter() {
         val iTunes = episode.iTunes ?: return
 
         if (iTunes.duration.isNeitherNullNorBlank()) {
-            appendElement("duration", namespace) { textContent = iTunes.duration }
+            appendElement("duration", namespace) { textContent = iTunes.duration?.trim() }
         }
 
         if (iTunes.season != null) {
@@ -67,7 +67,7 @@ internal class ITunesWriter : NamespaceWriter() {
         }
 
         if (iTunes.episodeType != null) {
-            appendElement("episodeType", namespace) { textContent = iTunes.episodeType.type }
+            appendElement("episodeType", namespace) { textContent = iTunes.episodeType.type.trim() }
         }
 
         appendCommonElements(episode.iTunes)
@@ -82,7 +82,7 @@ internal class ITunesWriter : NamespaceWriter() {
 
         val title = iTunes.title
         if (title.isNeitherNullNorBlank()) {
-            appendElement("title", namespace) { textContent = title }
+            appendElement("title", namespace) { textContent = title?.trim() }
         }
 
         val block = iTunes.block
@@ -90,17 +90,17 @@ internal class ITunesWriter : NamespaceWriter() {
 
         val author = iTunes.author
         if (author.isNeitherNullNorBlank()) {
-            appendElement("author", namespace) { textContent = author }
+            appendElement("author", namespace) { textContent = author?.trim() }
         }
 
         val subtitle = iTunes.subtitle
         if (subtitle.isNeitherNullNorBlank()) {
-            appendElement("subtitle", namespace) { textContent = subtitle }
+            appendElement("subtitle", namespace) { textContent = subtitle?.trim() }
         }
 
         val summary = iTunes.summary
         if (summary.isNeitherNullNorBlank()) {
-            appendElement("summary", namespace) { textContent = summary }
+            appendElement("summary", namespace) { textContent = summary?.trim() }
         }
     }
 }

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/PodloveSimpleChapterWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/PodloveSimpleChapterWriter.kt
@@ -35,14 +35,14 @@ internal class PodloveSimpleChapterWriter : NamespaceWriter() {
 
     private fun Element.appendChapterElement(chapter: Episode.Podlove.SimpleChapter) {
         appendElement("chapter", namespace) {
-            setAttribute("start", chapter.start)
-            setAttribute("title", chapter.title)
+            setAttribute("start", chapter.start.trim())
+            setAttribute("title", chapter.title.trim())
 
             if (chapter.href.isNeitherNullNorBlank()) {
-                setAttribute("href", chapter.href)
+                setAttribute("href", chapter.href?.trim())
             }
             if (chapter.image.isNeitherNullNorBlank()) {
-                setAttribute("image", chapter.image)
+                setAttribute("image", chapter.image?.trim())
             }
         }
     }

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/PodloveSimpleChapterWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/PodloveSimpleChapterWriter.kt
@@ -4,6 +4,7 @@ import io.hemin.wien.dom.appendElement
 import io.hemin.wien.model.Episode
 import io.hemin.wien.model.Podcast
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.isNeitherNullNorBlank
 import io.hemin.wien.writer.NamespaceWriter
 import org.w3c.dom.Element
 
@@ -22,9 +23,11 @@ internal class PodloveSimpleChapterWriter : NamespaceWriter() {
 
     override fun Element.appendEpisodeData(episode: Episode) {
         val chapters = episode.podlove?.simpleChapters ?: return
+        val validChapters = chapters.filter { it.isValid() }
+        if (validChapters.isEmpty()) return
 
         appendElement("chapters", namespace) {
-            for (chapter in chapters) {
+            for (chapter in validChapters) {
                 appendChapterElement(chapter)
             }
         }
@@ -35,8 +38,14 @@ internal class PodloveSimpleChapterWriter : NamespaceWriter() {
             setAttribute("start", chapter.start)
             setAttribute("title", chapter.title)
 
-            if (chapter.href != null) setAttribute("href", chapter.href)
-            if (chapter.image != null) setAttribute("image", chapter.image)
+            if (chapter.href.isNeitherNullNorBlank()) {
+                setAttribute("href", chapter.href)
+            }
+            if (chapter.image.isNeitherNullNorBlank()) {
+                setAttribute("image", chapter.image)
+            }
         }
     }
+
+    private fun Episode.Podlove.SimpleChapter.isValid() = start.isNotBlank() && title.isNotBlank()
 }

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/RssWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/RssWriter.kt
@@ -27,15 +27,15 @@ internal class RssWriter : NamespaceWriter() {
 
     override fun Element.appendPodcastData(podcast: Podcast) {
         if (podcast.title.isNotBlank()) {
-            appendElement("title") { textContent = podcast.title }
+            appendElement("title") { textContent = podcast.title.trim() }
         }
 
         if (podcast.link.isNotBlank()) {
-            appendElement("link") { textContent = podcast.link }
+            appendElement("link") { textContent = podcast.link.trim() }
         }
 
         if (podcast.description.isNotBlank()) {
-            appendElement("description") { textContent = podcast.description }
+            appendElement("description") { textContent = podcast.description.trim() }
         }
 
         if (podcast.pubDate != null) {
@@ -47,27 +47,27 @@ internal class RssWriter : NamespaceWriter() {
         }
 
         if (podcast.generator.isNeitherNullNorBlank()) {
-            appendElement("generator") { textContent = podcast.generator }
+            appendElement("generator") { textContent = podcast.generator?.trim() }
         }
 
         if (podcast.language.isNotBlank()) {
-            appendElement("language") { textContent = podcast.language }
+            appendElement("language") { textContent = podcast.language.trim() }
         }
 
         if (podcast.copyright.isNeitherNullNorBlank()) {
-            appendElement("copyright") { textContent = podcast.copyright }
+            appendElement("copyright") { textContent = podcast.copyright?.trim() }
         }
 
         if (podcast.docs.isNeitherNullNorBlank()) {
-            appendElement("docs") { textContent = podcast.docs }
+            appendElement("docs") { textContent = podcast.docs?.trim() }
         }
 
         if (podcast.managingEditor.isNeitherNullNorBlank()) {
-            appendElement("managingEditor") { textContent = podcast.managingEditor }
+            appendElement("managingEditor") { textContent = podcast.managingEditor?.trim() }
         }
 
         if (podcast.webMaster.isNeitherNullNorBlank()) {
-            appendElement("webMaster") { textContent = podcast.webMaster }
+            appendElement("webMaster") { textContent = podcast.webMaster?.trim() }
         }
 
         if (podcast.image != null) appendRssImageElement(podcast.image)
@@ -75,25 +75,25 @@ internal class RssWriter : NamespaceWriter() {
 
     override fun Element.appendEpisodeData(episode: Episode) {
         if (episode.title.isNotBlank()) {
-            appendElement("title") { textContent = episode.title }
+            appendElement("title") { textContent = episode.title.trim() }
         }
 
         if (episode.link.isNeitherNullNorBlank()) {
-            appendElement("link") { textContent = episode.link }
+            appendElement("link") { textContent = episode.link?.trim() }
         }
 
         if (episode.description.isNeitherNullNorBlank()) {
-            appendElement("description") { textContent = episode.description }
+            appendElement("description") { textContent = episode.description?.trim() }
         }
 
         if (episode.author.isNeitherNullNorBlank()) {
-            appendElement("author") { textContent = episode.author }
+            appendElement("author") { textContent = episode.author?.trim() }
         }
 
         appendRssCategoryElements(episode.categories)
 
         if (episode.comments.isNeitherNullNorBlank()) {
-            appendElement("comments") { textContent = episode.comments }
+            appendElement("comments") { textContent = episode.comments?.trim() }
         }
 
         appendEnclosureElement(episode.enclosure)
@@ -107,7 +107,7 @@ internal class RssWriter : NamespaceWriter() {
         }
 
         if (episode.source.isNeitherNullNorBlank()) {
-            appendElement("source") { textContent = episode.source }
+            appendElement("source") { textContent = episode.source?.trim() }
         }
     }
 

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/RssWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/RssWriter.kt
@@ -8,6 +8,7 @@ import io.hemin.wien.model.Podcast
 import io.hemin.wien.util.BooleanStringStyle
 import io.hemin.wien.util.FeedNamespace
 import io.hemin.wien.util.asBooleanString
+import io.hemin.wien.util.asDateString
 import io.hemin.wien.writer.NamespaceWriter
 import org.w3c.dom.Element
 

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/RssWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/RssWriter.kt
@@ -9,6 +9,7 @@ import io.hemin.wien.util.BooleanStringStyle
 import io.hemin.wien.util.FeedNamespace
 import io.hemin.wien.util.asBooleanString
 import io.hemin.wien.util.asDateString
+import io.hemin.wien.util.isNeitherNullNorBlank
 import io.hemin.wien.writer.NamespaceWriter
 import org.w3c.dom.Element
 
@@ -25,9 +26,17 @@ internal class RssWriter : NamespaceWriter() {
     override val namespace: FeedNamespace? = null
 
     override fun Element.appendPodcastData(podcast: Podcast) {
-        appendElement("title") { textContent = podcast.title }
-        appendElement("link") { textContent = podcast.link }
-        appendElement("description") { textContent = podcast.description }
+        if (podcast.title.isNotBlank()) {
+            appendElement("title") { textContent = podcast.title }
+        }
+
+        if (podcast.link.isNotBlank()) {
+            appendElement("link") { textContent = podcast.link }
+        }
+
+        if (podcast.description.isNotBlank()) {
+            appendElement("description") { textContent = podcast.description }
+        }
 
         if (podcast.pubDate != null) {
             appendElement("pubDate") { textContent = podcast.pubDate.asDateString() }
@@ -37,25 +46,27 @@ internal class RssWriter : NamespaceWriter() {
             appendElement("lastBuildDate") { textContent = podcast.lastBuildDate.asDateString() }
         }
 
-        if (podcast.generator != null) {
+        if (podcast.generator.isNeitherNullNorBlank()) {
             appendElement("generator") { textContent = podcast.generator }
         }
 
-        appendElement("language") { textContent = podcast.language }
+        if (podcast.language.isNotBlank()) {
+            appendElement("language") { textContent = podcast.language }
+        }
 
-        if (podcast.copyright != null) {
+        if (podcast.copyright.isNeitherNullNorBlank()) {
             appendElement("copyright") { textContent = podcast.copyright }
         }
 
-        if (podcast.docs != null) {
+        if (podcast.docs.isNeitherNullNorBlank()) {
             appendElement("docs") { textContent = podcast.docs }
         }
 
-        if (podcast.managingEditor != null) {
+        if (podcast.managingEditor.isNeitherNullNorBlank()) {
             appendElement("managingEditor") { textContent = podcast.managingEditor }
         }
 
-        if (podcast.webMaster != null) {
+        if (podcast.webMaster.isNeitherNullNorBlank()) {
             appendElement("webMaster") { textContent = podcast.webMaster }
         }
 
@@ -63,23 +74,25 @@ internal class RssWriter : NamespaceWriter() {
     }
 
     override fun Element.appendEpisodeData(episode: Episode) {
-        appendElement("title") { textContent = episode.title }
+        if (episode.title.isNotBlank()) {
+            appendElement("title") { textContent = episode.title }
+        }
 
-        if (episode.link != null) {
+        if (episode.link.isNeitherNullNorBlank()) {
             appendElement("link") { textContent = episode.link }
         }
 
-        if (episode.description != null) {
+        if (episode.description.isNeitherNullNorBlank()) {
             appendElement("description") { textContent = episode.description }
         }
 
-        if (episode.author != null) {
+        if (episode.author.isNeitherNullNorBlank()) {
             appendElement("author") { textContent = episode.author }
         }
 
         appendRssCategoryElements(episode.categories)
 
-        if (episode.comments != null) {
+        if (episode.comments.isNeitherNullNorBlank()) {
             appendElement("comments") { textContent = episode.comments }
         }
 
@@ -93,25 +106,27 @@ internal class RssWriter : NamespaceWriter() {
             appendElement("pubDate") { textContent = episode.pubDate.asDateString() }
         }
 
-        if (episode.source != null) {
+        if (episode.source.isNeitherNullNorBlank()) {
             appendElement("source") { textContent = episode.source }
         }
     }
 
     private fun Element.appendEnclosureElement(enclosure: Episode.Enclosure) {
+        if (enclosure.url.isBlank() || enclosure.type.isBlank()) return
         appendElement("enclosure") {
-            setAttribute("url", enclosure.url)
+            setAttribute("url", enclosure.url.trim())
             setAttribute("length", enclosure.length.toString())
-            setAttribute("type", enclosure.type)
+            setAttribute("type", enclosure.type.trim())
         }
     }
 
     private fun Element.appendGuidElement(guid: Episode.Guid) {
+        if (guid.guid.isBlank()) return
         appendElement("guid") {
             if (guid.isPermalink != null) {
                 setAttribute("isPermalink", guid.isPermalink.asBooleanString(BooleanStringStyle.TRUE_FALSE))
             }
-            textContent = guid.textContent
+            textContent = guid.guid.trim()
         }
     }
 }

--- a/src/test/kotlin/io/hemin/wien/Assertions.kt
+++ b/src/test/kotlin/io/hemin/wien/Assertions.kt
@@ -3,8 +3,12 @@ package io.hemin.wien
 import assertk.Assert
 import assertk.assertions.support.expected
 import io.hemin.wien.builder.Builder
+import io.hemin.wien.dom.asListOfNodes
 import io.hemin.wien.dom.asString
+import io.hemin.wien.dom.isNotEmpty
 import io.hemin.wien.util.FeedNamespace
+import org.w3c.dom.Attr
+import org.w3c.dom.Element
 import org.w3c.dom.Node
 import org.xmlunit.diff.Diff
 import java.io.File
@@ -76,4 +80,54 @@ internal fun Assert<Builder<*>>.hasNotEnoughDataToBuild() = given { builder ->
             actual = builder
         )
     }
+}
+
+/** Asserts the [Element] does not exist (is null). */
+internal fun Assert<Element?>.doesNotExist() = given { element ->
+    if (element == null) return@given
+    expected(
+        "to not exist",
+        expected = "null",
+        actual = element.asString()
+    )
+}
+
+/** Asserts the [Element] has the expected text content. */
+internal fun Assert<Element>.hasTextContent(expected: String) = given { element ->
+    if (element.textContent == expected) return@given
+    expected(
+        "to have the text content '$expected'",
+        expected = expected,
+        actual = element.textContent
+    )
+}
+
+/** Asserts the [Node] has no child nodes. */
+internal fun Assert<Node>.hasNoChildren() = given { element ->
+    if (element.childNodes.length == 0) return@given
+    expected(
+        "to have no children",
+        expected = emptyList<Node>(),
+        actual = element.childNodes.asListOfNodes().map { it.asString() }
+    )
+}
+
+/** Asserts the [Node] has only one child. */
+internal fun Assert<Node>.hasOneChild() = given { element ->
+    if (element.childNodes.length == 1) return@given
+    expected(
+        "to have exactly one child",
+        expected = listOf(element.firstChild.asString()),
+        actual = element.childNodes.asListOfNodes().map { it.asString() }
+    )
+}
+
+/** Asserts the [Attr] has the expected value. */
+internal fun Assert<Attr>.hasValue(expected: String) = given { element ->
+    if (element.value == expected) return@given
+    expected(
+        "to have the value '$expected'",
+        expected = expected,
+        actual = element.value
+    )
 }

--- a/src/test/kotlin/io/hemin/wien/Assertions.kt
+++ b/src/test/kotlin/io/hemin/wien/Assertions.kt
@@ -5,7 +5,6 @@ import assertk.assertions.support.expected
 import io.hemin.wien.builder.Builder
 import io.hemin.wien.dom.asListOfNodes
 import io.hemin.wien.dom.asString
-import io.hemin.wien.dom.isNotEmpty
 import io.hemin.wien.util.FeedNamespace
 import org.w3c.dom.Attr
 import org.w3c.dom.Element
@@ -131,3 +130,13 @@ internal fun Assert<Attr>.hasValue(expected: String) = given { element ->
         actual = element.value
     )
 }
+
+/**
+ * Transforms the current assertion to the list of [`childNodes`][Node.getChildNodes] that have
+ * the given [localName] and [namespace].
+ */
+internal fun Assert<Node>.childNodesNamed(localName: String, namespace: FeedNamespace? = null) =
+    transform { node ->
+        node.childNodes.asListOfNodes()
+            .filter { it.localName == localName && it.namespaceURI == namespace?.uri }
+    }

--- a/src/test/kotlin/io/hemin/wien/PodcastRssParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/PodcastRssParserTest.kt
@@ -179,7 +179,7 @@ internal class PodcastRssParserTest {
                     prop(Episode::title).isEqualTo("204: Green buttons, Olympic attacks, and... an apology")
                     prop(Episode::link).isEqualTo("http://www.smashingsecurity.com/204")
                     prop(Episode::guid).isNotNull().all {
-                        prop(Episode.Guid::textContent).isEqualTo("2ed98bdd-ea95-4129-98cf-ee23dd2ab478")
+                        prop(Episode.Guid::guid).isEqualTo("2ed98bdd-ea95-4129-98cf-ee23dd2ab478")
                         prop(Episode.Guid::isPermalink).isNotNull().isFalse()
                     }
                     prop(Episode::pubDate).isEqualTo(dateTime(year = 2020, month = Month.NOVEMBER, day = 12))

--- a/src/test/kotlin/io/hemin/wien/builder/validating/episode/ValidatingEpisodeGuidBuilderTest.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/validating/episode/ValidatingEpisodeGuidBuilderTest.kt
@@ -35,7 +35,7 @@ internal class ValidatingEpisodeGuidBuilderTest {
             assertThat(episodeGuidBuilder).prop(EpisodeGuidBuilder::hasEnoughDataToBuild).isTrue()
 
             assertThat(episodeGuidBuilder.build()).isNotNull().all {
-                prop(Episode.Guid::textContent).isEqualTo("textContent")
+                prop(Episode.Guid::guid).isEqualTo("textContent")
                 prop(Episode.Guid::isPermalink).isNull()
             }
         }
@@ -51,7 +51,7 @@ internal class ValidatingEpisodeGuidBuilderTest {
             assertThat(episodeGuidBuilder).prop(EpisodeGuidBuilder::hasEnoughDataToBuild).isTrue()
 
             assertThat(episodeGuidBuilder.build()).isNotNull().all {
-                prop(Episode.Guid::textContent).isEqualTo("textContent")
+                prop(Episode.Guid::guid).isEqualTo("textContent")
                 prop(Episode.Guid::isPermalink).isNotNull().isTrue()
             }
         }

--- a/src/test/kotlin/io/hemin/wien/dom/XPath.kt
+++ b/src/test/kotlin/io/hemin/wien/dom/XPath.kt
@@ -3,6 +3,7 @@ package io.hemin.wien.dom
 import io.hemin.wien.util.FeedNamespace
 import org.w3c.dom.Document
 import org.w3c.dom.Node
+import org.w3c.dom.NodeList
 import javax.xml.namespace.NamespaceContext
 import javax.xml.xpath.XPathConstants
 import javax.xml.xpath.XPathFactory
@@ -13,6 +14,9 @@ private val xPath = XPathFactory.newDefaultInstance()
 
 internal fun Node.findNodeByXPath(nodePath: String) =
     xPath.evaluate(nodePath, this, XPathConstants.NODE) as? Node
+
+internal fun Node.findNodesByXPath(nodePath: String) =
+    xPath.evaluate(nodePath, this, XPathConstants.NODESET) as? NodeList
 
 private object FeedNamespaceContext : NamespaceContext {
 

--- a/src/test/kotlin/io/hemin/wien/dom/XPath.kt
+++ b/src/test/kotlin/io/hemin/wien/dom/XPath.kt
@@ -11,7 +11,7 @@ private val xPath = XPathFactory.newDefaultInstance()
     .newXPath()
     .apply { namespaceContext = FeedNamespaceContext }
 
-internal fun Document.findNodeByXPath(nodePath: String) =
+internal fun Node.findNodeByXPath(nodePath: String) =
     xPath.evaluate(nodePath, this, XPathConstants.NODE) as? Node
 
 private object FeedNamespaceContext : NamespaceContext {

--- a/src/test/kotlin/io/hemin/wien/model/podcast/PodcastFixtures.kt
+++ b/src/test/kotlin/io/hemin/wien/model/podcast/PodcastFixtures.kt
@@ -31,7 +31,7 @@ internal fun aPodcast(
     webMaster: String? = "web master",
     image: RssImage? = anRssImage(url = "podcast image url"),
     episodes: List<Episode> = listOf(anEpisode()),
-    iTunes: Podcast.ITunes? = aPodcastItunes(),
+    iTunes: Podcast.ITunes? = aPodcastITunes(),
     atom: Podcast.Atom? = aPodcastAtom(),
     fyyd: Podcast.Fyyd? = aPodcastFyyd(),
     feedpress: Podcast.Feedpress? = aPodcastFeedpress(),
@@ -57,7 +57,7 @@ internal fun aPodcast(
     googlePlay
 )
 
-internal fun aPodcastItunes(
+internal fun aPodcastITunes(
     subtitle: String? = "podcast itunes subtitle",
     summary: String? = "podcast itunes summary",
     image: HrefOnlyImage = anHrefOnlyImage(href = "podcast itunes image url"),

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/AtomWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/AtomWriterTest.kt
@@ -2,9 +2,16 @@ package io.hemin.wien.writer.namespace
 
 import assertk.assertAll
 import assertk.assertThat
+import io.hemin.wien.hasNoAttribute
 import io.hemin.wien.hasNoDifferences
+import io.hemin.wien.hasTextContent
+import io.hemin.wien.hasValue
+import io.hemin.wien.model.aLink
+import io.hemin.wien.model.aPerson
 import io.hemin.wien.model.episode.anEpisode
+import io.hemin.wien.model.episode.anEpisodeAtom
 import io.hemin.wien.model.podcast.aPodcast
+import io.hemin.wien.model.podcast.aPodcastAtom
 import org.junit.jupiter.api.Test
 
 internal class AtomWriterTest : NamespaceWriterTest() {
@@ -31,12 +38,89 @@ internal class AtomWriterTest : NamespaceWriterTest() {
 
     @Test
     internal fun `should not write atom tags to the channel when there is no data to write`() {
+        val podcast = aPodcast(atom = null)
         assertAll {
-            assertTagIsNotWrittenToPodcast(aPodcast(atom = null), "author")
-            assertTagIsNotWrittenToPodcast(aPodcast(atom = null), "contributor")
-            assertTagIsNotWrittenToPodcast(aPodcast(atom = null), "link")
+            assertTagIsNotWrittenToPodcast(podcast, "author")
+            assertTagIsNotWrittenToPodcast(podcast, "contributor")
+            assertTagIsNotWrittenToPodcast(podcast, "link")
         }
     }
+
+    @Test
+    internal fun `should not write atom tags to the channel when the data is all blank`() {
+        val podcast = aPodcast(atom = aPodcastAtom(
+            authors = listOf(aPerson(" ", " ", " "), aPerson("", "", "")),
+            contributors = listOf(aPerson(" ", " ", " "), aPerson("", "", "")),
+            links = listOf(
+                aLink(" ", " ", " "," ", " ", " ", " "),
+                aLink("", "", "","", "", "", "")
+            )
+        ))
+        assertAll {
+            assertTagIsNotWrittenToPodcast(podcast, "author")
+            assertTagIsNotWrittenToPodcast(podcast, "contributor")
+            assertTagIsNotWrittenToPodcast(podcast, "link")
+        }
+    }
+
+    @Test
+    internal fun `should not write atom subtags to the channel when their data is blank`() {
+        val podcast = aPodcast(
+            atom = aPodcastAtom(
+                authors = listOf(
+                    aPerson("author 1", " ", " "), aPerson("author 2", "", "")
+                ),
+                contributors = listOf(
+                    aPerson("contrib 1", " ", " "), aPerson("contrib 2", "", "")
+                ),
+                links = listOf(
+                    aLink("link 1", " ", " ", " ", " ", " ", " "),
+                    aLink("link 2", "", "", "", "", "", "")
+                )
+            )
+        )
+        assertAll {
+            writePodcastDataXPath("//atom:author[1]", podcast = podcast) { element ->
+                assertThat(element).containsElement("name").hasTextContent("author 1")
+                assertThat(element).doesNotContainElement("email")
+                assertThat(element).doesNotContainElement("uri")
+            }
+            writePodcastDataXPath("//atom:author[2]", podcast = podcast) { element ->
+                assertThat(element).containsElement("name").hasTextContent("author 2")
+                assertThat(element).doesNotContainElement("email")
+                assertThat(element).doesNotContainElement("uri")
+            }
+            writePodcastDataXPath("//atom:contributor[1]", podcast = podcast) { element ->
+                assertThat(element).containsElement("name").hasTextContent("contrib 1")
+                assertThat(element).doesNotContainElement("email")
+                assertThat(element).doesNotContainElement("uri")
+            }
+            writePodcastDataXPath("//atom:contributor[2]", podcast = podcast) { element ->
+                assertThat(element).containsElement("name").hasTextContent("contrib 2")
+                assertThat(element).doesNotContainElement("email")
+                assertThat(element).doesNotContainElement("uri")
+            }
+            writePodcastDataXPath("//atom:link[1]", podcast = podcast) { element ->
+                assertThat(element).hasAttribute("href", namespace = null).hasValue("link 1")
+                assertThat(element).hasNoAttribute("hrefLang", namespace = null)
+                assertThat(element).hasNoAttribute("hrefResolved", namespace = null)
+                assertThat(element).hasNoAttribute("length", namespace = null)
+                assertThat(element).hasNoAttribute("rel", namespace = null)
+                assertThat(element).hasNoAttribute("title", namespace = null)
+                assertThat(element).hasNoAttribute("type", namespace = null)
+            }
+            writePodcastDataXPath("//atom:link[2]", podcast = podcast) { element ->
+                assertThat(element).hasAttribute("href", namespace = null).hasValue("link 2")
+                assertThat(element).hasNoAttribute("hrefLang", namespace = null)
+                assertThat(element).hasNoAttribute("hrefResolved", namespace = null)
+                assertThat(element).hasNoAttribute("length", namespace = null)
+                assertThat(element).hasNoAttribute("rel", namespace = null)
+                assertThat(element).hasNoAttribute("title", namespace = null)
+                assertThat(element).hasNoAttribute("type", namespace = null)
+            }
+        }
+    }
+
 
     @Test
     internal fun `should write the correct atom tags to the item when there is data to write`() {
@@ -62,6 +146,83 @@ internal class AtomWriterTest : NamespaceWriterTest() {
             assertTagIsNotWrittenToEpisode(anEpisode(atom = null), "author")
             assertTagIsNotWrittenToEpisode(anEpisode(atom = null), "contributor")
             assertTagIsNotWrittenToEpisode(anEpisode(atom = null), "link")
+        }
+    }
+
+    @Test
+    internal fun `should not write atom tags to the item when the data is all blank`() {
+        val episode = anEpisode(
+            atom = anEpisodeAtom(
+                authors = listOf(
+                    aPerson(" ", " ", " "), aPerson("", "", "")),
+                contributors = listOf(
+                    aPerson(" ", " ", " "), aPerson("", "", "")),
+                links = listOf(
+                    aLink(" ", " ", " ", " ", " ", " ", " "),
+                    aLink("", "", "", "", "", "", "")
+                )
+            )
+        )
+        assertAll {
+            assertTagIsNotWrittenToEpisode(episode, "author")
+            assertTagIsNotWrittenToEpisode(episode, "contributor")
+            assertTagIsNotWrittenToEpisode(episode, "link")
+        }
+    }
+
+    @Test
+    internal fun `should not write atom subtags to the item when their data is blank`() {
+        val episode = anEpisode(
+            atom = anEpisodeAtom(
+                authors = listOf(
+                    aPerson("author 1", " ", " "), aPerson("author 2", "", "")),
+                contributors = listOf(
+                    aPerson("contrib 1", " ", " "), aPerson("contrib 2", "", "")),
+                links = listOf(
+                    aLink("link 1", " ", " ", " ", " ", " ", " "),
+                    aLink("link 2", "", "", "", "", "", "")
+                )
+            )
+        )
+        assertAll {
+            writeEpisodeDataXPath("//atom:author[1]", episode = episode) { element ->
+                assertThat(element).containsElement("name").hasTextContent("author 1")
+                assertThat(element).doesNotContainElement("email")
+                assertThat(element).doesNotContainElement("uri")
+            }
+            writeEpisodeDataXPath("//atom:author[2]", episode = episode) { element ->
+                assertThat(element).containsElement("name").hasTextContent("author 2")
+                assertThat(element).doesNotContainElement("email")
+                assertThat(element).doesNotContainElement("uri")
+            }
+            writeEpisodeDataXPath("//atom:contributor[1]", episode = episode) { element ->
+                assertThat(element).containsElement("name").hasTextContent("contrib 1")
+                assertThat(element).doesNotContainElement("email")
+                assertThat(element).doesNotContainElement("uri")
+            }
+            writeEpisodeDataXPath("//atom:contributor[2]", episode = episode) { element ->
+                assertThat(element).containsElement("name").hasTextContent("contrib 2")
+                assertThat(element).doesNotContainElement("email")
+                assertThat(element).doesNotContainElement("uri")
+            }
+            writeEpisodeDataXPath("//atom:link[1]", episode = episode) { element ->
+                assertThat(element).hasAttribute("href", namespace = null).hasValue("link 1")
+                assertThat(element).hasNoAttribute("hrefLang", namespace = null)
+                assertThat(element).hasNoAttribute("hrefResolved", namespace = null)
+                assertThat(element).hasNoAttribute("length", namespace = null)
+                assertThat(element).hasNoAttribute("rel", namespace = null)
+                assertThat(element).hasNoAttribute("title", namespace = null)
+                assertThat(element).hasNoAttribute("type", namespace = null)
+            }
+            writeEpisodeDataXPath("//atom:link[2]", episode = episode) { element ->
+                assertThat(element).hasAttribute("href", namespace = null).hasValue("link 2")
+                assertThat(element).hasNoAttribute("hrefLang", namespace = null)
+                assertThat(element).hasNoAttribute("hrefResolved", namespace = null)
+                assertThat(element).hasNoAttribute("length", namespace = null)
+                assertThat(element).hasNoAttribute("rel", namespace = null)
+                assertThat(element).hasNoAttribute("title", namespace = null)
+                assertThat(element).hasNoAttribute("type", namespace = null)
+            }
         }
     }
 }

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/AtomWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/AtomWriterTest.kt
@@ -2,6 +2,7 @@ package io.hemin.wien.writer.namespace
 
 import assertk.assertAll
 import assertk.assertThat
+import assertk.assertions.hasSize
 import io.hemin.wien.hasNoAttribute
 import io.hemin.wien.hasNoDifferences
 import io.hemin.wien.hasTextContent
@@ -80,6 +81,9 @@ internal class AtomWriterTest : NamespaceWriterTest() {
             )
         )
         assertAll {
+            writePodcastDataXPathMultiple("//atom:author", podcast) { elements ->
+                assertThat(elements).hasSize(2)
+            }
             writePodcastDataXPath("//atom:author[1]", podcast = podcast) { element ->
                 assertThat(element).containsElement("name").hasTextContent("author 1")
                 assertThat(element).doesNotContainElement("email")
@@ -90,6 +94,9 @@ internal class AtomWriterTest : NamespaceWriterTest() {
                 assertThat(element).doesNotContainElement("email")
                 assertThat(element).doesNotContainElement("uri")
             }
+            writePodcastDataXPathMultiple("//atom:contributor", podcast) { elements ->
+                assertThat(elements).hasSize(2)
+            }
             writePodcastDataXPath("//atom:contributor[1]", podcast = podcast) { element ->
                 assertThat(element).containsElement("name").hasTextContent("contrib 1")
                 assertThat(element).doesNotContainElement("email")
@@ -99,6 +106,9 @@ internal class AtomWriterTest : NamespaceWriterTest() {
                 assertThat(element).containsElement("name").hasTextContent("contrib 2")
                 assertThat(element).doesNotContainElement("email")
                 assertThat(element).doesNotContainElement("uri")
+            }
+            writePodcastDataXPathMultiple("//atom:link", podcast) { elements ->
+                assertThat(elements).hasSize(2)
             }
             writePodcastDataXPath("//atom:link[1]", podcast = podcast) { element ->
                 assertThat(element).hasAttribute("href", namespace = null).hasValue("link 1")
@@ -185,6 +195,9 @@ internal class AtomWriterTest : NamespaceWriterTest() {
             )
         )
         assertAll {
+            writeEpisodeDataXPathMultiple("//atom:author", episode) { elements ->
+                assertThat(elements).hasSize(2)
+            }
             writeEpisodeDataXPath("//atom:author[1]", episode = episode) { element ->
                 assertThat(element).containsElement("name").hasTextContent("author 1")
                 assertThat(element).doesNotContainElement("email")
@@ -195,6 +208,9 @@ internal class AtomWriterTest : NamespaceWriterTest() {
                 assertThat(element).doesNotContainElement("email")
                 assertThat(element).doesNotContainElement("uri")
             }
+            writeEpisodeDataXPathMultiple("//atom:contributor", episode) { elements ->
+                assertThat(elements).hasSize(2)
+            }
             writeEpisodeDataXPath("//atom:contributor[1]", episode = episode) { element ->
                 assertThat(element).containsElement("name").hasTextContent("contrib 1")
                 assertThat(element).doesNotContainElement("email")
@@ -204,6 +220,9 @@ internal class AtomWriterTest : NamespaceWriterTest() {
                 assertThat(element).containsElement("name").hasTextContent("contrib 2")
                 assertThat(element).doesNotContainElement("email")
                 assertThat(element).doesNotContainElement("uri")
+            }
+            writeEpisodeDataXPathMultiple("//atom:link", episode) { elements ->
+                assertThat(elements).hasSize(2)
             }
             writeEpisodeDataXPath("//atom:link[1]", episode = episode) { element ->
                 assertThat(element).hasAttribute("href", namespace = null).hasValue("link 1")

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/BitloveWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/BitloveWriterTest.kt
@@ -7,6 +7,7 @@ import io.hemin.wien.dom.findElementByName
 import io.hemin.wien.hasNoAttribute
 import io.hemin.wien.hasNoDifferences
 import io.hemin.wien.model.episode.anEpisode
+import io.hemin.wien.model.episode.anEpisodeBitlove
 import org.junit.jupiter.api.Test
 
 internal class BitloveWriterTest : NamespaceWriterTest() {
@@ -33,6 +34,30 @@ internal class BitloveWriterTest : NamespaceWriterTest() {
         assertAll {
             val episodeWithoutBitlove = anEpisode(bitlove = null)
             assertTagIsNotWrittenToEpisode(episodeWithoutBitlove, "encoded")
+
+            val itemElement = createChannelElement().createItemElement()
+            val enclosureItem = itemElement.appendElement("enclosure")
+            writer.tryWritingEpisodeData(episodeWithoutBitlove, itemElement)
+            assertThat(enclosureItem).hasNoAttribute("guid", writer.namespace)
+        }
+    }
+
+    @Test
+    internal fun `should not write a bitlove_guid attribute to the item enclosure tag when the data is blank`() {
+        assertAll {
+            val episodeWithoutBitlove = anEpisode(bitlove = anEpisodeBitlove(" "))
+
+            val itemElement = createChannelElement().createItemElement()
+            val enclosureItem = itemElement.appendElement("enclosure")
+            writer.tryWritingEpisodeData(episodeWithoutBitlove, itemElement)
+            assertThat(enclosureItem).hasNoAttribute("guid", writer.namespace)
+        }
+    }
+
+    @Test
+    internal fun `should not write a bitlove_guid attribute to the item enclosure tag when the data is empty`() {
+        assertAll {
+            val episodeWithoutBitlove = anEpisode(bitlove = anEpisodeBitlove(""))
 
             val itemElement = createChannelElement().createItemElement()
             val enclosureItem = itemElement.appendElement("enclosure")

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/ContentWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/ContentWriterTest.kt
@@ -3,6 +3,7 @@ package io.hemin.wien.writer.namespace
 import assertk.assertThat
 import io.hemin.wien.hasNoDifferences
 import io.hemin.wien.model.episode.anEpisode
+import io.hemin.wien.model.episode.anEpisodeContent
 import org.junit.jupiter.api.Test
 
 internal class ContentWriterTest : NamespaceWriterTest() {
@@ -20,5 +21,15 @@ internal class ContentWriterTest : NamespaceWriterTest() {
     @Test
     internal fun `should not write a content_encoded tag to the item when there is no data to write`() {
         assertTagIsNotWrittenToEpisode(anEpisode(content = null), "encoded")
+    }
+
+    @Test
+    internal fun `should not write a content_encoded tag to the item when the data is blank`() {
+        assertTagIsNotWrittenToEpisode(anEpisode(content = anEpisodeContent(" ")), "encoded")
+    }
+
+    @Test
+    internal fun `should not write a content_encoded tag to the item when the data is empty`() {
+        assertTagIsNotWrittenToEpisode(anEpisode(content = anEpisodeContent("")), "encoded")
     }
 }

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/FeedpressWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/FeedpressWriterTest.kt
@@ -1,8 +1,10 @@
 package io.hemin.wien.writer.namespace
 
+import assertk.assertAll
 import assertk.assertThat
 import io.hemin.wien.hasNoDifferences
 import io.hemin.wien.model.podcast.aPodcast
+import io.hemin.wien.model.podcast.aPodcastFeedpress
 import org.junit.jupiter.api.Test
 
 internal class FeedpressWriterTest : NamespaceWriterTest() {
@@ -11,7 +13,7 @@ internal class FeedpressWriterTest : NamespaceWriterTest() {
 
     @Test
     internal fun `should write the correct feedpress tags to the channel when there is data to write`() {
-        assertk.assertAll {
+        assertAll {
             writePodcastData("newsletterId") { element ->
                 val diff = element.diffFromExpected("/rss/channel/feedpress:newsletterId")
                 assertThat(diff).hasNoDifferences()
@@ -37,12 +39,37 @@ internal class FeedpressWriterTest : NamespaceWriterTest() {
 
     @Test
     internal fun `should not write feedpress tags to the channel when there is no data to write`() {
-        assertk.assertAll {
-            assertTagIsNotWrittenToPodcast(aPodcast(feedpress = null), "newsletterId")
-            assertTagIsNotWrittenToPodcast(aPodcast(feedpress = null), "locale")
-            assertTagIsNotWrittenToPodcast(aPodcast(feedpress = null), "podcastId")
-            assertTagIsNotWrittenToPodcast(aPodcast(feedpress = null), "cssFile")
-            assertTagIsNotWrittenToPodcast(aPodcast(feedpress = null), "link")
+        val podcast = aPodcast(feedpress = null)
+        assertAll {
+            assertTagIsNotWrittenToPodcast(podcast, "newsletterId")
+            assertTagIsNotWrittenToPodcast(podcast, "locale")
+            assertTagIsNotWrittenToPodcast(podcast, "podcastId")
+            assertTagIsNotWrittenToPodcast(podcast, "cssFile")
+            assertTagIsNotWrittenToPodcast(podcast, "link")
+        }
+    }
+
+    @Test
+    internal fun `should not write feedpress tags to the channel when the data is blank`() {
+        val podcast = aPodcast(feedpress = aPodcastFeedpress(" "," "," "," "," "))
+        assertAll {
+            assertTagIsNotWrittenToPodcast(podcast, "newsletterId")
+            assertTagIsNotWrittenToPodcast(podcast, "locale")
+            assertTagIsNotWrittenToPodcast(podcast, "podcastId")
+            assertTagIsNotWrittenToPodcast(podcast, "cssFile")
+            assertTagIsNotWrittenToPodcast(podcast, "link")
+        }
+    }
+
+    @Test
+    internal fun `should not write feedpress tags to the channel when the data is empty`() {
+        val podcast = aPodcast(feedpress = aPodcastFeedpress("","","","",""))
+        assertAll {
+            assertTagIsNotWrittenToPodcast(podcast, "newsletterId")
+            assertTagIsNotWrittenToPodcast(podcast, "locale")
+            assertTagIsNotWrittenToPodcast(podcast, "podcastId")
+            assertTagIsNotWrittenToPodcast(podcast, "cssFile")
+            assertTagIsNotWrittenToPodcast(podcast, "link")
         }
     }
 }

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/FyydWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/FyydWriterTest.kt
@@ -3,6 +3,7 @@ package io.hemin.wien.writer.namespace
 import assertk.assertThat
 import io.hemin.wien.hasNoDifferences
 import io.hemin.wien.model.podcast.aPodcast
+import io.hemin.wien.model.podcast.aPodcastFyyd
 import org.junit.jupiter.api.Test
 
 internal class FyydWriterTest : NamespaceWriterTest() {
@@ -20,5 +21,15 @@ internal class FyydWriterTest : NamespaceWriterTest() {
     @Test
     internal fun `should not write a fyyd_verify tag to the item when there is no data to write`() {
         assertTagIsNotWrittenToPodcast(aPodcast(fyyd = null), "verify")
+    }
+
+    @Test
+    internal fun `should not write a fyyd_verify tag to the item when the data is blank`() {
+        assertTagIsNotWrittenToPodcast(aPodcast(fyyd = aPodcastFyyd(" ")), "verify")
+    }
+
+    @Test
+    internal fun `should not write a fyyd_verify tag to the item when the data is empty`() {
+        assertTagIsNotWrittenToPodcast(aPodcast(fyyd = aPodcastFyyd("")), "verify")
     }
 }

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/GooglePlayWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/GooglePlayWriterTest.kt
@@ -2,6 +2,8 @@ package io.hemin.wien.writer.namespace
 
 import assertk.assertAll
 import assertk.assertThat
+import assertk.assertions.hasSize
+import io.hemin.wien.childNodesNamed
 import io.hemin.wien.hasNoChildren
 import io.hemin.wien.hasNoDifferences
 import io.hemin.wien.hasValue
@@ -86,6 +88,9 @@ internal class GooglePlayWriterTest : NamespaceWriterTest() {
         assertAll {
             assertTagIsNotWrittenToPodcast(podcast, "author")
             assertTagIsNotWrittenToPodcast(podcast, "owner")
+            writePodcastDataXPathMultiple("//googleplay:category", podcast) { elements ->
+                assertThat(elements).hasSize(1)
+            }
             writePodcastData("category", podcast = podcast) { element ->
                 assertThat(element, "category element").hasAttribute("text", namespace = null).hasValue("nested")
                 assertThat(element, "category element children").hasNoChildren()
@@ -118,6 +123,9 @@ internal class GooglePlayWriterTest : NamespaceWriterTest() {
         assertAll {
             assertTagIsNotWrittenToPodcast(podcast, "author")
             assertTagIsNotWrittenToPodcast(podcast, "owner")
+            writePodcastDataXPathMultiple("//googleplay:category", podcast) { elements ->
+                assertThat(elements).hasSize(1)
+            }
             writePodcastData("category", podcast = podcast) { element ->
                 assertThat(element, "category element").hasAttribute("text", namespace = null).hasValue("nested")
                 assertThat(element, "category element children").hasNoChildren()

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/GooglePlayWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/GooglePlayWriterTest.kt
@@ -2,9 +2,16 @@ package io.hemin.wien.writer.namespace
 
 import assertk.assertAll
 import assertk.assertThat
+import io.hemin.wien.hasNoChildren
 import io.hemin.wien.hasNoDifferences
+import io.hemin.wien.hasValue
+import io.hemin.wien.model.HrefOnlyImage
+import io.hemin.wien.model.ITunesStyleCategory
+import io.hemin.wien.model.anHrefOnlyImage
 import io.hemin.wien.model.episode.anEpisode
+import io.hemin.wien.model.episode.anEpisodeGooglePlay
 import io.hemin.wien.model.podcast.aPodcast
+import io.hemin.wien.model.podcast.aPodcastGooglePlay
 import org.junit.jupiter.api.Test
 
 internal class GooglePlayWriterTest : NamespaceWriterTest() {
@@ -59,6 +66,70 @@ internal class GooglePlayWriterTest : NamespaceWriterTest() {
     }
 
     @Test
+    internal fun `should not write googleplay tags to the channel when the data is blank`() {
+        val categories = listOf(
+            ITunesStyleCategory.Simple(" "),
+            ITunesStyleCategory.Nested(" ", ITunesStyleCategory.Simple("subcategory")),
+            ITunesStyleCategory.Nested("nested", ITunesStyleCategory.Simple(" "))
+        )
+        val podcast = aPodcast(
+            googlePlay = aPodcastGooglePlay(
+                author = " ",
+                owner = " ",
+                description = " ",
+                categories = categories,
+                image = HrefOnlyImage(" "),
+                explicit = null,
+                block = null
+            )
+        )
+        assertAll {
+            assertTagIsNotWrittenToPodcast(podcast, "author")
+            assertTagIsNotWrittenToPodcast(podcast, "owner")
+            writePodcastData("category", podcast = podcast) { element ->
+                assertThat(element, "category element").hasAttribute("text", namespace = null).hasValue("nested")
+                assertThat(element, "category element children").hasNoChildren()
+            }
+            assertTagIsNotWrittenToPodcast(podcast, "description")
+            assertTagIsNotWrittenToPodcast(podcast, "explicit")
+            assertTagIsNotWrittenToPodcast(podcast, "block")
+            assertTagIsNotWrittenToPodcast(podcast, "image")
+        }
+    }
+
+    @Test
+    internal fun `should not write googleplay tags to the channel when the data is empty`() {
+        val categories = listOf(
+            ITunesStyleCategory.Simple(""),
+            ITunesStyleCategory.Nested("", ITunesStyleCategory.Simple("subcategory")),
+            ITunesStyleCategory.Nested("nested", ITunesStyleCategory.Simple(""))
+        )
+        val podcast = aPodcast(
+            googlePlay = aPodcastGooglePlay(
+                author = "",
+                owner = "",
+                description = "",
+                categories = categories,
+                image = HrefOnlyImage(""),
+                explicit = null,
+                block = null
+            )
+        )
+        assertAll {
+            assertTagIsNotWrittenToPodcast(podcast, "author")
+            assertTagIsNotWrittenToPodcast(podcast, "owner")
+            writePodcastData("category", podcast = podcast) { element ->
+                assertThat(element, "category element").hasAttribute("text", namespace = null).hasValue("nested")
+                assertThat(element, "category element children").hasNoChildren()
+            }
+            assertTagIsNotWrittenToPodcast(podcast, "description")
+            assertTagIsNotWrittenToPodcast(podcast, "explicit")
+            assertTagIsNotWrittenToPodcast(podcast, "block")
+            assertTagIsNotWrittenToPodcast(podcast, "image")
+        }
+    }
+
+    @Test
     internal fun `should write the correct googleplay tags to the item when there is data to write`() {
         assertAll {
             writeEpisodeData("description") { element ->
@@ -82,11 +153,34 @@ internal class GooglePlayWriterTest : NamespaceWriterTest() {
 
     @Test
     internal fun `should not write googleplay tags to the item when there is no data to write`() {
+        val episode = anEpisode(googlePlay = null)
         assertAll {
-            assertTagIsNotWrittenToEpisode(anEpisode(googlePlay = null), "description")
-            assertTagIsNotWrittenToEpisode(anEpisode(googlePlay = null), "explicit")
-            assertTagIsNotWrittenToEpisode(anEpisode(googlePlay = null), "block")
-            assertTagIsNotWrittenToEpisode(anEpisode(googlePlay = null), "image")
+            assertTagIsNotWrittenToEpisode(episode, "description")
+            assertTagIsNotWrittenToEpisode(episode, "explicit")
+            assertTagIsNotWrittenToEpisode(episode, "block")
+            assertTagIsNotWrittenToEpisode(episode, "image")
+        }
+    }
+
+    @Test
+    internal fun `should not write googleplay tags to the item when the data is blank`() {
+        val episode = anEpisode(googlePlay = anEpisodeGooglePlay(description = " ", explicit = null, block = null, image = anHrefOnlyImage(" ")))
+        assertAll {
+            assertTagIsNotWrittenToEpisode(episode, "description")
+            assertTagIsNotWrittenToEpisode(episode, "explicit")
+            assertTagIsNotWrittenToEpisode(episode, "block")
+            assertTagIsNotWrittenToEpisode(episode, "image")
+        }
+    }
+
+    @Test
+    internal fun `should not write googleplay tags to the item when the data is empty`() {
+        val episode = anEpisode(googlePlay = anEpisodeGooglePlay(description = "", explicit = null, block = null, image = anHrefOnlyImage("")))
+        assertAll {
+            assertTagIsNotWrittenToEpisode(episode, "description")
+            assertTagIsNotWrittenToEpisode(episode, "explicit")
+            assertTagIsNotWrittenToEpisode(episode, "block")
+            assertTagIsNotWrittenToEpisode(episode, "image")
         }
     }
 }

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/ITunesWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/ITunesWriterTest.kt
@@ -2,9 +2,16 @@ package io.hemin.wien.writer.namespace
 
 import assertk.assertAll
 import assertk.assertThat
+import io.hemin.wien.hasNoChildren
 import io.hemin.wien.hasNoDifferences
+import io.hemin.wien.hasTextContent
+import io.hemin.wien.hasValue
+import io.hemin.wien.model.ITunesStyleCategory
+import io.hemin.wien.model.anHrefOnlyImage
 import io.hemin.wien.model.episode.anEpisode
+import io.hemin.wien.model.episode.anEpisodeITunes
 import io.hemin.wien.model.podcast.aPodcast
+import io.hemin.wien.model.podcast.aPodcastITunes
 import org.junit.jupiter.api.Test
 
 internal class ITunesWriterTest : NamespaceWriterTest() {
@@ -67,19 +74,110 @@ internal class ITunesWriterTest : NamespaceWriterTest() {
 
     @Test
     internal fun `should not write itunes tags to the channel when there is no data to write`() {
+        val podcast = aPodcast(iTunes = null)
         assertAll {
-            assertTagIsNotWrittenToPodcast(aPodcast(iTunes = null), "author")
-            assertTagIsNotWrittenToPodcast(aPodcast(iTunes = null), "category")
-            assertTagIsNotWrittenToPodcast(aPodcast(iTunes = null), "complete")
-            assertTagIsNotWrittenToPodcast(aPodcast(iTunes = null), "keywords")
-            assertTagIsNotWrittenToPodcast(aPodcast(iTunes = null), "owner")
-            assertTagIsNotWrittenToPodcast(aPodcast(iTunes = null), "subtitle")
-            assertTagIsNotWrittenToPodcast(aPodcast(iTunes = null), "summary")
-            assertTagIsNotWrittenToPodcast(aPodcast(iTunes = null), "type")
-            assertTagIsNotWrittenToPodcast(aPodcast(iTunes = null), "image")
-            assertTagIsNotWrittenToPodcast(aPodcast(iTunes = null), "explicit")
-            assertTagIsNotWrittenToPodcast(aPodcast(iTunes = null), "title")
-            assertTagIsNotWrittenToPodcast(aPodcast(iTunes = null), "block")
+            assertTagIsNotWrittenToPodcast(podcast, "author")
+            assertTagIsNotWrittenToPodcast(podcast, "category")
+            assertTagIsNotWrittenToPodcast(podcast, "complete")
+            assertTagIsNotWrittenToPodcast(podcast, "keywords")
+            assertTagIsNotWrittenToPodcast(podcast, "owner")
+            assertTagIsNotWrittenToPodcast(podcast, "subtitle")
+            assertTagIsNotWrittenToPodcast(podcast, "summary")
+            assertTagIsNotWrittenToPodcast(podcast, "type")
+            assertTagIsNotWrittenToPodcast(podcast, "image")
+            assertTagIsNotWrittenToPodcast(podcast, "explicit")
+            assertTagIsNotWrittenToPodcast(podcast, "title")
+            assertTagIsNotWrittenToPodcast(podcast, "block")
+        }
+    }
+
+    @Test
+    internal fun `should not write itunes tags to the channel when the data is blank`() {
+        val categories = listOf(
+            ITunesStyleCategory.Simple(" "),
+            ITunesStyleCategory.Nested(" ", ITunesStyleCategory.Simple("subcategory")),
+            ITunesStyleCategory.Nested("nested", ITunesStyleCategory.Simple(" "))
+        )
+        val podcast = aPodcast(
+            iTunes = aPodcastITunes(
+                subtitle = " ",
+                summary = " ",
+                image = anHrefOnlyImage(" "),
+                keywords = " ",
+                author = " ",
+                categories = categories,
+                explicit = false,
+                block = null,
+                complete = null,
+                type = null,
+                owner = null,
+                title = " ",
+                newFeedUrl = " "
+            )
+        )
+        assertAll {
+            assertTagIsNotWrittenToPodcast(podcast, "author")
+            writePodcastData("category", podcast = podcast) { element ->
+                assertThat(element, "category element").hasAttribute("text", namespace = null).hasValue("nested")
+                assertThat(element, "category element children").hasNoChildren()
+            }
+            assertTagIsNotWrittenToPodcast(podcast, "complete")
+            assertTagIsNotWrittenToPodcast(podcast, "keywords")
+            assertTagIsNotWrittenToPodcast(podcast, "owner")
+            assertTagIsNotWrittenToPodcast(podcast, "subtitle")
+            assertTagIsNotWrittenToPodcast(podcast, "summary")
+            assertTagIsNotWrittenToPodcast(podcast, "type")
+            assertTagIsNotWrittenToPodcast(podcast, "image")
+            writePodcastData("explicit", podcast = podcast) { element ->
+                assertThat(element, "explicit element").hasTextContent("false")
+            }
+            assertTagIsNotWrittenToPodcast(podcast, "title")
+            assertTagIsNotWrittenToPodcast(podcast, "block")
+        }
+    }
+
+    @Test
+    internal fun `should not write itunes tags to the channel when the data is empty`() {
+        val categories = listOf(
+            ITunesStyleCategory.Simple(""),
+            ITunesStyleCategory.Nested("", ITunesStyleCategory.Simple("subcategory")),
+            ITunesStyleCategory.Nested("nested", ITunesStyleCategory.Simple(""))
+        )
+        val podcast = aPodcast(
+            iTunes = aPodcastITunes(
+                subtitle = "",
+                summary = "",
+                image = anHrefOnlyImage(""),
+                keywords = "",
+                author = "",
+                categories = categories,
+                explicit = false,
+                block = null,
+                complete = null,
+                type = null,
+                owner = null,
+                title = "",
+                newFeedUrl = ""
+            )
+        )
+        assertAll {
+            assertTagIsNotWrittenToPodcast(podcast, "author")
+            writePodcastData("category", podcast = podcast) { element ->
+                assertThat(element, "category element").hasAttribute("text", namespace = null).hasValue("nested")
+                assertThat(element, "category element children").hasNoChildren()
+            }
+            assertTagIsNotWrittenToPodcast(podcast, "complete")
+            assertTagIsNotWrittenToPodcast(podcast, "keywords")
+            assertTagIsNotWrittenToPodcast(podcast, "owner")
+            assertTagIsNotWrittenToPodcast(podcast, "subtitle")
+            assertTagIsNotWrittenToPodcast(podcast, "summary")
+            assertTagIsNotWrittenToPodcast(podcast, "type")
+            assertTagIsNotWrittenToPodcast(podcast, "image")
+            writePodcastData("explicit", podcast = podcast) { element ->
+                assertThat(element, "explicit element").hasTextContent("false")
+            }
+            assertTagIsNotWrittenToPodcast(podcast, "title")
+            assertTagIsNotWrittenToPodcast(podcast, "block")
         }
     }
 
@@ -123,15 +221,70 @@ internal class ITunesWriterTest : NamespaceWriterTest() {
 
     @Test
     internal fun `should not write itunes tags to the item when there is no data to write`() {
+        val episode = anEpisode(iTunes = null)
         assertAll {
-            assertTagIsNotWrittenToEpisode(anEpisode(iTunes = null), "duration")
-            assertTagIsNotWrittenToEpisode(anEpisode(iTunes = null), "season")
-            assertTagIsNotWrittenToEpisode(anEpisode(iTunes = null), "episode")
-            assertTagIsNotWrittenToEpisode(anEpisode(iTunes = null), "episodeType")
-            assertTagIsNotWrittenToEpisode(anEpisode(iTunes = null), "image")
-            assertTagIsNotWrittenToEpisode(anEpisode(iTunes = null), "explicit")
-            assertTagIsNotWrittenToEpisode(anEpisode(iTunes = null), "title")
-            assertTagIsNotWrittenToEpisode(anEpisode(iTunes = null), "block")
+            assertTagIsNotWrittenToEpisode(episode, "duration")
+            assertTagIsNotWrittenToEpisode(episode, "season")
+            assertTagIsNotWrittenToEpisode(episode, "episode")
+            assertTagIsNotWrittenToEpisode(episode, "episodeType")
+            assertTagIsNotWrittenToEpisode(episode, "image")
+            assertTagIsNotWrittenToEpisode(episode, "explicit")
+            assertTagIsNotWrittenToEpisode(episode, "title")
+            assertTagIsNotWrittenToEpisode(episode, "block")
+        }
+    }
+
+    @Test
+    internal fun `should not write itunes tags to the item when the data is blank`() {
+        val episode = anEpisode(iTunes = anEpisodeITunes(
+            title = " ",
+            duration = " ",
+            image = anHrefOnlyImage(" "),
+            explicit = null,
+            block = null,
+            season = null,
+            episode = null,
+            episodeType = null,
+            author = " ",
+            subtitle = " ",
+            summary = " "
+        ))
+        assertAll {
+            assertTagIsNotWrittenToEpisode(episode, "duration")
+            assertTagIsNotWrittenToEpisode(episode, "season")
+            assertTagIsNotWrittenToEpisode(episode, "episode")
+            assertTagIsNotWrittenToEpisode(episode, "episodeType")
+            assertTagIsNotWrittenToEpisode(episode, "image")
+            assertTagIsNotWrittenToEpisode(episode, "explicit")
+            assertTagIsNotWrittenToEpisode(episode, "title")
+            assertTagIsNotWrittenToEpisode(episode, "block")
+        }
+    }
+
+    @Test
+    internal fun `should not write itunes tags to the item when the data is empty`() {
+        val episode = anEpisode(iTunes = anEpisodeITunes(
+            title = "",
+            duration = "",
+            image = anHrefOnlyImage(""),
+            explicit = null,
+            block = null,
+            season = null,
+            episode = null,
+            episodeType = null,
+            author = "",
+            subtitle = "",
+            summary = ""
+        ))
+        assertAll {
+            assertTagIsNotWrittenToEpisode(episode, "duration")
+            assertTagIsNotWrittenToEpisode(episode, "season")
+            assertTagIsNotWrittenToEpisode(episode, "episode")
+            assertTagIsNotWrittenToEpisode(episode, "episodeType")
+            assertTagIsNotWrittenToEpisode(episode, "image")
+            assertTagIsNotWrittenToEpisode(episode, "explicit")
+            assertTagIsNotWrittenToEpisode(episode, "title")
+            assertTagIsNotWrittenToEpisode(episode, "block")
         }
     }
 }

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/ITunesWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/ITunesWriterTest.kt
@@ -2,6 +2,8 @@ package io.hemin.wien.writer.namespace
 
 import assertk.assertAll
 import assertk.assertThat
+import assertk.assertions.hasSize
+import io.hemin.wien.childNodesNamed
 import io.hemin.wien.hasNoChildren
 import io.hemin.wien.hasNoDifferences
 import io.hemin.wien.hasTextContent
@@ -117,6 +119,9 @@ internal class ITunesWriterTest : NamespaceWriterTest() {
         )
         assertAll {
             assertTagIsNotWrittenToPodcast(podcast, "author")
+            writePodcastDataXPathMultiple("//itunes:category", podcast) { elements ->
+                assertThat(elements).hasSize(1)
+            }
             writePodcastData("category", podcast = podcast) { element ->
                 assertThat(element, "category element").hasAttribute("text", namespace = null).hasValue("nested")
                 assertThat(element, "category element children").hasNoChildren()
@@ -162,6 +167,9 @@ internal class ITunesWriterTest : NamespaceWriterTest() {
         )
         assertAll {
             assertTagIsNotWrittenToPodcast(podcast, "author")
+            writePodcastDataXPathMultiple("//itunes:category", podcast) { elements ->
+                assertThat(elements).hasSize(1)
+            }
             writePodcastData("category", podcast = podcast) { element ->
                 assertThat(element, "category element").hasAttribute("text", namespace = null).hasValue("nested")
                 assertThat(element, "category element children").hasNoChildren()

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/NamespaceWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/NamespaceWriterTest.kt
@@ -1,19 +1,25 @@
 package io.hemin.wien.writer.namespace
 
+import assertk.Assert
 import assertk.assertThat
-import assertk.assertions.isNull
+import assertk.assertions.support.appendName
+import assertk.assertions.support.expected
 import assertk.fail
 import io.hemin.wien.documentFromResource
+import io.hemin.wien.doesNotExist
 import io.hemin.wien.dom.DomBuilderFactory
 import io.hemin.wien.dom.appendElement
+import io.hemin.wien.dom.asString
 import io.hemin.wien.dom.findElementByName
 import io.hemin.wien.dom.findNodeByXPath
+import io.hemin.wien.dom.getAttributeByName
 import io.hemin.wien.model.Episode
 import io.hemin.wien.model.Podcast
 import io.hemin.wien.model.episode.anEpisode
 import io.hemin.wien.model.podcast.aPodcast
 import io.hemin.wien.util.FeedNamespace
 import io.hemin.wien.writer.NamespaceWriter
+import org.w3c.dom.Attr
 import org.w3c.dom.Element
 import org.w3c.dom.Node
 import org.xmlunit.builder.DiffBuilder
@@ -54,6 +60,21 @@ internal abstract class NamespaceWriterTest {
         assertions(actualElement)
     }
 
+    protected fun writePodcastDataXPath(
+        xPath: String,
+        podcast: Podcast = aPodcast(),
+        assertions: (element: Element) -> Unit
+    ) {
+        val itemElement = createChannelElement()
+        writer.tryWritingPodcastData(podcast, itemElement)
+
+        val actual = itemElement.findNodeByXPath(xPath)
+            ?: fail("No tag matching `$xPath` was written")
+        if (actual !is Element) fail("The XPath `$xPath` does not match an element")
+
+        assertions(actual)
+    }
+
     protected fun assertTagIsNotWrittenToPodcast(
         podcast: Podcast,
         localName: String,
@@ -62,7 +83,7 @@ internal abstract class NamespaceWriterTest {
         val itemElement = createChannelElement()
         writer.tryWritingPodcastData(podcast, itemElement)
 
-        assertThat(itemElement.findElementByName(localName, namespace)).isNull()
+        assertThat(itemElement.findElementByName(localName, namespace)).doesNotExist()
     }
 
     protected fun writeEpisodeData(
@@ -80,6 +101,21 @@ internal abstract class NamespaceWriterTest {
         assertions(actualElement)
     }
 
+    protected fun writeEpisodeDataXPath(
+        xPath: String,
+        episode: Episode = anEpisode(),
+        assertions: (element: Element) -> Unit
+    ) {
+        val itemElement = createChannelElement().createItemElement()
+        writer.tryWritingEpisodeData(episode, itemElement)
+
+        val actual = itemElement.findNodeByXPath(xPath)
+            ?: fail("No tag matching `$xPath` was written")
+        if (actual !is Element) fail("The XPath `$xPath` does not match an element")
+
+        assertions(actual)
+    }
+
     protected fun assertTagIsNotWrittenToEpisode(
         episode: Episode,
         localName: String,
@@ -88,7 +124,7 @@ internal abstract class NamespaceWriterTest {
         val itemElement = createChannelElement().createItemElement()
         writer.tryWritingEpisodeData(episode, itemElement)
 
-        assertThat(itemElement.findElementByName(localName, namespace)).isNull()
+        assertThat(itemElement.findElementByName(localName, namespace)).doesNotExist()
     }
 
     protected fun createChannelElement(): Element {
@@ -104,5 +140,40 @@ internal abstract class NamespaceWriterTest {
     protected fun Element.createItemElement(): Element {
         require(namespaceURI == null && nodeName == "channel") { " Only a <channel> can contain items" }
         return appendElement("item")
+    }
+
+    protected fun Assert<Element>.containsElement(
+        localName: String,
+        namespace: FeedNamespace? = writer.namespace
+    ): Assert<Element> {
+        given { element ->
+            val actual = element.findElementByName(localName, namespace)
+            if (actual != null) return assertThat(actual)
+            val tagName = if (namespace != null) "${namespace.prefix}:$localName" else localName
+            expected("to contain element $tagName:\n${element.asString()}", expected = "<$tagName>...</$tagName>", actual = "null")
+        }
+        throw IllegalStateException("Should never reach here")
+    }
+
+    protected fun Assert<Element>.hasAttribute(
+        localName: String,
+        namespace: FeedNamespace? = writer.namespace
+    ): Assert<Attr> {
+        given { element ->
+            val actual = element.getAttributeByName(localName, namespace)
+            val attributeName = if (namespace != null) "${namespace.prefix}:$localName" else localName
+            if (actual != null) return assertThat(actual, appendName(" $attributeName attribute"))
+            expected("to contain attribute $attributeName:\n${element.asString()}", expected = "$attributeName=\"...\"", actual = "null")
+        }
+        throw IllegalStateException("Should never reach here")
+    }
+
+    protected fun Assert<Element>.doesNotContainElement(
+        localName: String,
+        namespace: FeedNamespace? = writer.namespace
+    ) = given { element ->
+        val actual = element.findElementByName(localName, namespace) ?: return@given
+        val tagName = if (namespace != null) "${namespace.prefix}:$localName" else localName
+        expected("NOT to contain element $tagName", expected = "null", actual = actual.asString())
     }
 }

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/NamespaceWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/NamespaceWriterTest.kt
@@ -9,10 +9,13 @@ import io.hemin.wien.documentFromResource
 import io.hemin.wien.doesNotExist
 import io.hemin.wien.dom.DomBuilderFactory
 import io.hemin.wien.dom.appendElement
+import io.hemin.wien.dom.asListOfNodes
 import io.hemin.wien.dom.asString
 import io.hemin.wien.dom.findElementByName
 import io.hemin.wien.dom.findNodeByXPath
+import io.hemin.wien.dom.findNodesByXPath
 import io.hemin.wien.dom.getAttributeByName
+import io.hemin.wien.dom.isEmpty
 import io.hemin.wien.model.Episode
 import io.hemin.wien.model.Podcast
 import io.hemin.wien.model.episode.anEpisode
@@ -75,6 +78,23 @@ internal abstract class NamespaceWriterTest {
         assertions(actual)
     }
 
+    protected fun writePodcastDataXPathMultiple(
+        xPath: String,
+        podcast: Podcast = aPodcast(),
+        assertions: (elements: List<Element>) -> Unit
+    ) {
+        val itemElement = createChannelElement()
+        writer.tryWritingPodcastData(podcast, itemElement)
+
+        val actual = itemElement.findNodesByXPath(xPath)
+            ?: fail("No tags matching `$xPath` found")
+        if (actual.isEmpty()) fail("No tag matching `$xPath` was written")
+        val actualElements = actual.asListOfNodes().filterIsInstance(Element::class.java)
+        if (actual.length != actualElements.size) fail("Not all nodes matched by the `$xPath` are Elements")
+
+        assertions(actualElements)
+    }
+
     protected fun assertTagIsNotWrittenToPodcast(
         podcast: Podcast,
         localName: String,
@@ -114,6 +134,22 @@ internal abstract class NamespaceWriterTest {
         if (actual !is Element) fail("The XPath `$xPath` does not match an element")
 
         assertions(actual)
+    }
+
+    protected fun writeEpisodeDataXPathMultiple(
+        xPath: String,
+        episode: Episode = anEpisode(),
+        assertions: (elements: List<Element>) -> Unit
+    ) {
+        val itemElement = createChannelElement().createItemElement()
+        writer.tryWritingEpisodeData(episode, itemElement)
+
+        val actual = itemElement.findNodesByXPath(xPath)
+            ?: fail("No tag matching `$xPath` was written")
+        val actualElements = actual.asListOfNodes().filterIsInstance(Element::class.java)
+        if (actual.length != actualElements.size) fail("Not all nodes matched by the `$xPath` are Elements")
+
+        assertions(actualElements)
     }
 
     protected fun assertTagIsNotWrittenToEpisode(

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/PodloveSimpleChapterWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/PodloveSimpleChapterWriterTest.kt
@@ -1,9 +1,18 @@
 package io.hemin.wien.writer.namespace
 
+import assertk.all
+import assertk.assertAll
 import assertk.assertThat
+import assertk.assertions.isInstanceOf
+import io.hemin.wien.hasNoAttribute
+import io.hemin.wien.hasOneChild
 import io.hemin.wien.hasNoDifferences
+import io.hemin.wien.hasValue
+import io.hemin.wien.model.episode.aPodloveSimpleChapter
 import io.hemin.wien.model.episode.anEpisode
+import io.hemin.wien.model.episode.anEpisodePodlove
 import org.junit.jupiter.api.Test
+import org.w3c.dom.Element
 
 internal class PodloveSimpleChapterWriterTest : NamespaceWriterTest() {
 
@@ -20,5 +29,47 @@ internal class PodloveSimpleChapterWriterTest : NamespaceWriterTest() {
     @Test
     internal fun `should not write psc tags to the item when there is no data to write`() {
         assertTagIsNotWrittenToEpisode(anEpisode(podlove = null), "chapters")
+    }
+
+    @Test
+    internal fun `should not write psc tags to the item when data is blank`() {
+        val podlove = anEpisodePodlove(
+            listOf(
+                aPodloveSimpleChapter(start = "start 1", title = "title 1", href = " ", image = " "),
+                aPodloveSimpleChapter(start = " ", title = " ", href = " ", image = " ")
+            )
+        )
+        assertAll {
+            writeEpisodeData("chapters", episode = anEpisode(podlove = podlove)) { element ->
+                assertThat(element).hasOneChild()
+                assertThat(element.firstChild, "chapter").isInstanceOf(Element::class).all {
+                    hasAttribute("start", namespace = null).hasValue("start 1")
+                    hasAttribute("title", namespace = null).hasValue("title 1")
+                    hasNoAttribute("href", namespace = null)
+                    hasNoAttribute("image", namespace = null)
+                }
+            }
+        }
+    }
+
+    @Test
+    internal fun `should not write psc tags to the item when data is empty`() {
+        val podlove = anEpisodePodlove(
+            listOf(
+                aPodloveSimpleChapter(start = "start 1", title = "title 1", href = "", image = ""),
+                aPodloveSimpleChapter(start = "", title = "", href = "", image = "")
+            )
+        )
+        assertAll {
+            writeEpisodeData("chapters", episode = anEpisode(podlove = podlove)) { element ->
+                assertThat(element).hasOneChild()
+                assertThat(element.firstChild, "chapter").isInstanceOf(Element::class).all {
+                    hasAttribute("start", namespace = null).hasValue("start 1")
+                    hasAttribute("title", namespace = null).hasValue("title 1")
+                    hasNoAttribute("href", namespace = null)
+                    hasNoAttribute("image", namespace = null)
+                }
+            }
+        }
     }
 }

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/RssWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/RssWriterTest.kt
@@ -1,0 +1,343 @@
+package io.hemin.wien.writer.namespace
+
+import assertk.all
+import assertk.assertAll
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isInstanceOf
+import io.hemin.wien.hasNoAttribute
+import io.hemin.wien.hasNoDifferences
+import io.hemin.wien.hasTextContent
+import io.hemin.wien.hasValue
+import io.hemin.wien.model.anRssCategory
+import io.hemin.wien.model.anRssImage
+import io.hemin.wien.model.episode.anEpisode
+import io.hemin.wien.model.episode.anEpisodeEnclosure
+import io.hemin.wien.model.episode.anEpisodeGuid
+import io.hemin.wien.model.podcast.aPodcast
+import io.hemin.wien.util.FeedNamespace
+import org.junit.jupiter.api.Test
+import org.w3c.dom.Element
+
+internal class RssWriterTest : NamespaceWriterTest() {
+
+    override val writer = RssWriter()
+
+    @Test
+    internal fun `should write the correct RSS tags to the channel when there is data to write`() {
+        assertAll {
+            writePodcastData("title") { element ->
+                val diff = element.diffFromExpected("/rss/channel/title")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("link") { element ->
+                val diff = element.diffFromExpected("/rss/channel/link")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("generator") { element ->
+                val diff = element.diffFromExpected("/rss/channel/generator")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("description") { element ->
+                val diff = element.diffFromExpected("/rss/channel/description")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("pubDate") { element ->
+                val diff = element.diffFromExpected("/rss/channel/pubDate")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("lastBuildDate") { element ->
+                val diff = element.diffFromExpected("/rss/channel/lastBuildDate")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("language") { element ->
+                val diff = element.diffFromExpected("/rss/channel/language")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("copyright") { element ->
+                val diff = element.diffFromExpected("/rss/channel/copyright")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("docs") { element ->
+                val diff = element.diffFromExpected("/rss/channel/docs")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("managingEditor") { element ->
+                val diff = element.diffFromExpected("/rss/channel/managingEditor")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("webMaster") { element ->
+                val diff = element.diffFromExpected("/rss/channel/webMaster")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("image") { element ->
+                val diff = element.diffFromExpected("/rss/channel/image")
+                assertThat(diff).hasNoDifferences()
+            }
+        }
+    }
+
+    @Test
+    internal fun `should not write RSS tags to the channel when there is no data to write`() {
+        val podcast = aPodcast(
+            title = "title",
+            link = "link",
+            description = "description",
+            pubDate = null,
+            lastBuildDate = null,
+            language = "language",
+            copyright = null,
+            docs = null,
+            managingEditor = null,
+            webMaster = null,
+            image = null,
+            generator = null
+        )
+        assertAll {
+            writePodcastData("title") { element ->
+                val diff = element.diffFromExpected("/rss/channel/title")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("link") { element ->
+                val diff = element.diffFromExpected("/rss/channel/link")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("description") { element ->
+                val diff = element.diffFromExpected("/rss/channel/description")
+                assertThat(diff).hasNoDifferences()
+            }
+            assertTagIsNotWrittenToPodcast(podcast, "pubDate")
+            assertTagIsNotWrittenToPodcast(podcast, "lastBuildDate")
+            writePodcastData("language") { element ->
+                val diff = element.diffFromExpected("/rss/channel/language")
+                assertThat(diff).hasNoDifferences()
+            }
+            assertTagIsNotWrittenToPodcast(podcast, "copyright")
+            assertTagIsNotWrittenToPodcast(podcast, "docs")
+            assertTagIsNotWrittenToPodcast(podcast, "managingEditor")
+            assertTagIsNotWrittenToPodcast(podcast, "webMaster")
+            assertTagIsNotWrittenToPodcast(podcast, "image")
+        }
+    }
+
+    @Test
+    internal fun `should not write RSS tags to the channel when the data is blank`() {
+        val podcast = aPodcast(
+            title = " ",
+            link = " ",
+            description = " ",
+            pubDate = null,
+            lastBuildDate = null,
+            language = " ",
+            copyright = " ",
+            docs = " ",
+            managingEditor = " ",
+            webMaster = " ",
+            image = anRssImage(" "),
+            generator = " "
+        )
+        assertAll {
+            assertTagIsNotWrittenToPodcast(podcast, "title")
+            assertTagIsNotWrittenToPodcast(podcast, "link")
+            assertTagIsNotWrittenToPodcast(podcast, "description")
+            assertTagIsNotWrittenToPodcast(podcast, "pubDate")
+            assertTagIsNotWrittenToPodcast(podcast, "lastBuildDate")
+            assertTagIsNotWrittenToPodcast(podcast, "language")
+            assertTagIsNotWrittenToPodcast(podcast, "copyright")
+            assertTagIsNotWrittenToPodcast(podcast, "docs")
+            assertTagIsNotWrittenToPodcast(podcast, "managingEditor")
+            assertTagIsNotWrittenToPodcast(podcast, "webMaster")
+            assertTagIsNotWrittenToPodcast(podcast, "image")
+        }
+    }
+
+    @Test
+    internal fun `should not write RSS tags to the channel when the data is empty`() {
+        val podcast = aPodcast(
+            title = "",
+            link = "",
+            description = "",
+            pubDate = null,
+            lastBuildDate = null,
+            language = "",
+            copyright = "",
+            docs = "",
+            managingEditor = "",
+            webMaster = "",
+            image = anRssImage(""),
+            generator = ""
+        )
+        assertAll {
+            assertTagIsNotWrittenToPodcast(podcast, "title")
+            assertTagIsNotWrittenToPodcast(podcast, "link")
+            assertTagIsNotWrittenToPodcast(podcast, "description")
+            assertTagIsNotWrittenToPodcast(podcast, "pubDate")
+            assertTagIsNotWrittenToPodcast(podcast, "lastBuildDate")
+            assertTagIsNotWrittenToPodcast(podcast, "language")
+            assertTagIsNotWrittenToPodcast(podcast, "copyright")
+            assertTagIsNotWrittenToPodcast(podcast, "docs")
+            assertTagIsNotWrittenToPodcast(podcast, "managingEditor")
+            assertTagIsNotWrittenToPodcast(podcast, "webMaster")
+            assertTagIsNotWrittenToPodcast(podcast, "image")
+        }
+    }
+
+    @Test
+    internal fun `should write the correct RSS tags to the item when there is data to write`() {
+        assertAll {
+            writeEpisodeData("title") { element ->
+                val diff = element.diffFromExpected("/rss/channel/item[1]/title")
+                assertThat(diff).hasNoDifferences()
+            }
+            writeEpisodeData("link") { element ->
+                val diff = element.diffFromExpected("/rss/channel/item[1]/link")
+                assertThat(diff).hasNoDifferences()
+            }
+            writeEpisodeData("description") { element ->
+                val diff = element.diffFromExpected("/rss/channel/item[1]/description")
+                assertThat(diff).hasNoDifferences()
+            }
+            writeEpisodeData("author") { element ->
+                val diff = element.diffFromExpected("/rss/channel/item[1]/author")
+                assertThat(diff).hasNoDifferences()
+            }
+            writeEpisodeData("category") { element ->
+                val diff = element.diffFromExpected("/rss/channel/item[1]/category")
+                assertThat(diff).hasNoDifferences()
+            }
+            writeEpisodeData("comments") { element ->
+                val diff = element.diffFromExpected("/rss/channel/item[1]/comments")
+                assertThat(diff).hasNoDifferences()
+            }
+            writeEpisodeData("enclosure") { element ->
+                assertThat(element).all {
+                    hasAttribute("url").hasValue("episode enclosure url")
+                    hasAttribute("length").hasValue("777")
+                    hasAttribute("type").hasValue("episode enclosure type")
+                    hasNoAttribute("guid", FeedNamespace.BITLOVE)
+                }
+            }
+            writeEpisodeData("guid") { element ->
+                val diff = element.diffFromExpected("/rss/channel/item[1]/guid")
+                assertThat(diff).hasNoDifferences()
+            }
+            writeEpisodeData("pubDate") { element ->
+                val diff = element.diffFromExpected("/rss/channel/item[1]/pubDate")
+                assertThat(diff).hasNoDifferences()
+            }
+            writeEpisodeData("source") { element ->
+                val diff = element.diffFromExpected("/rss/channel/item[1]/source")
+                assertThat(diff).hasNoDifferences()
+            }
+        }
+    }
+
+    @Test
+    internal fun `should not write RSS tags to the item when there is no data to write`() {
+        val episode = anEpisode(
+            title = "title",
+            link = null,
+            description = null,
+            author = null,
+            categories = emptyList(),
+            comments = null,
+            enclosure = anEpisodeEnclosure("url", 123, "type"),
+            guid = null,
+            pubDate = null,
+            source = null
+        )
+        assertAll {
+            writeEpisodeData("title", episode = episode) { element ->
+                assertThat(element).hasTextContent("title")
+            }
+            assertTagIsNotWrittenToEpisode(episode, "link")
+            assertTagIsNotWrittenToEpisode(episode, "description")
+            assertTagIsNotWrittenToEpisode(episode, "author")
+            assertTagIsNotWrittenToEpisode(episode, "category")
+            assertTagIsNotWrittenToEpisode(episode, "comments")
+            writeEpisodeData("enclosure", episode = episode) { element ->
+                assertThat(element).all {
+                    hasAttribute("url").hasValue("url")
+                    hasAttribute("length").hasValue("123")
+                    hasAttribute("type").hasValue("type")
+                }
+            }
+            assertTagIsNotWrittenToEpisode(episode, "guid")
+            assertTagIsNotWrittenToEpisode(episode, "pubDate")
+            assertTagIsNotWrittenToEpisode(episode, "source")
+        }
+    }
+
+    @Test
+    internal fun `should not write RSS tags to the item when the data is blank`() {
+        val episode = anEpisode(
+            title = " ",
+            link = " ",
+            description = " ",
+            author = " ",
+            categories = listOf(anRssCategory(" ", " "), anRssCategory("category 2", " ")),
+            comments = " ",
+            enclosure = anEpisodeEnclosure(" ", 123, " "),
+            guid = anEpisodeGuid(" "),
+            pubDate = null,
+            source = " "
+        )
+        assertAll {
+            assertTagIsNotWrittenToEpisode(episode, "title")
+            assertTagIsNotWrittenToEpisode(episode, "link")
+            assertTagIsNotWrittenToEpisode(episode, "description")
+            assertTagIsNotWrittenToEpisode(episode, "author")
+            writeEpisodeDataXPathMultiple("//category", episode = episode) { elements ->
+                assertThat(elements).all {
+                    hasSize(1)
+                    transform { it.first() }.isInstanceOf(Element::class).all {
+                        hasTextContent("category 2")
+                        hasNoAttribute("domain")
+                    }
+                }
+            }
+            assertTagIsNotWrittenToEpisode(episode, "comments")
+            assertTagIsNotWrittenToEpisode(episode, "guid")
+            assertTagIsNotWrittenToEpisode(episode, "enclosure")
+            assertTagIsNotWrittenToEpisode(episode, "pubDate")
+            assertTagIsNotWrittenToEpisode(episode, "source")
+        }
+    }
+
+    @Test
+    internal fun `should not write RSS tags to the item when the data is empty`() {
+        val episode = anEpisode(
+            title = "",
+            link = "",
+            description = "",
+            author = "",
+            categories = listOf(anRssCategory("", ""), anRssCategory("category 2", "")),
+            comments = "",
+            enclosure = anEpisodeEnclosure("", 123, ""),
+            guid = anEpisodeGuid(""),
+            pubDate = null,
+            source = ""
+        )
+        assertAll {
+            assertTagIsNotWrittenToEpisode(episode, "title")
+            assertTagIsNotWrittenToEpisode(episode, "link")
+            assertTagIsNotWrittenToEpisode(episode, "description")
+            assertTagIsNotWrittenToEpisode(episode, "author")
+            writeEpisodeDataXPathMultiple("//category", episode = episode) { elements ->
+                assertThat(elements).all {
+                    hasSize(1)
+                    transform { it.first() }.isInstanceOf(Element::class).all {
+                        hasTextContent("category 2")
+                        hasNoAttribute("domain")
+                    }
+                }
+            }
+            assertTagIsNotWrittenToEpisode(episode, "comments")
+            assertTagIsNotWrittenToEpisode(episode, "guid")
+            assertTagIsNotWrittenToEpisode(episode, "enclosure")
+            assertTagIsNotWrittenToEpisode(episode, "pubDate")
+            assertTagIsNotWrittenToEpisode(episode, "source")
+        }
+    }
+
+}

--- a/src/test/resources/xml/writer-fixtures.xml
+++ b/src/test/resources/xml/writer-fixtures.xml
@@ -12,15 +12,22 @@
         <title>podcast title</title>
         <link>podcast link</link>
         <description>podcast description</description>
-        <pubDate>Sat, 26 Dec 2020 15:32:22</pubDate>
-        <lastBuildDate>Tue, 22 Dec 2020 08:11:04</lastBuildDate>
+        <pubDate>Sat, 26 Dec 2020 15:32:22 GMT</pubDate>
+        <lastBuildDate>Tue, 22 Dec 2020 08:11:04 GMT</lastBuildDate>
         <language>language</language>
         <generator>generator</generator>
         <copyright>copyright</copyright>
         <docs>docs</docs>
-        <managingEditor>managingEditor</managingEditor>
-        <webMaster>webMaster</webMaster>
-        <image href="podcast image url" title="image title" link="image link" width="123" height="456" description="image description"/>
+        <managingEditor>managing editor</managingEditor>
+        <webMaster>web master</webMaster>
+        <image>
+            <url>podcast image url</url>
+            <title>image title</title>
+            <link>image link</link>
+            <description>image description</description>
+            <height>456</height>
+            <width>123</width>
+        </image>
         <itunes:subtitle>podcast itunes subtitle</itunes:subtitle>
         <itunes:summary>podcast itunes summary</itunes:summary>
         <itunes:image href="podcast itunes image url"/>
@@ -71,11 +78,11 @@
             <link>episode link</link>
             <description>episode description</description>
             <author>episode author</author>
-            <category text="episode category"/>
+            <category domain="rss category domain">episode category</category>
             <comments>episode comments</comments>
             <enclosure url="episode enclosure url" length="777" type="episode enclosure type" bitlove:guid="episode bitlove guid"/>
-            <guid isPermaLink="false">episode guid textContent</guid>
-            <pubDate>Sun, 20 Dec 2020 12:11:10</pubDate>
+            <guid isPermalink="false">episode guid textContent</guid>
+            <pubDate>Sun, 20 Dec 2020 12:11:10 GMT</pubDate>
             <source>episode source</source>
             <content:encoded>episode content encoded</content:encoded>
             <itunes:title>episode itunes title</itunes:title>


### PR DESCRIPTION
Firstly, apologies for the not-so-small PR. Most of it is tests, as anticipated, as the fixes/changes proper are quite small.
I have made sure that empty/blank elements and attrs are not written to RSS (as they're pointless anyway), and that we trim any value we write, as well. Lastly, I realised `RssWriter` had no tests as I had apparently forgotten to write them. Oops! Now that's fixed.

On my roadmap:
 - [x] Ensure parsers read empty fields as null
 - [x] Ensure writers don't write out empty fields/attributes (and trim values we do write)
 - [ ] Add parsing/writing of RSS `<categories>` nodes in `<channel>`
 - [ ] Add support for `podcast:` namespace
 - [ ] Unify `Atom` and `AtomBuilder` podcast/episode versions since they're exactly the same
 - [ ] Add some end-to-end tests that read a bunch of real-life RSS feeds