### PR TITLE
Support RSS categories in channel

### DIFF
--- a/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastBuilder.kt
@@ -8,6 +8,7 @@ import io.hemin.wien.builder.PersonBuilder
 import io.hemin.wien.builder.RssCategoryBuilder
 import io.hemin.wien.builder.RssImageBuilder
 import io.hemin.wien.builder.episode.EpisodeBuilder
+import io.hemin.wien.model.Episode
 import io.hemin.wien.model.Podcast
 import java.time.temporal.TemporalAccessor
 
@@ -70,6 +71,14 @@ internal interface PodcastBuilder : Builder<Podcast> {
      * @param episodeBuilder The [EpisodeBuilder] to add.
      */
     fun addEpisodeBuilder(episodeBuilder: EpisodeBuilder): PodcastBuilder
+
+    /**
+     * Adds a category to the list of categories.
+     *
+     * @param categoryBuilder The The [RssCategoryBuilder] used to initialize the
+     * [Episode.categories] items when [build] is called.
+     */
+    fun addCategoryBuilder(categoryBuilder: RssCategoryBuilder): PodcastBuilder
 
     /** Creates an instance of [RssImageBuilder] to use with this builder. */
     fun createRssImageBuilder(): RssImageBuilder

--- a/src/main/kotlin/io/hemin/wien/builder/validating/podcast/ValidatingPodcastBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/validating/podcast/ValidatingPodcastBuilder.kt
@@ -37,6 +37,7 @@ internal class ValidatingPodcastBuilder : PodcastBuilder {
     private var managingEditor: String? = null
     private var webMaster: String? = null
     private var imageBuilder: RssImageBuilder? = null
+    private val categoryBuilders: MutableList<RssCategoryBuilder> = mutableListOf()
 
     private val episodeBuilders: MutableList<EpisodeBuilder> = mutableListOf()
 
@@ -78,6 +79,10 @@ internal class ValidatingPodcastBuilder : PodcastBuilder {
         episodeBuilders.add(episodeBuilder)
     }
 
+    override fun addCategoryBuilder(categoryBuilder: RssCategoryBuilder): PodcastBuilder = apply {
+        categoryBuilders.add(categoryBuilder)
+    }
+
     override fun createRssImageBuilder(): RssImageBuilder = ValidatingRssImageBuilder()
 
     override fun createHrefOnlyImageBuilder(): HrefOnlyImageBuilder = ValidatingHrefOnlyImageBuilder()
@@ -96,11 +101,11 @@ internal class ValidatingPodcastBuilder : PodcastBuilder {
             ::linkValue.isInitialized && ::languageValue.isInitialized
 
     override fun build(): Podcast? {
-        val builtEpisodes = episodeBuilders.mapNotNull { it.build() }
         if (!hasEnoughDataToBuild) {
             return null
         }
 
+        val builtEpisodes = episodeBuilders.mapNotNull { it.build() }
         return Podcast(
             title = titleValue,
             link = linkValue,
@@ -119,7 +124,8 @@ internal class ValidatingPodcastBuilder : PodcastBuilder {
             atom = atom.build(),
             fyyd = fyyd.build(),
             feedpress = feedpress.build(),
-            googlePlay = googlePlay.build()
+            googlePlay = googlePlay.build(),
+            categories = categoryBuilders.mapNotNull { it.build() }
         )
     }
 }

--- a/src/main/kotlin/io/hemin/wien/model/Episode.kt
+++ b/src/main/kotlin/io/hemin/wien/model/Episode.kt
@@ -29,7 +29,7 @@ data class Episode(
     val link: String? = null,
     val description: String? = null,
     val author: String? = null,
-    val categories: List<RssCategory>,
+    val categories: List<RssCategory> = emptyList(),
     val comments: String? = null,
     val enclosure: Enclosure,
     val guid: Guid? = null,

--- a/src/main/kotlin/io/hemin/wien/model/Podcast.kt
+++ b/src/main/kotlin/io/hemin/wien/model/Podcast.kt
@@ -23,6 +23,7 @@ import java.time.temporal.TemporalAccessor
  * @property fyyd The data from the Fyyd namespace, or null if no data from this namespace was found.
  * @property feedpress The data from the Feedpress namespace, or null if no data from this namespace was found.
  * @property googlePlay The data from the Google Play namespace, or null if no data from this namespace was found.
+ * @property categories The RSS feed categories, if any.
  */
 data class Podcast(
     val title: String,
@@ -42,7 +43,8 @@ data class Podcast(
     val atom: Atom? = null,
     val fyyd: Fyyd? = null,
     val feedpress: Feedpress? = null,
-    val googlePlay: GooglePlay? = null
+    val googlePlay: GooglePlay? = null,
+    val categories: List<RssCategory>
 ) {
 
     /**

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/RssParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/RssParser.kt
@@ -54,6 +54,10 @@ internal class RssParser : NamespaceParser() {
                 builder.title(title)
             }
             "webMaster" -> builder.webMaster(ifCanBeParsed { textOrNull() })
+            "category" -> {
+                val categoryBuilder = ifCanBeParsed { toRssCategoryBuilder(builder.createRssCategoryBuilder()) } ?: return
+                builder.addCategoryBuilder(categoryBuilder)
+            }
             "item" -> pass // Items are parsed by the root parser direcly
         }
     }

--- a/src/main/kotlin/io/hemin/wien/writer/NamespaceWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/NamespaceWriter.kt
@@ -5,7 +5,6 @@ import io.hemin.wien.model.Podcast
 import io.hemin.wien.util.FeedNamespace
 import org.w3c.dom.Element
 import org.w3c.dom.Node
-import java.time.temporal.TemporalAccessor
 
 /** Base class for XML namespace writer implementations. */
 internal abstract class NamespaceWriter {

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/RssWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/RssWriter.kt
@@ -70,6 +70,8 @@ internal class RssWriter : NamespaceWriter() {
             appendElement("webMaster") { textContent = podcast.webMaster?.trim() }
         }
 
+        appendRssCategoryElements(podcast.categories)
+
         if (podcast.image != null) appendRssImageElement(podcast.image)
     }
 

--- a/src/test/kotlin/io/hemin/wien/builder/fake/podcast/FakePodcastBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/podcast/FakePodcastBuilder.kt
@@ -35,6 +35,7 @@ internal class FakePodcastBuilder : FakeBuilder<Podcast>(), PodcastBuilder {
     var imageBuilder: RssImageBuilder? = null
 
     val episodeBuilders: MutableList<EpisodeBuilder> = mutableListOf()
+    val categoryBuilders: MutableList<RssCategoryBuilder> = mutableListOf()
 
     override val iTunes: FakePodcastITunesBuilder = FakePodcastITunesBuilder()
 
@@ -74,6 +75,10 @@ internal class FakePodcastBuilder : FakeBuilder<Podcast>(), PodcastBuilder {
         episodeBuilders.add(episodeBuilder)
     }
 
+    override fun addCategoryBuilder(categoryBuilder: RssCategoryBuilder): PodcastBuilder = apply {
+        categoryBuilders.add(categoryBuilder)
+    }
+
     override fun createRssImageBuilder(): RssImageBuilder = FakeRssImageBuilder()
 
     override fun createHrefOnlyImageBuilder(): HrefOnlyImageBuilder = FakeHrefOnlyImageBuilder()
@@ -103,6 +108,7 @@ internal class FakePodcastBuilder : FakeBuilder<Podcast>(), PodcastBuilder {
         if (webMaster != other.webMaster) return false
         if (imageBuilder != other.imageBuilder) return false
         if (episodeBuilders != other.episodeBuilders) return false
+        if (categoryBuilders != other.categoryBuilders) return false
         if (iTunes != other.iTunes) return false
         if (atom != other.atom) return false
         if (fyyd != other.fyyd) return false
@@ -126,6 +132,7 @@ internal class FakePodcastBuilder : FakeBuilder<Podcast>(), PodcastBuilder {
         result = 31 * result + (webMaster?.hashCode() ?: 0)
         result = 31 * result + (imageBuilder?.hashCode() ?: 0)
         result = 31 * result + episodeBuilders.hashCode()
+        result = 31 * result + categoryBuilders.hashCode()
         result = 31 * result + iTunes.hashCode()
         result = 31 * result + atom.hashCode()
         result = 31 * result + fyyd.hashCode()
@@ -138,5 +145,5 @@ internal class FakePodcastBuilder : FakeBuilder<Podcast>(), PodcastBuilder {
         "FakePodcastBuilder(titleValue=$titleValue, linkValue=$linkValue, descriptionValue=$descriptionValue, languageValue=$languageValue, " +
             "pubDate=$pubDate, lastBuildDate=$lastBuildDate, generator=$generator, copyright=$copyright, docs=$docs, " +
             "managingEditor=$managingEditor, webMaster=$webMaster, imageBuilder=$imageBuilder, episodeBuilders=$episodeBuilders, " +
-            "iTunes=$iTunes, atom=$atom, fyyd=$fyyd, feedpress=$feedpress, googlePlay=$googlePlay)"
+            "categoryBuilders=$categoryBuilders, iTunes=$iTunes, atom=$atom, fyyd=$fyyd, feedpress=$feedpress, googlePlay=$googlePlay)"
 }

--- a/src/test/kotlin/io/hemin/wien/builder/validating/podcast/ValidatingPodcastBuilderTest.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/validating/podcast/ValidatingPodcastBuilderTest.kt
@@ -14,6 +14,7 @@ import io.hemin.wien.builder.podcast.PodcastBuilder
 import io.hemin.wien.builder.validating.ValidatingHrefOnlyImageBuilder
 import io.hemin.wien.builder.validating.ValidatingITunesStyleCategoryBuilder
 import io.hemin.wien.builder.validating.ValidatingPersonBuilder
+import io.hemin.wien.builder.validating.ValidatingRssCategoryBuilder
 import io.hemin.wien.builder.validating.ValidatingRssImageBuilder
 import io.hemin.wien.builder.validating.episode.ValidatingEpisodeBuilder
 import io.hemin.wien.builder.validating.episode.ValidatingEpisodeEnclosureBuilder
@@ -49,6 +50,11 @@ internal class ValidatingPodcastBuilderTest {
     private val expectedITunesCategoryBuilder = ValidatingITunesStyleCategoryBuilder()
         .category("itunes category")
         .subcategory("itunes subcategory")
+
+    private val expectedCategoryBuilders = listOf(
+        ValidatingRssCategoryBuilder().category("category 1").domain("domain"),
+        ValidatingRssCategoryBuilder().category("category 2")
+    )
 
     @Test
     internal fun `should not build a Podcast when the mandatory fields are missing`() {
@@ -187,6 +193,8 @@ internal class ValidatingPodcastBuilderTest {
             .webMaster("webMaster")
             .imageBuilder(expectedImageBuilder)
             .addEpisodeBuilder(expectedEpisodeBuilder)
+            .addCategoryBuilder(expectedCategoryBuilders[0])
+            .addCategoryBuilder(expectedCategoryBuilders[1])
             .apply {
                 iTunes.imageBuilder(expectedITunesImageBuilder)
                     .addCategoryBuilder(expectedITunesCategoryBuilder)
@@ -213,6 +221,7 @@ internal class ValidatingPodcastBuilderTest {
                 prop(Podcast::managingEditor).isEqualTo("managingEditor")
                 prop(Podcast::webMaster).isEqualTo("webMaster")
                 prop(Podcast::image).isEqualTo(expectedImageBuilder.build())
+                prop(Podcast::categories).containsExactly(expectedCategoryBuilders[0].build(), expectedCategoryBuilders[1].build())
                 prop(Podcast::episodes).containsExactly(expectedEpisodeBuilder.build())
                 prop(Podcast::iTunes).isNotNull().prop(Podcast.ITunes::categories).containsExactly(expectedITunesCategoryBuilder.build())
                 prop(Podcast::atom).isNotNull().prop(Podcast.Atom::authors)

--- a/src/test/kotlin/io/hemin/wien/dom/XPath.kt
+++ b/src/test/kotlin/io/hemin/wien/dom/XPath.kt
@@ -1,7 +1,6 @@
 package io.hemin.wien.dom
 
 import io.hemin.wien.util.FeedNamespace
-import org.w3c.dom.Document
 import org.w3c.dom.Node
 import org.w3c.dom.NodeList
 import javax.xml.namespace.NamespaceContext

--- a/src/test/kotlin/io/hemin/wien/model/podcast/PodcastFixtures.kt
+++ b/src/test/kotlin/io/hemin/wien/model/podcast/PodcastFixtures.kt
@@ -7,11 +7,13 @@ import io.hemin.wien.model.ITunesStyleCategory
 import io.hemin.wien.model.Link
 import io.hemin.wien.model.Person
 import io.hemin.wien.model.Podcast
+import io.hemin.wien.model.RssCategory
 import io.hemin.wien.model.RssImage
 import io.hemin.wien.model.aLink
 import io.hemin.wien.model.aPerson
 import io.hemin.wien.model.anHrefOnlyImage
 import io.hemin.wien.model.anITunesCategory
+import io.hemin.wien.model.anRssCategory
 import io.hemin.wien.model.anRssImage
 import io.hemin.wien.model.episode.anEpisode
 import java.time.Month
@@ -35,7 +37,8 @@ internal fun aPodcast(
     atom: Podcast.Atom? = aPodcastAtom(),
     fyyd: Podcast.Fyyd? = aPodcastFyyd(),
     feedpress: Podcast.Feedpress? = aPodcastFeedpress(),
-    googlePlay: Podcast.GooglePlay? = aPodcastGooglePlay()
+    googlePlay: Podcast.GooglePlay? = aPodcastGooglePlay(),
+    categories: List<RssCategory> = listOf(anRssCategory("podcast category"))
 ) = Podcast(
     title,
     link,
@@ -54,7 +57,8 @@ internal fun aPodcast(
     atom,
     fyyd,
     feedpress,
-    googlePlay
+    googlePlay,
+    categories
 )
 
 internal fun aPodcastITunes(

--- a/src/test/kotlin/io/hemin/wien/parser/RssParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/RssParserTest.kt
@@ -69,6 +69,10 @@ internal class RssParserTest : NamespaceParserTest() {
             prop(FakePodcastBuilder::managingEditor).isEqualTo("editor@example.org")
             prop(FakePodcastBuilder::webMaster).isEqualTo("webmaster@example.org")
             prop(FakePodcastBuilder::imageBuilder).isEqualTo(expectedImageBuilder)
+            prop(FakePodcastBuilder::categoryBuilders).containsExactly(
+                FakeRssCategoryBuilder().category("category 1").domain("banana"),
+                FakeRssCategoryBuilder().category("category 2")
+            )
         }
     }
 
@@ -91,6 +95,7 @@ internal class RssParserTest : NamespaceParserTest() {
             prop(FakePodcastBuilder::managingEditor).isNull()
             prop(FakePodcastBuilder::webMaster).isNull()
             prop(FakePodcastBuilder::imageBuilder).isNull()
+            prop(FakePodcastBuilder::categoryBuilders).isEmpty()
         }
     }
 
@@ -113,6 +118,7 @@ internal class RssParserTest : NamespaceParserTest() {
             prop(FakePodcastBuilder::managingEditor).isNull()
             prop(FakePodcastBuilder::webMaster).isNull()
             prop(FakePodcastBuilder::imageBuilder).isNotNull().hasNotEnoughDataToBuild()
+            prop(FakePodcastBuilder::categoryBuilders).isEmpty()
         }
     }
 

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/AtomWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/AtomWriterTest.kt
@@ -49,14 +49,16 @@ internal class AtomWriterTest : NamespaceWriterTest() {
 
     @Test
     internal fun `should not write atom tags to the channel when the data is all blank`() {
-        val podcast = aPodcast(atom = aPodcastAtom(
-            authors = listOf(aPerson(" ", " ", " "), aPerson("", "", "")),
-            contributors = listOf(aPerson(" ", " ", " "), aPerson("", "", "")),
-            links = listOf(
-                aLink(" ", " ", " "," ", " ", " ", " "),
-                aLink("", "", "","", "", "", "")
+        val podcast = aPodcast(
+            atom = aPodcastAtom(
+                authors = listOf(aPerson(" ", " ", " "), aPerson("", "", "")),
+                contributors = listOf(aPerson(" ", " ", " "), aPerson("", "", "")),
+                links = listOf(
+                    aLink(" ", " ", " ", " ", " ", " ", " "),
+                    aLink("", "", "", "", "", "", "")
+                )
             )
-        ))
+        )
         assertAll {
             assertTagIsNotWrittenToPodcast(podcast, "author")
             assertTagIsNotWrittenToPodcast(podcast, "contributor")
@@ -131,7 +133,6 @@ internal class AtomWriterTest : NamespaceWriterTest() {
         }
     }
 
-
     @Test
     internal fun `should write the correct atom tags to the item when there is data to write`() {
         assertAll {
@@ -164,9 +165,11 @@ internal class AtomWriterTest : NamespaceWriterTest() {
         val episode = anEpisode(
             atom = anEpisodeAtom(
                 authors = listOf(
-                    aPerson(" ", " ", " "), aPerson("", "", "")),
+                    aPerson(" ", " ", " "), aPerson("", "", "")
+                ),
                 contributors = listOf(
-                    aPerson(" ", " ", " "), aPerson("", "", "")),
+                    aPerson(" ", " ", " "), aPerson("", "", "")
+                ),
                 links = listOf(
                     aLink(" ", " ", " ", " ", " ", " ", " "),
                     aLink("", "", "", "", "", "", "")
@@ -185,9 +188,11 @@ internal class AtomWriterTest : NamespaceWriterTest() {
         val episode = anEpisode(
             atom = anEpisodeAtom(
                 authors = listOf(
-                    aPerson("author 1", " ", " "), aPerson("author 2", "", "")),
+                    aPerson("author 1", " ", " "), aPerson("author 2", "", "")
+                ),
                 contributors = listOf(
-                    aPerson("contrib 1", " ", " "), aPerson("contrib 2", "", "")),
+                    aPerson("contrib 1", " ", " "), aPerson("contrib 2", "", "")
+                ),
                 links = listOf(
                     aLink("link 1", " ", " ", " ", " ", " ", " "),
                     aLink("link 2", "", "", "", "", "", "")

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/FeedpressWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/FeedpressWriterTest.kt
@@ -51,7 +51,7 @@ internal class FeedpressWriterTest : NamespaceWriterTest() {
 
     @Test
     internal fun `should not write feedpress tags to the channel when the data is blank`() {
-        val podcast = aPodcast(feedpress = aPodcastFeedpress(" "," "," "," "," "))
+        val podcast = aPodcast(feedpress = aPodcastFeedpress(" ", " ", " ", " ", " "))
         assertAll {
             assertTagIsNotWrittenToPodcast(podcast, "newsletterId")
             assertTagIsNotWrittenToPodcast(podcast, "locale")
@@ -63,7 +63,7 @@ internal class FeedpressWriterTest : NamespaceWriterTest() {
 
     @Test
     internal fun `should not write feedpress tags to the channel when the data is empty`() {
-        val podcast = aPodcast(feedpress = aPodcastFeedpress("","","","",""))
+        val podcast = aPodcast(feedpress = aPodcastFeedpress("", "", "", "", ""))
         assertAll {
             assertTagIsNotWrittenToPodcast(podcast, "newsletterId")
             assertTagIsNotWrittenToPodcast(podcast, "locale")

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/GooglePlayWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/GooglePlayWriterTest.kt
@@ -3,7 +3,6 @@ package io.hemin.wien.writer.namespace
 import assertk.assertAll
 import assertk.assertThat
 import assertk.assertions.hasSize
-import io.hemin.wien.childNodesNamed
 import io.hemin.wien.hasNoChildren
 import io.hemin.wien.hasNoDifferences
 import io.hemin.wien.hasValue

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/ITunesWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/ITunesWriterTest.kt
@@ -3,7 +3,6 @@ package io.hemin.wien.writer.namespace
 import assertk.assertAll
 import assertk.assertThat
 import assertk.assertions.hasSize
-import io.hemin.wien.childNodesNamed
 import io.hemin.wien.hasNoChildren
 import io.hemin.wien.hasNoDifferences
 import io.hemin.wien.hasTextContent
@@ -244,19 +243,21 @@ internal class ITunesWriterTest : NamespaceWriterTest() {
 
     @Test
     internal fun `should not write itunes tags to the item when the data is blank`() {
-        val episode = anEpisode(iTunes = anEpisodeITunes(
-            title = " ",
-            duration = " ",
-            image = anHrefOnlyImage(" "),
-            explicit = null,
-            block = null,
-            season = null,
-            episode = null,
-            episodeType = null,
-            author = " ",
-            subtitle = " ",
-            summary = " "
-        ))
+        val episode = anEpisode(
+            iTunes = anEpisodeITunes(
+                title = " ",
+                duration = " ",
+                image = anHrefOnlyImage(" "),
+                explicit = null,
+                block = null,
+                season = null,
+                episode = null,
+                episodeType = null,
+                author = " ",
+                subtitle = " ",
+                summary = " "
+            )
+        )
         assertAll {
             assertTagIsNotWrittenToEpisode(episode, "duration")
             assertTagIsNotWrittenToEpisode(episode, "season")
@@ -271,19 +272,21 @@ internal class ITunesWriterTest : NamespaceWriterTest() {
 
     @Test
     internal fun `should not write itunes tags to the item when the data is empty`() {
-        val episode = anEpisode(iTunes = anEpisodeITunes(
-            title = "",
-            duration = "",
-            image = anHrefOnlyImage(""),
-            explicit = null,
-            block = null,
-            season = null,
-            episode = null,
-            episodeType = null,
-            author = "",
-            subtitle = "",
-            summary = ""
-        ))
+        val episode = anEpisode(
+            iTunes = anEpisodeITunes(
+                title = "",
+                duration = "",
+                image = anHrefOnlyImage(""),
+                explicit = null,
+                block = null,
+                season = null,
+                episode = null,
+                episodeType = null,
+                author = "",
+                subtitle = "",
+                summary = ""
+            )
+        )
         assertAll {
             assertTagIsNotWrittenToEpisode(episode, "duration")
             assertTagIsNotWrittenToEpisode(episode, "season")

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/PodloveSimpleChapterWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/PodloveSimpleChapterWriterTest.kt
@@ -5,8 +5,8 @@ import assertk.assertAll
 import assertk.assertThat
 import assertk.assertions.isInstanceOf
 import io.hemin.wien.hasNoAttribute
-import io.hemin.wien.hasOneChild
 import io.hemin.wien.hasNoDifferences
+import io.hemin.wien.hasOneChild
 import io.hemin.wien.hasValue
 import io.hemin.wien.model.episode.aPodloveSimpleChapter
 import io.hemin.wien.model.episode.anEpisode

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/RssWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/RssWriterTest.kt
@@ -42,6 +42,10 @@ internal class RssWriterTest : NamespaceWriterTest() {
                 val diff = element.diffFromExpected("/rss/channel/description")
                 assertThat(diff).hasNoDifferences()
             }
+            writePodcastData("category") { element ->
+                val diff = element.diffFromExpected("/rss/channel/category")
+                assertThat(diff).hasNoDifferences()
+            }
             writePodcastData("pubDate") { element ->
                 val diff = element.diffFromExpected("/rss/channel/pubDate")
                 assertThat(diff).hasNoDifferences()

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/RssWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/RssWriterTest.kt
@@ -343,5 +343,4 @@ internal class RssWriterTest : NamespaceWriterTest() {
             assertTagIsNotWrittenToEpisode(episode, "source")
         }
     }
-
 }

--- a/src/test/resources/xml/channel.xml
+++ b/src/test/resources/xml/channel.xml
@@ -24,6 +24,8 @@
         <height>600</height>
         <description>Lorem Ipsum</description>
     </image>
+    <category domain="banana">category 1</category>
+    <category>category 2</category>
     <itunes:subtitle>Lorem Ipsum</itunes:subtitle>
     <itunes:summary>Lorem Ipsum</itunes:summary>
     <itunes:image href="http://example.org/podcast-cover.jpg"/>

--- a/src/test/resources/xml/writer-fixtures.xml
+++ b/src/test/resources/xml/writer-fixtures.xml
@@ -28,6 +28,7 @@
             <height>456</height>
             <width>123</width>
         </image>
+        <category domain="rss category domain">podcast category</category>
         <itunes:subtitle>podcast itunes subtitle</itunes:subtitle>
         <itunes:summary>podcast itunes summary</itunes:summary>
         <itunes:image href="podcast itunes image url"/>


### PR DESCRIPTION
This small PR adds support for reading and writing the RSS `<category>` tag at the `<channel>` level, just like we had already for `<item>`s.

On my roadmap:
 - [x] Ensure parsers read empty fields as null
 - [x] Ensure writers don't write out empty fields/attributes (and trim values we do write)
 - [x] Add parsing/writing of RSS `<categories>` nodes in `<channel>`
 - [ ] Add support for `podcast:` namespace
 - [ ] Unify `Atom` and `AtomBuilder` podcast/episode versions since they're exactly the same
 - [ ] Add some end-to-end tests that read a bunch of real-life RSS feeds