### PR TITLE
Add podcast ns support

### DIFF
--- a/src/main/kotlin/io/hemin/wien/PodcastRssParser.kt
+++ b/src/main/kotlin/io/hemin/wien/PodcastRssParser.kt
@@ -44,10 +44,6 @@ object PodcastRssParser {
         PodcastNamespaceParser()
     )
 
-    /** Set of all XML namespaces supported when parsing documents. */
-    val supportedNamespaces: Set<String> = parsers.mapNotNull { parser -> parser.namespace?.uri }
-        .toSet()
-
     private val builder: DocumentBuilder = DomBuilderFactory.newDocumentBuilder()
 
     /**

--- a/src/main/kotlin/io/hemin/wien/PodcastRssParser.kt
+++ b/src/main/kotlin/io/hemin/wien/PodcastRssParser.kt
@@ -16,6 +16,7 @@ import io.hemin.wien.parser.namespace.FeedpressParser
 import io.hemin.wien.parser.namespace.FyydParser
 import io.hemin.wien.parser.namespace.GooglePlayParser
 import io.hemin.wien.parser.namespace.ITunesParser
+import io.hemin.wien.parser.namespace.PodcastNamespaceParser
 import io.hemin.wien.parser.namespace.PodloveSimpleChapterParser
 import io.hemin.wien.parser.namespace.RssParser
 import org.w3c.dom.Document
@@ -39,7 +40,8 @@ object PodcastRssParser {
         GooglePlayParser(),
         ITunesParser(),
         PodloveSimpleChapterParser(),
-        RssParser()
+        RssParser(),
+        PodcastNamespaceParser()
     )
 
     /** Set of all XML namespaces supported when parsing documents. */

--- a/src/main/kotlin/io/hemin/wien/PodcastRssWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/PodcastRssWriter.kt
@@ -12,6 +12,7 @@ import io.hemin.wien.writer.namespace.FeedpressWriter
 import io.hemin.wien.writer.namespace.FyydWriter
 import io.hemin.wien.writer.namespace.GooglePlayWriter
 import io.hemin.wien.writer.namespace.ITunesWriter
+import io.hemin.wien.writer.namespace.PodcastNamespaceWriter
 import io.hemin.wien.writer.namespace.PodloveSimpleChapterWriter
 import io.hemin.wien.writer.namespace.RssWriter
 import org.w3c.dom.Document
@@ -35,7 +36,8 @@ object PodcastRssWriter {
         BitloveWriter(),
         FeedpressWriter(),
         FyydWriter(),
-        PodloveSimpleChapterWriter()
+        PodloveSimpleChapterWriter(),
+        PodcastNamespaceWriter()
     )
 
     private val supportedNamespaces = writers.mapNotNull { it.namespace }

--- a/src/main/kotlin/io/hemin/wien/builder/episode/EpisodeBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/episode/EpisodeBuilder.kt
@@ -12,22 +12,25 @@ import java.time.temporal.TemporalAccessor
 internal interface EpisodeBuilder : Builder<Episode> {
 
     /** The builder for data from the Content namespace. */
-    val content: EpisodeContentBuilder
+    val contentBuilder: EpisodeContentBuilder
 
     /** The builder for data from the iTunes namespace. */
-    val iTunes: EpisodeITunesBuilder
+    val iTunesBuilder: EpisodeITunesBuilder
 
     /** The builder for data from the Atom namespace. */
-    val atom: EpisodeAtomBuilder
+    val atomBuilder: EpisodeAtomBuilder
 
     /** The builder for data from namespaces of the Podlove standards. */
-    val podlove: EpisodePodloveBuilder
+    val podloveBuilder: EpisodePodloveBuilder
 
     /** The builder for data from the Google Play namespace. */
-    val googlePlay: EpisodeGooglePlayBuilder
+    val googlePlayBuilder: EpisodeGooglePlayBuilder
 
     /** The builder for data from the Bitlove namespace. */
-    val bitlove: EpisodeBitloveBuilder
+    val bitloveBuilder: EpisodeBitloveBuilder
+
+    /** The builder for data from the Podcast namespace. */
+    val podcastBuilder: EpisodePodcastBuilder
 
     /** Set the title value. */
     fun title(title: String): EpisodeBuilder
@@ -96,5 +99,14 @@ internal interface EpisodeBuilder : Builder<Episode> {
     fun createRssCategoryBuilder(): RssCategoryBuilder
 
     /** Creates an instance of [ITunesStyleCategoryBuilder] to use with this builder. */
-    fun createITunesCategoryBuilder(): ITunesStyleCategoryBuilder
+    fun createITunesStyleCategoryBuilder(): ITunesStyleCategoryBuilder
+
+    /** Creates an instance of [EpisodePodcastTranscriptBuilder] to use with this builder. */
+    fun createEpisodePodcastTranscriptBuilder(): EpisodePodcastTranscriptBuilder
+
+    /** Creates an instance of [EpisodePodcastChaptersBuilder] to use with this builder. */
+    fun createEpisodePodcastChaptersBuilder(): EpisodePodcastChaptersBuilder
+
+    /** Creates an instance of [EpisodePodcastSoundbiteBuilder] to use with this builder. */
+    fun createEpisodePodcastSoundbiteBuilder(): EpisodePodcastSoundbiteBuilder
 }

--- a/src/main/kotlin/io/hemin/wien/builder/episode/EpisodePodcastBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/episode/EpisodePodcastBuilder.kt
@@ -1,0 +1,27 @@
+package io.hemin.wien.builder.episode
+
+import io.hemin.wien.builder.Builder
+import io.hemin.wien.builder.LinkBuilder
+import io.hemin.wien.builder.PersonBuilder
+import io.hemin.wien.builder.podcast.PodcastPodcastBuilder
+import io.hemin.wien.builder.podcast.PodcastPodcastFundingBuilder
+import io.hemin.wien.builder.podcast.PodcastPodcastLockedBuilder
+import io.hemin.wien.model.Episode
+
+internal interface EpisodePodcastBuilder : Builder<Episode.Podcast> {
+
+    /**
+     * The builder for the Podcast namespace `<chapters>` info.
+     */
+    fun chaptersBuilder(chaptersBuilder: EpisodePodcastChaptersBuilder): EpisodePodcastBuilder
+
+    /**
+     * The builders for the Podcast namespace `<soundbite>` info.
+     */
+    fun addSoundbiteBuilder(soundbiteBuilder: EpisodePodcastSoundbiteBuilder): EpisodePodcastBuilder
+
+    /**
+     * The builders for the Podcast namespace `<transcript>` info.
+     */
+    fun addTranscriptBuilder(transcriptBuilder: EpisodePodcastTranscriptBuilder): EpisodePodcastBuilder
+}

--- a/src/main/kotlin/io/hemin/wien/builder/episode/EpisodePodcastBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/episode/EpisodePodcastBuilder.kt
@@ -1,11 +1,6 @@
 package io.hemin.wien.builder.episode
 
 import io.hemin.wien.builder.Builder
-import io.hemin.wien.builder.LinkBuilder
-import io.hemin.wien.builder.PersonBuilder
-import io.hemin.wien.builder.podcast.PodcastPodcastBuilder
-import io.hemin.wien.builder.podcast.PodcastPodcastFundingBuilder
-import io.hemin.wien.builder.podcast.PodcastPodcastLockedBuilder
 import io.hemin.wien.model.Episode
 
 internal interface EpisodePodcastBuilder : Builder<Episode.Podcast> {

--- a/src/main/kotlin/io/hemin/wien/builder/episode/EpisodePodcastChaptersBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/episode/EpisodePodcastChaptersBuilder.kt
@@ -1,0 +1,11 @@
+package io.hemin.wien.builder.episode
+
+import io.hemin.wien.builder.Builder
+import io.hemin.wien.model.Episode
+
+internal interface EpisodePodcastChaptersBuilder: Builder<Episode.Podcast.Chapters> {
+
+    fun url(url: String): EpisodePodcastChaptersBuilder
+
+    fun type(type: String): EpisodePodcastChaptersBuilder
+}

--- a/src/main/kotlin/io/hemin/wien/builder/episode/EpisodePodcastChaptersBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/episode/EpisodePodcastChaptersBuilder.kt
@@ -3,7 +3,7 @@ package io.hemin.wien.builder.episode
 import io.hemin.wien.builder.Builder
 import io.hemin.wien.model.Episode
 
-internal interface EpisodePodcastChaptersBuilder: Builder<Episode.Podcast.Chapters> {
+internal interface EpisodePodcastChaptersBuilder : Builder<Episode.Podcast.Chapters> {
 
     fun url(url: String): EpisodePodcastChaptersBuilder
 

--- a/src/main/kotlin/io/hemin/wien/builder/episode/EpisodePodcastSoundbiteBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/episode/EpisodePodcastSoundbiteBuilder.kt
@@ -1,0 +1,14 @@
+package io.hemin.wien.builder.episode
+
+import io.hemin.wien.builder.Builder
+import io.hemin.wien.model.Episode
+import java.time.Duration
+
+internal interface EpisodePodcastSoundbiteBuilder: Builder<Episode.Podcast.Soundbite> {
+
+    fun startTime(startTime: Duration): EpisodePodcastSoundbiteBuilder
+
+    fun duration(duration: Duration): EpisodePodcastSoundbiteBuilder
+
+    fun title(title: String?): EpisodePodcastSoundbiteBuilder
+}

--- a/src/main/kotlin/io/hemin/wien/builder/episode/EpisodePodcastSoundbiteBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/episode/EpisodePodcastSoundbiteBuilder.kt
@@ -4,7 +4,7 @@ import io.hemin.wien.builder.Builder
 import io.hemin.wien.model.Episode
 import java.time.Duration
 
-internal interface EpisodePodcastSoundbiteBuilder: Builder<Episode.Podcast.Soundbite> {
+internal interface EpisodePodcastSoundbiteBuilder : Builder<Episode.Podcast.Soundbite> {
 
     fun startTime(startTime: Duration): EpisodePodcastSoundbiteBuilder
 

--- a/src/main/kotlin/io/hemin/wien/builder/episode/EpisodePodcastTranscriptBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/episode/EpisodePodcastTranscriptBuilder.kt
@@ -1,0 +1,16 @@
+package io.hemin.wien.builder.episode
+
+import io.hemin.wien.builder.Builder
+import io.hemin.wien.model.Episode
+import java.util.Locale
+
+internal interface EpisodePodcastTranscriptBuilder: Builder<Episode.Podcast.Transcript> {
+
+    fun url(url: String): EpisodePodcastTranscriptBuilder
+
+    fun type(type: Episode.Podcast.Transcript.Type): EpisodePodcastTranscriptBuilder
+
+    fun language(language: Locale?): EpisodePodcastTranscriptBuilder
+
+    fun rel(rel: String?): EpisodePodcastTranscriptBuilder
+}

--- a/src/main/kotlin/io/hemin/wien/builder/episode/EpisodePodcastTranscriptBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/episode/EpisodePodcastTranscriptBuilder.kt
@@ -4,7 +4,7 @@ import io.hemin.wien.builder.Builder
 import io.hemin.wien.model.Episode
 import java.util.Locale
 
-internal interface EpisodePodcastTranscriptBuilder: Builder<Episode.Podcast.Transcript> {
+internal interface EpisodePodcastTranscriptBuilder : Builder<Episode.Podcast.Transcript> {
 
     fun url(url: String): EpisodePodcastTranscriptBuilder
 

--- a/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastBuilder.kt
@@ -15,19 +15,22 @@ import java.time.temporal.TemporalAccessor
 internal interface PodcastBuilder : Builder<Podcast> {
 
     /** The builder for data from the iTunes namespace. */
-    val iTunes: PodcastITunesBuilder
+    val iTunesBuilder: PodcastITunesBuilder
 
     /** The builder for data from the Atom namespace. */
-    val atom: PodcastAtomBuilder
+    val atomBuilder: PodcastAtomBuilder
 
     /** The builder for data from the Fyyd namespace. */
-    val fyyd: PodcastFyydBuilder
+    val fyydBuilder: PodcastFyydBuilder
 
     /** The builder for data from the Feedpress namespace. */
-    val feedpress: PodcastFeedpressBuilder
+    val feedpressBuilder: PodcastFeedpressBuilder
 
     /** The builder for data from the Google Play namespace. */
-    val googlePlay: PodcastGooglePlayBuilder
+    val googlePlayBuilder: PodcastGooglePlayBuilder
+
+    /** Set the Podcast namespace builder. */
+    val podcastBuilder: PodcastPodcastBuilder
 
     /** Set the title value. */
     fun title(title: String): PodcastBuilder
@@ -96,5 +99,11 @@ internal interface PodcastBuilder : Builder<Podcast> {
     fun createRssCategoryBuilder(): RssCategoryBuilder
 
     /** Creates an instance of [ITunesStyleCategoryBuilder] to use with this builder. */
-    fun createITunesCategoryBuilder(): ITunesStyleCategoryBuilder
+    fun createITunesStyleCategoryBuilder(): ITunesStyleCategoryBuilder
+
+    /** Creates an instance of [PodcastPodcastLockedBuilder] to use with this builder. */
+    fun createPodcastPodcastLockedBuilder(): PodcastPodcastLockedBuilder
+
+    /** Creates an instance of [PodcastPodcastFundingBuilder] to use with this builder. */
+    fun createPodcastPodcastFundingBuilder(): PodcastPodcastFundingBuilder
 }

--- a/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastPodcastBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastPodcastBuilder.kt
@@ -1,0 +1,17 @@
+package io.hemin.wien.builder.podcast
+
+import io.hemin.wien.builder.Builder
+import io.hemin.wien.model.Podcast
+
+internal interface PodcastPodcastBuilder : Builder<Podcast.Podcast> {
+
+    /**
+     * The builder for the Podcast namespace `<locked>` status.
+     */
+    fun lockedBuilder(lockedBuilder: PodcastPodcastLockedBuilder): PodcastPodcastBuilder
+
+    /**
+     * The builders for the Podcast namespace `<funding>` info.
+     */
+    fun addFundingBuilder(fundingBuilder: PodcastPodcastFundingBuilder): PodcastPodcastBuilder
+}

--- a/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastPodcastFundingBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastPodcastFundingBuilder.kt
@@ -3,7 +3,7 @@ package io.hemin.wien.builder.podcast
 import io.hemin.wien.builder.Builder
 import io.hemin.wien.model.Podcast
 
-internal interface PodcastPodcastFundingBuilder: Builder<Podcast.Podcast.Funding> {
+internal interface PodcastPodcastFundingBuilder : Builder<Podcast.Podcast.Funding> {
 
     fun url(url: String): PodcastPodcastFundingBuilder
 

--- a/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastPodcastFundingBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastPodcastFundingBuilder.kt
@@ -1,0 +1,11 @@
+package io.hemin.wien.builder.podcast
+
+import io.hemin.wien.builder.Builder
+import io.hemin.wien.model.Podcast
+
+internal interface PodcastPodcastFundingBuilder: Builder<Podcast.Podcast.Funding> {
+
+    fun url(url: String): PodcastPodcastFundingBuilder
+
+    fun message(message: String): PodcastPodcastFundingBuilder
+}

--- a/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastPodcastLockedBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastPodcastLockedBuilder.kt
@@ -1,0 +1,11 @@
+package io.hemin.wien.builder.podcast
+
+import io.hemin.wien.builder.Builder
+import io.hemin.wien.model.Podcast
+
+internal interface PodcastPodcastLockedBuilder: Builder<Podcast.Podcast.Locked> {
+
+    fun owner(owner: String): PodcastPodcastLockedBuilder
+
+    fun locked(locked: Boolean): PodcastPodcastLockedBuilder
+}

--- a/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastPodcastLockedBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastPodcastLockedBuilder.kt
@@ -3,7 +3,7 @@ package io.hemin.wien.builder.podcast
 import io.hemin.wien.builder.Builder
 import io.hemin.wien.model.Podcast
 
-internal interface PodcastPodcastLockedBuilder: Builder<Podcast.Podcast.Locked> {
+internal interface PodcastPodcastLockedBuilder : Builder<Podcast.Podcast.Locked> {
 
     fun owner(owner: String): PodcastPodcastLockedBuilder
 

--- a/src/main/kotlin/io/hemin/wien/builder/validating/episode/ValidatingEpisodeBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/validating/episode/ValidatingEpisodeBuilder.kt
@@ -13,6 +13,10 @@ import io.hemin.wien.builder.episode.EpisodeEnclosureBuilder
 import io.hemin.wien.builder.episode.EpisodeGooglePlayBuilder
 import io.hemin.wien.builder.episode.EpisodeGuidBuilder
 import io.hemin.wien.builder.episode.EpisodeITunesBuilder
+import io.hemin.wien.builder.episode.EpisodePodcastBuilder
+import io.hemin.wien.builder.episode.EpisodePodcastChaptersBuilder
+import io.hemin.wien.builder.episode.EpisodePodcastSoundbiteBuilder
+import io.hemin.wien.builder.episode.EpisodePodcastTranscriptBuilder
 import io.hemin.wien.builder.episode.EpisodePodloveBuilder
 import io.hemin.wien.builder.episode.EpisodePodloveSimpleChapterBuilder
 import io.hemin.wien.builder.validating.ValidatingHrefOnlyImageBuilder
@@ -37,17 +41,19 @@ internal class ValidatingEpisodeBuilder : EpisodeBuilder {
     private var pubDate: TemporalAccessor? = null
     private var source: String? = null
 
-    override val content: EpisodeContentBuilder = ValidatingEpisodeContentBuilder()
+    override val contentBuilder: EpisodeContentBuilder = ValidatingEpisodeContentBuilder()
 
-    override val iTunes: EpisodeITunesBuilder = ValidatingEpisodeITunesBuilder()
+    override val iTunesBuilder: EpisodeITunesBuilder = ValidatingEpisodeITunesBuilder()
 
-    override val atom: EpisodeAtomBuilder = ValidatingEpisodeAtomBuilder()
+    override val atomBuilder: EpisodeAtomBuilder = ValidatingEpisodeAtomBuilder()
 
-    override val podlove: EpisodePodloveBuilder = ValidatingEpisodePodloveBuilder()
+    override val podloveBuilder: EpisodePodloveBuilder = ValidatingEpisodePodloveBuilder()
 
-    override val googlePlay: EpisodeGooglePlayBuilder = ValidatingEpisodeGooglePlayBuilder()
+    override val googlePlayBuilder: EpisodeGooglePlayBuilder = ValidatingEpisodeGooglePlayBuilder()
 
-    override val bitlove: EpisodeBitloveBuilder = ValidatingEpisodeBitloveBuilder()
+    override val bitloveBuilder: EpisodeBitloveBuilder = ValidatingEpisodeBitloveBuilder()
+
+    override val podcastBuilder: EpisodePodcastBuilder = ValidatingEpisodePodcastBuilder()
 
     override fun title(title: String): EpisodeBuilder = apply { this.titleValue = title }
 
@@ -87,7 +93,13 @@ internal class ValidatingEpisodeBuilder : EpisodeBuilder {
 
     override fun createRssCategoryBuilder(): RssCategoryBuilder = ValidatingRssCategoryBuilder()
 
-    override fun createITunesCategoryBuilder(): ITunesStyleCategoryBuilder = ValidatingITunesStyleCategoryBuilder()
+    override fun createITunesStyleCategoryBuilder(): ITunesStyleCategoryBuilder = ValidatingITunesStyleCategoryBuilder()
+
+    override fun createEpisodePodcastTranscriptBuilder(): EpisodePodcastTranscriptBuilder = ValidatingEpisodePodcastTranscriptBuilder()
+
+    override fun createEpisodePodcastChaptersBuilder(): EpisodePodcastChaptersBuilder = ValidatingEpisodePodcastChaptersBuilder()
+
+    override fun createEpisodePodcastSoundbiteBuilder(): EpisodePodcastSoundbiteBuilder = ValidatingEpisodePodcastSoundbiteBuilder()
 
     override val hasEnoughDataToBuild: Boolean
         get() = ::titleValue.isInitialized && (::enclosureBuilderValue.isInitialized && enclosureBuilderValue.hasEnoughDataToBuild)
@@ -111,12 +123,13 @@ internal class ValidatingEpisodeBuilder : EpisodeBuilder {
             guid = guidBuilder?.build(),
             pubDate = pubDate,
             source = source,
-            content = content.build(),
-            iTunes = iTunes.build(),
-            atom = atom.build(),
-            podlove = podlove.build(),
-            googlePlay = googlePlay.build(),
-            bitlove = bitlove.build()
+            content = contentBuilder.build(),
+            iTunes = iTunesBuilder.build(),
+            atom = atomBuilder.build(),
+            podlove = podloveBuilder.build(),
+            googlePlay = googlePlayBuilder.build(),
+            bitlove = bitloveBuilder.build(),
+            podcast = podcastBuilder.build()
         )
     }
 }

--- a/src/main/kotlin/io/hemin/wien/builder/validating/episode/ValidatingEpisodePodcastBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/validating/episode/ValidatingEpisodePodcastBuilder.kt
@@ -1,0 +1,43 @@
+package io.hemin.wien.builder.validating.episode
+
+import io.hemin.wien.builder.episode.EpisodePodcastBuilder
+import io.hemin.wien.builder.episode.EpisodePodcastChaptersBuilder
+import io.hemin.wien.builder.episode.EpisodePodcastSoundbiteBuilder
+import io.hemin.wien.builder.episode.EpisodePodcastTranscriptBuilder
+import io.hemin.wien.model.Episode
+
+internal class ValidatingEpisodePodcastBuilder : EpisodePodcastBuilder {
+
+    private var chaptersBuilderValue: EpisodePodcastChaptersBuilder? = null
+    private val transcriptBuilders: MutableList<EpisodePodcastTranscriptBuilder> = mutableListOf()
+    private val soundbiteBuilders: MutableList<EpisodePodcastSoundbiteBuilder> = mutableListOf()
+
+    override fun chaptersBuilder(chaptersBuilder: EpisodePodcastChaptersBuilder): EpisodePodcastBuilder = apply {
+        this.chaptersBuilderValue = chaptersBuilder
+    }
+
+    override fun addSoundbiteBuilder(soundbiteBuilder: EpisodePodcastSoundbiteBuilder): EpisodePodcastBuilder = apply {
+        soundbiteBuilders.add(soundbiteBuilder)
+    }
+
+    override fun addTranscriptBuilder(transcriptBuilder: EpisodePodcastTranscriptBuilder): EpisodePodcastBuilder = apply {
+        transcriptBuilders.add(transcriptBuilder)
+    }
+
+    override val hasEnoughDataToBuild: Boolean
+        get() = chaptersBuilderValue?.hasEnoughDataToBuild == true ||
+            transcriptBuilders.any { it.hasEnoughDataToBuild } ||
+            soundbiteBuilders.any { it.hasEnoughDataToBuild }
+
+    override fun build(): Episode.Podcast? {
+        if (!hasEnoughDataToBuild) {
+            return null
+        }
+
+        return Episode.Podcast(
+            transcripts = transcriptBuilders.mapNotNull { it.build() },
+            soundbites = soundbiteBuilders.mapNotNull { it.build() },
+            chapters = chaptersBuilderValue?.build()
+        )
+    }
+}

--- a/src/main/kotlin/io/hemin/wien/builder/validating/episode/ValidatingEpisodePodcastChaptersBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/validating/episode/ValidatingEpisodePodcastChaptersBuilder.kt
@@ -1,0 +1,25 @@
+package io.hemin.wien.builder.validating.episode
+
+import io.hemin.wien.builder.episode.EpisodePodcastChaptersBuilder
+import io.hemin.wien.model.Episode
+
+internal class ValidatingEpisodePodcastChaptersBuilder : EpisodePodcastChaptersBuilder {
+
+    private lateinit var urlValue: String
+    private lateinit var typeValue: String
+
+    override fun url(url: String): EpisodePodcastChaptersBuilder = apply { this.urlValue = url }
+
+    override fun type(type: String): EpisodePodcastChaptersBuilder = apply { this.typeValue = type }
+
+    override val hasEnoughDataToBuild: Boolean
+        get() = ::urlValue.isInitialized && ::typeValue.isInitialized
+
+    override fun build(): Episode.Podcast.Chapters? {
+        if (!hasEnoughDataToBuild) {
+            return null
+        }
+
+        return Episode.Podcast.Chapters(urlValue, typeValue)
+    }
+}

--- a/src/main/kotlin/io/hemin/wien/builder/validating/episode/ValidatingEpisodePodcastSoundbiteBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/validating/episode/ValidatingEpisodePodcastSoundbiteBuilder.kt
@@ -1,0 +1,34 @@
+package io.hemin.wien.builder.validating.episode
+
+import io.hemin.wien.builder.episode.EpisodePodcastSoundbiteBuilder
+import io.hemin.wien.model.Episode
+import java.time.Duration
+
+internal class ValidatingEpisodePodcastSoundbiteBuilder : EpisodePodcastSoundbiteBuilder {
+
+    private lateinit var startTimeValue: Duration
+    private lateinit var durationValue: Duration
+
+    private var title: String? = null
+
+    override fun startTime(startTime: Duration): EpisodePodcastSoundbiteBuilder = apply { this.startTimeValue = startTime }
+
+    override fun duration(duration: Duration): EpisodePodcastSoundbiteBuilder = apply { this.durationValue = duration }
+
+    override fun title(title: String?): EpisodePodcastSoundbiteBuilder = apply { this.title = title }
+
+    override val hasEnoughDataToBuild: Boolean
+        get() = ::startTimeValue.isInitialized && ::durationValue.isInitialized
+
+    override fun build(): Episode.Podcast.Soundbite? {
+        if (!hasEnoughDataToBuild) {
+            return null
+        }
+
+        if (startTimeValue.isNegative || durationValue.isNegative || durationValue.isZero) {
+            return null
+        }
+
+        return Episode.Podcast.Soundbite(startTimeValue, durationValue, title)
+    }
+}

--- a/src/main/kotlin/io/hemin/wien/builder/validating/episode/ValidatingEpisodePodcastTranscriptBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/validating/episode/ValidatingEpisodePodcastTranscriptBuilder.kt
@@ -1,0 +1,33 @@
+package io.hemin.wien.builder.validating.episode
+
+import io.hemin.wien.builder.episode.EpisodePodcastTranscriptBuilder
+import io.hemin.wien.model.Episode
+import java.util.Locale
+
+internal class ValidatingEpisodePodcastTranscriptBuilder : EpisodePodcastTranscriptBuilder {
+
+    private lateinit var urlValue: String
+    private lateinit var typeValue: Episode.Podcast.Transcript.Type
+
+    private var language: Locale? = null
+    private var rel: String? = null
+
+    override fun url(url: String): EpisodePodcastTranscriptBuilder = apply { this.urlValue = url }
+
+    override fun type(type: Episode.Podcast.Transcript.Type): EpisodePodcastTranscriptBuilder = apply { this.typeValue = type }
+
+    override fun language(language: Locale?): EpisodePodcastTranscriptBuilder = apply { this.language = language }
+
+    override fun rel(rel: String?): EpisodePodcastTranscriptBuilder = apply { this.rel = rel }
+
+    override val hasEnoughDataToBuild: Boolean
+        get() = ::urlValue.isInitialized && ::typeValue.isInitialized
+
+    override fun build(): Episode.Podcast.Transcript? {
+        if (!hasEnoughDataToBuild) {
+            return null
+        }
+
+        return Episode.Podcast.Transcript(urlValue, typeValue, language, rel)
+    }
+}

--- a/src/main/kotlin/io/hemin/wien/builder/validating/podcast/ValidatingPodcastBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/validating/podcast/ValidatingPodcastBuilder.kt
@@ -13,6 +13,9 @@ import io.hemin.wien.builder.podcast.PodcastFeedpressBuilder
 import io.hemin.wien.builder.podcast.PodcastFyydBuilder
 import io.hemin.wien.builder.podcast.PodcastGooglePlayBuilder
 import io.hemin.wien.builder.podcast.PodcastITunesBuilder
+import io.hemin.wien.builder.podcast.PodcastPodcastBuilder
+import io.hemin.wien.builder.podcast.PodcastPodcastFundingBuilder
+import io.hemin.wien.builder.podcast.PodcastPodcastLockedBuilder
 import io.hemin.wien.builder.validating.ValidatingHrefOnlyImageBuilder
 import io.hemin.wien.builder.validating.ValidatingITunesStyleCategoryBuilder
 import io.hemin.wien.builder.validating.ValidatingLinkBuilder
@@ -41,15 +44,17 @@ internal class ValidatingPodcastBuilder : PodcastBuilder {
 
     private val episodeBuilders: MutableList<EpisodeBuilder> = mutableListOf()
 
-    override val iTunes: PodcastITunesBuilder = ValidatingPodcastITunesBuilder()
+    override val iTunesBuilder: PodcastITunesBuilder = ValidatingPodcastITunesBuilder()
 
-    override val atom: PodcastAtomBuilder = ValidatingPodcastAtomBuilder()
+    override val atomBuilder: PodcastAtomBuilder = ValidatingPodcastAtomBuilder()
 
-    override val fyyd: PodcastFyydBuilder = ValidatingPodcastFyydBuilder()
+    override val fyydBuilder: PodcastFyydBuilder = ValidatingPodcastFyydBuilder()
 
-    override val feedpress: PodcastFeedpressBuilder = ValidatingPodcastFeedpressBuilder()
+    override val feedpressBuilder: PodcastFeedpressBuilder = ValidatingPodcastFeedpressBuilder()
 
-    override val googlePlay: PodcastGooglePlayBuilder = ValidatingPodcastGooglePlayBuilder()
+    override val googlePlayBuilder: PodcastGooglePlayBuilder = ValidatingPodcastGooglePlayBuilder()
+
+    override val podcastBuilder: PodcastPodcastBuilder = ValidatingPodcastPodcastBuilder()
 
     override fun title(title: String): PodcastBuilder = apply { this.titleValue = title }
 
@@ -93,7 +98,11 @@ internal class ValidatingPodcastBuilder : PodcastBuilder {
 
     override fun createRssCategoryBuilder(): RssCategoryBuilder = ValidatingRssCategoryBuilder()
 
-    override fun createITunesCategoryBuilder(): ITunesStyleCategoryBuilder = ValidatingITunesStyleCategoryBuilder()
+    override fun createITunesStyleCategoryBuilder(): ITunesStyleCategoryBuilder = ValidatingITunesStyleCategoryBuilder()
+
+    override fun createPodcastPodcastLockedBuilder(): PodcastPodcastLockedBuilder = ValidatingPodcastPodcastLockedBuilder()
+
+    override fun createPodcastPodcastFundingBuilder(): PodcastPodcastFundingBuilder = ValidatingPodcastPodcastFundingBuilder()
 
     override val hasEnoughDataToBuild: Boolean
         get() = episodeBuilders.any { it.hasEnoughDataToBuild } &&
@@ -120,12 +129,13 @@ internal class ValidatingPodcastBuilder : PodcastBuilder {
             webMaster = webMaster,
             image = imageBuilder?.build(),
             episodes = builtEpisodes,
-            iTunes = iTunes.build(),
-            atom = atom.build(),
-            fyyd = fyyd.build(),
-            feedpress = feedpress.build(),
-            googlePlay = googlePlay.build(),
-            categories = categoryBuilders.mapNotNull { it.build() }
+            iTunes = iTunesBuilder.build(),
+            atom = atomBuilder.build(),
+            fyyd = fyydBuilder.build(),
+            feedpress = feedpressBuilder.build(),
+            googlePlay = googlePlayBuilder.build(),
+            categories = categoryBuilders.mapNotNull { it.build() },
+            podcast = podcastBuilder.build()
         )
     }
 }

--- a/src/main/kotlin/io/hemin/wien/builder/validating/podcast/ValidatingPodcastPodcastBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/validating/podcast/ValidatingPodcastPodcastBuilder.kt
@@ -1,0 +1,33 @@
+package io.hemin.wien.builder.validating.podcast
+
+import io.hemin.wien.builder.podcast.PodcastPodcastBuilder
+import io.hemin.wien.builder.podcast.PodcastPodcastFundingBuilder
+import io.hemin.wien.builder.podcast.PodcastPodcastLockedBuilder
+import io.hemin.wien.model.Podcast
+
+internal class ValidatingPodcastPodcastBuilder : PodcastPodcastBuilder {
+
+    private lateinit var lockedBuilderValue: PodcastPodcastLockedBuilder
+    private val fundingBuilders: MutableList<PodcastPodcastFundingBuilder> = mutableListOf()
+
+    override fun lockedBuilder(lockedBuilder: PodcastPodcastLockedBuilder): PodcastPodcastBuilder = apply {
+        this.lockedBuilderValue = lockedBuilder
+    }
+
+    override fun addFundingBuilder(fundingBuilder: PodcastPodcastFundingBuilder): PodcastPodcastBuilder = apply {
+        fundingBuilders.add(fundingBuilder)
+    }
+
+    override val hasEnoughDataToBuild: Boolean
+        get() = (::lockedBuilderValue.isInitialized && lockedBuilderValue.hasEnoughDataToBuild) ||
+            fundingBuilders.any { it.hasEnoughDataToBuild }
+
+    override fun build(): Podcast.Podcast? {
+        if (!hasEnoughDataToBuild) {
+            return null
+        }
+
+        val locked = if (::lockedBuilderValue.isInitialized) lockedBuilderValue.build() else null
+        return Podcast.Podcast(locked, fundingBuilders.mapNotNull { it.build() })
+    }
+}

--- a/src/main/kotlin/io/hemin/wien/builder/validating/podcast/ValidatingPodcastPodcastFundingBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/validating/podcast/ValidatingPodcastPodcastFundingBuilder.kt
@@ -1,0 +1,29 @@
+package io.hemin.wien.builder.validating.podcast
+
+import io.hemin.wien.builder.podcast.PodcastPodcastFundingBuilder
+import io.hemin.wien.model.Podcast
+
+internal class ValidatingPodcastPodcastFundingBuilder : PodcastPodcastFundingBuilder {
+
+    private lateinit var urlValue: String
+    private lateinit var messageValue: String
+
+    override fun url(url: String): PodcastPodcastFundingBuilder = apply {
+        this.urlValue = url
+    }
+
+    override fun message(message: String): PodcastPodcastFundingBuilder = apply {
+        this.messageValue = message
+    }
+
+    override val hasEnoughDataToBuild: Boolean
+        get() = ::urlValue.isInitialized && ::messageValue.isInitialized
+
+    override fun build(): Podcast.Podcast.Funding? {
+        if (!hasEnoughDataToBuild) {
+            return null
+        }
+
+        return Podcast.Podcast.Funding(urlValue, messageValue)
+    }
+}

--- a/src/main/kotlin/io/hemin/wien/builder/validating/podcast/ValidatingPodcastPodcastLockedBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/validating/podcast/ValidatingPodcastPodcastLockedBuilder.kt
@@ -1,0 +1,30 @@
+package io.hemin.wien.builder.validating.podcast
+
+import io.hemin.wien.builder.podcast.PodcastPodcastLockedBuilder
+import io.hemin.wien.model.Podcast
+
+internal class ValidatingPodcastPodcastLockedBuilder : PodcastPodcastLockedBuilder {
+
+    private lateinit var ownerValue: String
+    private var locked: Boolean? = null
+
+    override fun owner(owner: String): PodcastPodcastLockedBuilder = apply {
+        this.ownerValue = owner
+    }
+
+    override fun locked(locked: Boolean): PodcastPodcastLockedBuilder = apply {
+        this.locked = locked
+    }
+
+    override val hasEnoughDataToBuild: Boolean
+        get() = ::ownerValue.isInitialized && locked != null
+
+    override fun build(): Podcast.Podcast.Locked? {
+        if (!hasEnoughDataToBuild) {
+            return null
+        }
+
+        val lockedValue = locked ?: throw IllegalStateException("The locked flag is not set, while hasEnoughDataToBuild == true")
+        return Podcast.Podcast.Locked(ownerValue, lockedValue)
+    }
+}

--- a/src/main/kotlin/io/hemin/wien/dom/DomExtensions.kt
+++ b/src/main/kotlin/io/hemin/wien/dom/DomExtensions.kt
@@ -1,6 +1,7 @@
 package io.hemin.wien.dom
 
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.FeedNamespace.Companion.matches
 import io.hemin.wien.util.trimmedOrNullIfBlank
 import org.w3c.dom.Attr
 import org.w3c.dom.Element
@@ -14,7 +15,7 @@ internal fun Node.findElementByName(
     namespace: FeedNamespace? = null,
     filter: (Node) -> Boolean = { true }
 ) = childNodes.asListOfNodes()
-    .firstOrNull { it.getTagName() == name && it.namespaceURI == namespace?.uri && filter(it) }
+    .firstOrNull { it.getTagName() == name && namespace.matches(it.namespaceURI) && filter(it) }
     ?.asElement()
 
 private fun Node.getTagName(): String? = when (this) {

--- a/src/main/kotlin/io/hemin/wien/dom/DomParsingExtensions.kt
+++ b/src/main/kotlin/io/hemin/wien/dom/DomParsingExtensions.kt
@@ -7,6 +7,7 @@ import io.hemin.wien.builder.RssCategoryBuilder
 import io.hemin.wien.builder.RssImageBuilder
 import io.hemin.wien.parser.DateParser
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.FeedNamespace.Companion.matches
 import io.hemin.wien.util.trimmedOrNullIfBlank
 import org.w3c.dom.Element
 import org.w3c.dom.Node
@@ -72,7 +73,7 @@ internal fun Node.parseAsTemporalAccessor(): TemporalAccessor? = DateParser.pars
  */
 internal fun Node.toRssImageBuilder(imageBuilder: RssImageBuilder, namespace: FeedNamespace? = null): RssImageBuilder {
     for (node in childNodes.asListOfNodes()) {
-        if (node.namespaceURI != namespace?.uri) continue
+        if (!namespace.matches(node.namespaceURI)) continue
 
         when (node.localName) {
             "description" -> imageBuilder.description(node.textOrNull())
@@ -125,7 +126,7 @@ internal fun Node.toHrefOnlyImageBuilder(imageBuilder: HrefOnlyImageBuilder): Hr
 internal fun Node.toPersonBuilder(personBuilder: PersonBuilder, namespace: FeedNamespace? = null): PersonBuilder {
     for (child in childNodes.asListOfNodes()) {
         if (child !is Element) continue
-        if (child.namespaceURI != namespace?.uri) continue
+        if (!namespace.matches(child.namespaceURI)) continue
         val value: String? = child.textOrNull()
 
         when (child.localName) {

--- a/src/main/kotlin/io/hemin/wien/model/Episode.kt
+++ b/src/main/kotlin/io/hemin/wien/model/Episode.kt
@@ -1,5 +1,6 @@
 package io.hemin.wien.model
 
+import io.hemin.wien.model.Episode.Podcast.Transcript.Type
 import io.hemin.wien.model.Episode.Podlove.SimpleChapter
 import java.time.Duration
 import java.time.temporal.TemporalAccessor
@@ -205,6 +206,7 @@ data class Episode(
      * Model class for data from elements of the Podcast 1.0 namespace that are valid within `<item>` elements.
      *
      * @property transcripts The transcript information for the episode.
+     * @property soundbites The soundbites information for the episode.
      * @property chapters The chapters information for the episode.
      */
     data class Podcast(
@@ -226,7 +228,7 @@ data class Episode(
             val type: Type,
             val language: Locale? = null,
             val rel: String? = null
-        )  {
+        ) {
 
             /**
              * Supported transcript types. See the
@@ -235,12 +237,20 @@ data class Episode(
             enum class Type(val type: String) {
                 /** Plain text, with no timing information. */
                 PLAIN_TEXT("text/plain"),
+
                 /** HTML, potentially with some timing information. */
                 HTML("text/html"),
+
                 /** JSON ,with full timing information. */
                 JSON("application/json"),
+
                 /** SRT, with full timing information. */
-                SRT("application/srt")
+                SRT("application/srt");
+
+                companion object {
+
+                    fun from(rawType: String): Type? = values().find { it.type == rawType }
+                }
             }
         }
 
@@ -259,12 +269,12 @@ data class Episode(
         /**
          * The soundbite information for the episode. Used to automatically extract soundbites from the [Episode.enclosure].
          *
-         * @param start The timestamp at which the soundbite starts.
+         * @param startTime The timestamp at which the soundbite starts.
          * @param duration The duration of the timestamp (recommended between 15 and 120 seconds).
          * @param title A custom title for the soundbite. When null, the [Episode.title] is used.
          */
         data class Soundbite(
-            val start: Duration,
+            val startTime: Duration,
             val duration: Duration,
             val title: String? = null
         )

--- a/src/main/kotlin/io/hemin/wien/model/Episode.kt
+++ b/src/main/kotlin/io/hemin/wien/model/Episode.kt
@@ -1,7 +1,9 @@
 package io.hemin.wien.model
 
 import io.hemin.wien.model.Episode.Podlove.SimpleChapter
+import java.time.Duration
 import java.time.temporal.TemporalAccessor
+import java.util.Locale
 
 /**
  * Model class for all the properties extracted by parser implementations from RSS `<item>` elements.
@@ -22,6 +24,7 @@ import java.time.temporal.TemporalAccessor
  * @property podlove The data from the Podlove standards namespaces, or null if no data from these namespaces were found.
  * @property googlePlay The data from the Google Play namespace, or null if no data from this namespace was found.
  * @property bitlove The data from the Bitlove namespace, or null if no data from this namespace was found.
+ * @property podcast The data from the Podcast namespace, or null if no data from this namespace was found.
  */
 @Suppress("unused")
 data class Episode(
@@ -40,7 +43,8 @@ data class Episode(
     val atom: Atom? = null,
     val podlove: Podlove? = null,
     val googlePlay: GooglePlay? = null,
-    val bitlove: Bitlove? = null
+    val bitlove: Bitlove? = null,
+    val podcast: Podcast? = null
 ) {
 
     /**
@@ -196,4 +200,73 @@ data class Episode(
     data class Bitlove(
         val guid: String
     )
+
+    /**
+     * Model class for data from elements of the Podcast 1.0 namespace that are valid within `<item>` elements.
+     *
+     * @property transcripts The transcript information for the episode.
+     * @property chapters The chapters information for the episode.
+     */
+    data class Podcast(
+        val transcripts: List<Transcript> = emptyList(),
+        val soundbites: List<Soundbite> = emptyList(),
+        val chapters: Chapters? = null
+    ) {
+
+        /**
+         * The transcript for the episode.
+         *
+         * @param url The URL of the episode transcript.
+         * @param type The type of transcript. One of the supported [Type]s.
+         * @param language The transcript language.
+         * @param rel When present and equals to `captions`, the transcript is considered to be a CC, regardless of its [type].
+         */
+        data class Transcript(
+            val url: String,
+            val type: Type,
+            val language: Locale? = null,
+            val rel: String? = null
+        )  {
+
+            /**
+             * Supported transcript types. See the
+             * [reference docs](https://github.com/Podcastindex-org/podcast-namespace/blob/main/transcripts/transcripts.md).
+             */
+            enum class Type(val type: String) {
+                /** Plain text, with no timing information. */
+                PLAIN_TEXT("text/plain"),
+                /** HTML, potentially with some timing information. */
+                HTML("text/html"),
+                /** JSON ,with full timing information. */
+                JSON("application/json"),
+                /** SRT, with full timing information. */
+                SRT("application/srt")
+            }
+        }
+
+        /**
+         * The chapters information for the episode. See the
+         * [reference docs](https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md#chapters).
+         *
+         * @param url The URL for the chapters information.
+         * @param type The MIME type of the chapters file. JSON (`application/json+chapters`) is the preferred format.
+         */
+        data class Chapters(
+            val url: String,
+            val type: String
+        )
+
+        /**
+         * The soundbite information for the episode. Used to automatically extract soundbites from the [Episode.enclosure].
+         *
+         * @param start The timestamp at which the soundbite starts.
+         * @param duration The duration of the timestamp (recommended between 15 and 120 seconds).
+         * @param title A custom title for the soundbite. When null, the [Episode.title] is used.
+         */
+        data class Soundbite(
+            val start: Duration,
+            val duration: Duration,
+            val title: String? = null
+        )
+    }
 }

--- a/src/main/kotlin/io/hemin/wien/model/Episode.kt
+++ b/src/main/kotlin/io/hemin/wien/model/Episode.kt
@@ -234,7 +234,7 @@ data class Episode(
              * Supported transcript types. See the
              * [reference docs](https://github.com/Podcastindex-org/podcast-namespace/blob/main/transcripts/transcripts.md).
              */
-            enum class Type(val type: String) {
+            enum class Type(val rawType: String) {
                 /** Plain text, with no timing information. */
                 PLAIN_TEXT("text/plain"),
 
@@ -249,7 +249,7 @@ data class Episode(
 
                 companion object {
 
-                    fun from(rawType: String): Type? = values().find { it.type == rawType }
+                    fun from(rawType: String): Type? = values().find { it.rawType == rawType }
                 }
             }
         }

--- a/src/main/kotlin/io/hemin/wien/model/Podcast.kt
+++ b/src/main/kotlin/io/hemin/wien/model/Podcast.kt
@@ -24,6 +24,7 @@ import java.time.temporal.TemporalAccessor
  * @property feedpress The data from the Feedpress namespace, or null if no data from this namespace was found.
  * @property googlePlay The data from the Google Play namespace, or null if no data from this namespace was found.
  * @property categories The RSS feed categories, if any.
+ * @property podcast The data from the Podcast namespace, or null if no data from this namespace was found.
  */
 data class Podcast(
     val title: String,
@@ -44,7 +45,8 @@ data class Podcast(
     val fyyd: Fyyd? = null,
     val feedpress: Feedpress? = null,
     val googlePlay: GooglePlay? = null,
-    val categories: List<RssCategory>
+    val categories: List<RssCategory> = emptyList(),
+    val podcast: Podcast? = null
 ) {
 
     /**
@@ -167,4 +169,39 @@ data class Podcast(
         val cssFile: String? = null,
         val link: String? = null
     )
+
+    /**
+     * Model class for data from elements of the Podcast 1.0 namespace that are valid within `<channel>` elements.
+     *
+     * @property locked The lock status of the podcast.
+     * @property funding The funding information for the podcast.
+     */
+    data class Podcast(
+        val locked: Locked? = null,
+        val funding: Funding? = null
+    ) {
+
+        /**
+         * The lock status of the podcast. Tells other podcast platforms whether they are allowed to
+         * import this feed into their systems.
+         *
+         * @param owner An email address that can be used to verify ownership when moving hosting platforms.
+         * @param locked When `true`, the podcast cannot be transferred to a new hosting platform.
+         */
+        data class Locked(
+            val owner: String,
+            val locked: Boolean
+        )
+
+        /**
+         * The funding information for the podcast.
+         *
+         * @param url The URL where listeners can find funding information for the podcast.
+         * @param message The recommended CTA text to show users for the funding link.
+         */
+        data class Funding(
+            val url: String,
+            val message: String
+        )
+    }
 }

--- a/src/main/kotlin/io/hemin/wien/model/Podcast.kt
+++ b/src/main/kotlin/io/hemin/wien/model/Podcast.kt
@@ -178,7 +178,7 @@ data class Podcast(
      */
     data class Podcast(
         val locked: Locked? = null,
-        val funding: Funding? = null
+        val funding: List<Funding> = emptyList()
     ) {
 
         /**

--- a/src/main/kotlin/io/hemin/wien/parser/NamespaceParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/NamespaceParser.kt
@@ -32,10 +32,10 @@ internal abstract class NamespaceParser {
     /**
      * Extract all the data from a `<channel>` child node for the [namespace],
      * adding it to the provided builder as it goes.
-     * **Note:** this method is only ever called when the node
+     * **Note:** this method is only ever called when the [Node] receiver has
+     * the correct namespace, and it is indeed a direct child of `<channel>`.
      *
      * @param builder The builder where all parsed data is added to.
-     * @param this@parseChannelNode The DOM node from which all data is extracted from.
      */
     protected abstract fun Node.parseChannelData(builder: PodcastBuilder)
 

--- a/src/main/kotlin/io/hemin/wien/parser/NamespaceParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/NamespaceParser.kt
@@ -4,6 +4,7 @@ import io.hemin.wien.builder.episode.EpisodeBuilder
 import io.hemin.wien.builder.podcast.PodcastBuilder
 import io.hemin.wien.dom.isDirectChildOf
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.FeedNamespace.Companion.matches
 import org.w3c.dom.Node
 
 /** Base class for XML namespace parser implementations. */
@@ -82,9 +83,9 @@ internal abstract class NamespaceParser {
 
     /**
      * Should return `true` when this parser can parse a given [Node]. By default true when the node namespace
-     * matches the parser's [namespace], checking its [`uri`][FeedNamespace.uri].
+     * matches the parser's [namespace], checking its `uri`s with [FeedNamespace.Companion.matches].
      */
-    protected open fun canParse(node: Node) = node.namespaceURI == this.namespace?.uri
+    protected open fun canParse(node: Node) = this.namespace.matches(node.namespaceURI)
 
     /** Explicitly do nothing. Used for exhaustive when blocks. */
     protected val pass: Unit = Unit

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/AtomParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/AtomParser.kt
@@ -22,15 +22,15 @@ internal class AtomParser : NamespaceParser() {
         when (localName) {
             "contributor" -> {
                 val personBuilder = ifCanBeParsed { toPersonBuilder(builder.createPersonBuilder(), namespace) } ?: return
-                builder.atom.addContributorBuilder(personBuilder)
+                builder.atomBuilder.addContributorBuilder(personBuilder)
             }
             "author" -> {
                 val personBuilder = ifCanBeParsed { toPersonBuilder(builder.createPersonBuilder(), namespace) } ?: return
-                builder.atom.addAuthorBuilder(personBuilder)
+                builder.atomBuilder.addAuthorBuilder(personBuilder)
             }
             "link" -> {
                 val linkBuilder = ifCanBeParsed { toLinkBuilder(builder.createLinkBuilder()) } ?: return
-                builder.atom.addLinkBuilder(linkBuilder)
+                builder.atomBuilder.addLinkBuilder(linkBuilder)
             }
             else -> pass
         }
@@ -40,15 +40,15 @@ internal class AtomParser : NamespaceParser() {
         when (localName) {
             "contributor" -> {
                 val personBuilder = ifCanBeParsed { toPersonBuilder(builder.createPersonBuilder(), namespace) } ?: return
-                builder.atom.addContributorBuilder(personBuilder)
+                builder.atomBuilder.addContributorBuilder(personBuilder)
             }
             "author" -> {
                 val personBuilder = ifCanBeParsed { toPersonBuilder(builder.createPersonBuilder(), namespace) } ?: return
-                builder.atom.addAuthorBuilder(personBuilder)
+                builder.atomBuilder.addAuthorBuilder(personBuilder)
             }
             "link" -> {
-                val linkBuilder = ifCanBeParsed { toLinkBuilder(builder.createLinkBuilder()) } ?: return
-                builder.atom.addLinkBuilder(linkBuilder)
+                val linkBuilder = toLinkBuilder(builder.createLinkBuilder()) ?: return
+                builder.atomBuilder.addLinkBuilder(linkBuilder)
             }
             else -> pass
         }
@@ -57,8 +57,7 @@ internal class AtomParser : NamespaceParser() {
     private fun Node.toLinkBuilder(linkBuilder: LinkBuilder): LinkBuilder? = ifCanBeParsed {
         val href = getAttributeValueByName("href") ?: return@ifCanBeParsed null
 
-        linkBuilder
-            .href(href)
+        linkBuilder.href(href)
             .hrefLang(getAttributeValueByName("hrefLang"))
             .hrefResolved(getAttributeValueByName("hrefResolved"))
             .length(getAttributeValueByName("length"))

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/BitloveParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/BitloveParser.kt
@@ -23,7 +23,7 @@ internal class BitloveParser : NamespaceParser() {
 
     override fun Node.parseItemData(builder: EpisodeBuilder) {
         val guid = findGuid() ?: return
-        builder.bitlove.guid(guid)
+        builder.bitloveBuilder.guid(guid)
     }
 
     private fun Node.findGuid(): String? = getAttributeValueByName("guid", namespace)

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/ContentParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/ContentParser.kt
@@ -24,7 +24,7 @@ internal class ContentParser : NamespaceParser() {
         when (localName) {
             "encoded" -> {
                 val encoded = ifCanBeParsed { textOrNull() } ?: return
-                builder.content.encoded(encoded)
+                builder.contentBuilder.encoded(encoded)
             }
             else -> pass
         }

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/FeedpressParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/FeedpressParser.kt
@@ -18,11 +18,11 @@ internal class FeedpressParser : NamespaceParser() {
 
     override fun Node.parseChannelData(builder: PodcastBuilder) {
         when (localName) {
-            "newsletterId" -> builder.feedpress.newsletterId(ifCanBeParsed { textOrNull() })
-            "locale" -> builder.feedpress.locale(ifCanBeParsed { textOrNull() })
-            "podcastId" -> builder.feedpress.podcastId(ifCanBeParsed { textOrNull() })
-            "cssFile" -> builder.feedpress.cssFile(ifCanBeParsed { textOrNull() })
-            "link" -> builder.feedpress.link(ifCanBeParsed { textOrNull() })
+            "newsletterId" -> builder.feedpressBuilder.newsletterId(ifCanBeParsed { textOrNull() })
+            "locale" -> builder.feedpressBuilder.locale(ifCanBeParsed { textOrNull() })
+            "podcastId" -> builder.feedpressBuilder.podcastId(ifCanBeParsed { textOrNull() })
+            "cssFile" -> builder.feedpressBuilder.cssFile(ifCanBeParsed { textOrNull() })
+            "link" -> builder.feedpressBuilder.link(ifCanBeParsed { textOrNull() })
             else -> pass
         }
     }

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/FyydParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/FyydParser.kt
@@ -20,7 +20,7 @@ internal class FyydParser : NamespaceParser() {
         when (localName) {
             "verify" -> {
                 val verify = ifCanBeParsed { textOrNull() } ?: return
-                builder.fyyd.verify(verify)
+                builder.fyydBuilder.verify(verify)
             }
             else -> pass
         }

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/GooglePlayParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/GooglePlayParser.kt
@@ -21,19 +21,19 @@ internal class GooglePlayParser : NamespaceParser() {
 
     override fun Node.parseChannelData(builder: PodcastBuilder) {
         when (localName) {
-            "author" -> builder.googlePlay.author(ifCanBeParsed { textOrNull() })
-            "owner" -> builder.googlePlay.owner(ifCanBeParsed { textOrNull() })
+            "author" -> builder.googlePlayBuilder.author(ifCanBeParsed { textOrNull() })
+            "owner" -> builder.googlePlayBuilder.owner(ifCanBeParsed { textOrNull() })
             "category" -> {
-                val categoryBuilder = builder.createITunesCategoryBuilder()
+                val categoryBuilder = builder.createITunesStyleCategoryBuilder()
                 val category = ifCanBeParsed { toITunesCategoryBuilder(categoryBuilder, namespace) } ?: return
-                builder.googlePlay.addCategoryBuilder(category)
+                builder.googlePlayBuilder.addCategoryBuilder(category)
             }
-            "description" -> builder.googlePlay.description(ifCanBeParsed { textOrNull() })
-            "explicit" -> builder.googlePlay.explicit(ifCanBeParsed { textAsBooleanOrNull() })
-            "block" -> builder.googlePlay.block(ifCanBeParsed { textAsBooleanOrNull() })
+            "description" -> builder.googlePlayBuilder.description(ifCanBeParsed { textOrNull() })
+            "explicit" -> builder.googlePlayBuilder.explicit(ifCanBeParsed { textAsBooleanOrNull() })
+            "block" -> builder.googlePlayBuilder.block(ifCanBeParsed { textAsBooleanOrNull() })
             "image" -> {
                 val imageBuilder = ifCanBeParsed { toHrefOnlyImageBuilder(builder.createHrefOnlyImageBuilder()) }
-                builder.googlePlay.imageBuilder(imageBuilder)
+                builder.googlePlayBuilder.imageBuilder(imageBuilder)
             }
             else -> pass
         }
@@ -41,12 +41,12 @@ internal class GooglePlayParser : NamespaceParser() {
 
     override fun Node.parseItemData(builder: EpisodeBuilder) {
         when (localName) {
-            "description" -> builder.googlePlay.description(ifCanBeParsed { textOrNull() })
-            "explicit" -> builder.googlePlay.explicit(ifCanBeParsed { textAsBooleanOrNull() })
-            "block" -> builder.googlePlay.block(ifCanBeParsed { textAsBooleanOrNull() })
+            "description" -> builder.googlePlayBuilder.description(ifCanBeParsed { textOrNull() })
+            "explicit" -> builder.googlePlayBuilder.explicit(ifCanBeParsed { textAsBooleanOrNull() })
+            "block" -> builder.googlePlayBuilder.block(ifCanBeParsed { textAsBooleanOrNull() })
             "image" -> {
                 val imageBuilder = ifCanBeParsed { toHrefOnlyImageBuilder(builder.createHrefOnlyImageBuilder()) }
-                builder.googlePlay.imageBuilder(imageBuilder)
+                builder.googlePlayBuilder.imageBuilder(imageBuilder)
             }
             else -> pass
         }

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/ITunesParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/ITunesParser.kt
@@ -24,33 +24,33 @@ internal class ITunesParser : NamespaceParser() {
 
     override fun Node.parseChannelData(builder: PodcastBuilder) {
         when (localName) {
-            "author" -> builder.iTunes.author(ifCanBeParsed { textOrNull() })
-            "block" -> builder.iTunes.block(ifCanBeParsed { textAsBooleanOrNull() })
+            "author" -> builder.iTunesBuilder.author(ifCanBeParsed { textOrNull() })
+            "block" -> builder.iTunesBuilder.block(ifCanBeParsed { textAsBooleanOrNull() })
             "category" -> {
                 val categoryBuilder = ifCanBeParsed {
-                    toITunesCategoryBuilder(builder.createITunesCategoryBuilder(), namespace)
+                    toITunesCategoryBuilder(builder.createITunesStyleCategoryBuilder(), namespace)
                 } ?: return
-                builder.iTunes.addCategoryBuilder(categoryBuilder)
+                builder.iTunesBuilder.addCategoryBuilder(categoryBuilder)
             }
-            "complete" -> builder.iTunes.complete(ifCanBeParsed { textAsBooleanOrNull() })
+            "complete" -> builder.iTunesBuilder.complete(ifCanBeParsed { textAsBooleanOrNull() })
             "explicit" -> {
                 val explicit = ifCanBeParsed { textAsBooleanOrNull() } ?: return
-                builder.iTunes.explicit(explicit)
+                builder.iTunesBuilder.explicit(explicit)
             }
             "image" -> {
                 val image = ifCanBeParsed { toHrefOnlyImageBuilder(builder.createHrefOnlyImageBuilder()) } ?: return
-                builder.iTunes.imageBuilder(image)
+                builder.iTunesBuilder.imageBuilder(image)
             }
-            "keywords" -> builder.iTunes.keywords(ifCanBeParsed { textOrNull() })
+            "keywords" -> builder.iTunesBuilder.keywords(ifCanBeParsed { textOrNull() })
             "owner" -> {
                 val ownerBuilder = ifCanBeParsed { toOwnerBuilder(builder.createPersonBuilder()) }
-                builder.iTunes.ownerBuilder(ownerBuilder)
+                builder.iTunesBuilder.ownerBuilder(ownerBuilder)
             }
-            "subtitle" -> builder.iTunes.subtitle(ifCanBeParsed { textOrNull() })
-            "summary" -> builder.iTunes.summary(ifCanBeParsed { textOrNull() })
-            "type" -> builder.iTunes.type(ifCanBeParsed { textOrNull() })
-            "title" -> builder.iTunes.title(ifCanBeParsed { textOrNull() })
-            "new-feed-url" -> builder.iTunes.newFeedUrl(ifCanBeParsed { textOrNull() })
+            "subtitle" -> builder.iTunesBuilder.subtitle(ifCanBeParsed { textOrNull() })
+            "summary" -> builder.iTunesBuilder.summary(ifCanBeParsed { textOrNull() })
+            "type" -> builder.iTunesBuilder.type(ifCanBeParsed { textOrNull() })
+            "title" -> builder.iTunesBuilder.title(ifCanBeParsed { textOrNull() })
+            "new-feed-url" -> builder.iTunesBuilder.newFeedUrl(ifCanBeParsed { textOrNull() })
             else -> pass
         }
     }
@@ -63,20 +63,20 @@ internal class ITunesParser : NamespaceParser() {
 
     override fun Node.parseItemData(builder: EpisodeBuilder) {
         when (localName) {
-            "block" -> builder.iTunes.block(ifCanBeParsed { textAsBooleanOrNull() })
-            "duration" -> builder.iTunes.duration(ifCanBeParsed { textOrNull() })
-            "episode" -> builder.iTunes.episode(ifCanBeParsed { parseAsInt() })
-            "episodeType" -> builder.iTunes.episodeType(ifCanBeParsed { textOrNull() })
-            "explicit" -> builder.iTunes.explicit(ifCanBeParsed { textAsBooleanOrNull() })
+            "block" -> builder.iTunesBuilder.block(ifCanBeParsed { textAsBooleanOrNull() })
+            "duration" -> builder.iTunesBuilder.duration(ifCanBeParsed { textOrNull() })
+            "episode" -> builder.iTunesBuilder.episode(ifCanBeParsed { parseAsInt() })
+            "episodeType" -> builder.iTunesBuilder.episodeType(ifCanBeParsed { textOrNull() })
+            "explicit" -> builder.iTunesBuilder.explicit(ifCanBeParsed { textAsBooleanOrNull() })
             "image" -> {
                 val imageBuilder = toHrefOnlyImageBuilder(builder.createHrefOnlyImageBuilder())
-                builder.iTunes.imageBuilder(imageBuilder)
+                builder.iTunesBuilder.imageBuilder(imageBuilder)
             }
-            "season" -> builder.iTunes.season(ifCanBeParsed { parseAsInt() })
-            "title" -> builder.iTunes.title(ifCanBeParsed { textOrNull() })
-            "author" -> builder.iTunes.author(ifCanBeParsed { textOrNull() })
-            "subtitle" -> builder.iTunes.subtitle(ifCanBeParsed { textOrNull() })
-            "summary" -> builder.iTunes.summary(ifCanBeParsed { textOrNull() })
+            "season" -> builder.iTunesBuilder.season(ifCanBeParsed { parseAsInt() })
+            "title" -> builder.iTunesBuilder.title(ifCanBeParsed { textOrNull() })
+            "author" -> builder.iTunesBuilder.author(ifCanBeParsed { textOrNull() })
+            "subtitle" -> builder.iTunesBuilder.subtitle(ifCanBeParsed { textOrNull() })
+            "summary" -> builder.iTunesBuilder.summary(ifCanBeParsed { textOrNull() })
             else -> pass
         }
     }

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/PodcastNamespaceParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/PodcastNamespaceParser.kt
@@ -1,0 +1,114 @@
+package io.hemin.wien.parser.namespace
+
+import io.hemin.wien.builder.episode.EpisodeBuilder
+import io.hemin.wien.builder.episode.EpisodePodcastChaptersBuilder
+import io.hemin.wien.builder.episode.EpisodePodcastSoundbiteBuilder
+import io.hemin.wien.builder.episode.EpisodePodcastTranscriptBuilder
+import io.hemin.wien.builder.podcast.PodcastBuilder
+import io.hemin.wien.builder.podcast.PodcastPodcastFundingBuilder
+import io.hemin.wien.builder.podcast.PodcastPodcastLockedBuilder
+import io.hemin.wien.dom.getAttributeByName
+import io.hemin.wien.dom.parseAsBooleanOrNull
+import io.hemin.wien.model.Episode
+import io.hemin.wien.parser.NamespaceParser
+import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.trimmedOrNullIfBlank
+import org.w3c.dom.Node
+import java.time.Duration
+import java.time.format.DateTimeParseException
+
+internal class PodcastNamespaceParser : NamespaceParser() {
+
+    override val namespace: FeedNamespace = FeedNamespace.PODCAST
+
+    override fun Node.parseChannelData(builder: PodcastBuilder) {
+        when (localName) {
+            "locked" -> {
+                val lockedBuilder = ifCanBeParsed { toLockedBuilder(builder.createPodcastPodcastLockedBuilder()) } ?: return
+                builder.podcastBuilder.lockedBuilder(lockedBuilder)
+            }
+            "funding" -> {
+                val fundingBuilder = ifCanBeParsed { toFundingBuilder(builder.createPodcastPodcastFundingBuilder()) } ?: return
+                builder.podcastBuilder.addFundingBuilder(fundingBuilder)
+            }
+            else -> pass
+        }
+    }
+
+    private fun Node.toLockedBuilder(lockedBuilder: PodcastPodcastLockedBuilder): PodcastPodcastLockedBuilder? {
+        val owner = getAttributeByName("owner")?.value.trimmedOrNullIfBlank()
+        val locked = textContent.parseAsBooleanOrNull()
+
+        if (owner == null || locked == null) return null
+        return lockedBuilder.owner(owner)
+            .locked(locked)
+    }
+
+    private fun Node.toFundingBuilder(fundingBuilder: PodcastPodcastFundingBuilder): PodcastPodcastFundingBuilder? {
+        val url = getAttributeByName("url")?.value.trimmedOrNullIfBlank()
+        val message = textContent.trimmedOrNullIfBlank()
+
+        if (url == null || message == null) return null
+        return fundingBuilder.url(url)
+            .message(message)
+    }
+
+    override fun Node.parseItemData(builder: EpisodeBuilder) {
+        when (localName) {
+            "chapters" -> {
+                val chaptersBuilder = ifCanBeParsed { toChaptersBuilder(builder.createEpisodePodcastChaptersBuilder()) } ?: return
+                builder.podcastBuilder.chaptersBuilder(chaptersBuilder)
+            }
+            "soundbite" -> {
+                val soundbiteBuilder = ifCanBeParsed { toSoundbiteBuilder(builder.createEpisodePodcastSoundbiteBuilder()) } ?: return
+                builder.podcastBuilder.addSoundbiteBuilder(soundbiteBuilder)
+            }
+            "transcript" -> {
+                val transcriptBuilder = ifCanBeParsed { toTranscriptBuilder(builder.createEpisodePodcastTranscriptBuilder()) } ?: return
+                builder.podcastBuilder.addTranscriptBuilder(transcriptBuilder)
+            }
+            else -> pass
+        }
+    }
+
+    private fun Node.toChaptersBuilder(chaptersBuilder: EpisodePodcastChaptersBuilder): EpisodePodcastChaptersBuilder? {
+        val url = getAttributeByName("url")?.value.trimmedOrNullIfBlank()
+        val type = getAttributeByName("type")?.value.trimmedOrNullIfBlank()
+
+        if (url == null || type == null) return null
+        return chaptersBuilder.url(url)
+            .type(type)
+    }
+
+    private fun Node.toSoundbiteBuilder(soundbiteBuilder: EpisodePodcastSoundbiteBuilder): EpisodePodcastSoundbiteBuilder? {
+        val startTime = getAttributeByName("startTime")?.value.trimmedOrNullIfBlank().parseAsDurationOrNull()
+        val duration = getAttributeByName("duration")?.value.trimmedOrNullIfBlank().parseAsDurationOrNull()
+        val title = textContent?.trimmedOrNullIfBlank()
+
+        if (startTime == null || duration == null) return null
+        return soundbiteBuilder.startTime(startTime)
+            .duration(duration)
+            .title(title)
+    }
+
+    private fun String?.parseAsDurationOrNull(): Duration? {
+        if (this == null) return null
+
+        return try {
+            Duration.parse("PT${this}S")
+        } catch (e: DateTimeParseException) {
+            null
+        }
+    }
+
+    private fun Node.toTranscriptBuilder(transcriptBuilder: EpisodePodcastTranscriptBuilder): EpisodePodcastTranscriptBuilder? {
+        val url = getAttributeByName("url")?.value.trimmedOrNullIfBlank()
+        val type = getAttributeByName("type")?.value.trimmedOrNullIfBlank()?.let { rawType ->
+            Episode.Podcast.Transcript.Type.from(rawType)
+        }
+
+        if (url == null || type == null) return null
+        return transcriptBuilder.url(url)
+            .type(type)
+    }
+}

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/PodcastNamespaceParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/PodcastNamespaceParser.kt
@@ -16,6 +16,7 @@ import io.hemin.wien.util.trimmedOrNullIfBlank
 import org.w3c.dom.Node
 import java.time.Duration
 import java.time.format.DateTimeParseException
+import java.util.Locale
 
 internal class PodcastNamespaceParser : NamespaceParser() {
 
@@ -106,9 +107,15 @@ internal class PodcastNamespaceParser : NamespaceParser() {
         val type = getAttributeByName("type")?.value.trimmedOrNullIfBlank()?.let { rawType ->
             Episode.Podcast.Transcript.Type.from(rawType)
         }
+        val language = getAttributeByName("language")?.value.trimmedOrNullIfBlank()?.let { rawLocale ->
+            Locale.forLanguageTag(rawLocale)
+        }
+        val rel = getAttributeByName("rel")?.value.trimmedOrNullIfBlank()
 
         if (url == null || type == null) return null
         return transcriptBuilder.url(url)
             .type(type)
+            .language(language)
+            .rel(rel)
     }
 }

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/PodloveSimpleChapterParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/PodloveSimpleChapterParser.kt
@@ -26,7 +26,7 @@ internal class PodloveSimpleChapterParser : NamespaceParser() {
         when (localName) {
             "chapters" -> {
                 val chapters = ifCanBeParsed { toPodloveSimpleChapterBuilders(builder) } ?: return
-                builder.podlove.addSimpleChapterBuilders(chapters)
+                builder.podloveBuilder.addSimpleChapterBuilders(chapters)
             }
             else -> pass
         }

--- a/src/main/kotlin/io/hemin/wien/util/BooleanStringStyle.kt
+++ b/src/main/kotlin/io/hemin/wien/util/BooleanStringStyle.kt
@@ -10,7 +10,11 @@ internal enum class BooleanStringStyle(val trueValue: String, val falseValue: St
      * A true value will be written as `yes`, a false value as `null`. Useful for cases
      * when false values should cause a node to be omitted, as it only supports `yes`.
      */
-    YES_NULL("yes", null)
+    YES_NULL("yes", null),
+    /**
+     * A true value will be written as `yes`, a false value as `no`.
+     */
+    YES_NO("yes", "no")
 }
 
 internal fun Boolean.asBooleanString(style: BooleanStringStyle) =

--- a/src/main/kotlin/io/hemin/wien/util/FeedNamespace.kt
+++ b/src/main/kotlin/io/hemin/wien/util/FeedNamespace.kt
@@ -2,7 +2,8 @@ package io.hemin.wien.util
 
 internal enum class FeedNamespace(
     val prefix: String,
-    val uri: String
+    val uri: String,
+    val otherUris: List<String> = emptyList()
 ) {
     ATOM("atom", "http://www.w3.org/2005/Atom"),
     BITLOVE("bitlove", "http://bitlove.org"),
@@ -12,5 +13,22 @@ internal enum class FeedNamespace(
     GOOGLE_PLAY("googleplay", "http://www.google.com/schemas/play-podcasts/1.0"),
     ITUNES("itunes", "http://www.itunes.com/dtds/podcast-1.0.dtd"),
     PODLOVE_SIMPLE_CHAPTER("psc", "http://podlove.org/simple-chapters"),
-    PODCAST("podcast", "https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md")
+    PODCAST(
+        prefix = "podcast",
+        uri = "https://podcastindex.org/namespace/1.0",
+        otherUris = listOf("https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md")
+    );
+
+    val allUris = listOf(uri) + otherUris
+
+    companion object {
+
+        fun FeedNamespace?.matches(uri: String?): Boolean =
+            when {
+                this == null -> uri == null
+                this.uri == uri -> true
+                otherUris.isEmpty() -> false
+                else -> otherUris.any { it == uri }
+            }
+    }
 }

--- a/src/main/kotlin/io/hemin/wien/util/FeedNamespace.kt
+++ b/src/main/kotlin/io/hemin/wien/util/FeedNamespace.kt
@@ -11,5 +11,6 @@ internal enum class FeedNamespace(
     FYYD("fyyd", "https://fyyd.de/fyyd-ns/"),
     GOOGLE_PLAY("googleplay", "http://www.google.com/schemas/play-podcasts/1.0"),
     ITUNES("itunes", "http://www.itunes.com/dtds/podcast-1.0.dtd"),
-    PODLOVE_SIMPLE_CHAPTER("psc", "http://podlove.org/simple-chapters")
+    PODLOVE_SIMPLE_CHAPTER("psc", "http://podlove.org/simple-chapters"),
+    PODCAST("podcast", "https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md")
 }

--- a/src/main/kotlin/io/hemin/wien/util/StringExtensions.kt
+++ b/src/main/kotlin/io/hemin/wien/util/StringExtensions.kt
@@ -1,7 +1,8 @@
 package io.hemin.wien.util
 
 /** Returns the trimmed string, or null if it was blank to begin with. */
-internal fun String.trimmedOrNullIfBlank(): String? {
+internal fun String?.trimmedOrNullIfBlank(): String? {
+    if (this == null) return null
     val trimmed = trim()
     return if (trimmed.isNotEmpty()) trimmed else null
 }

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/PodcastNamespaceWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/PodcastNamespaceWriter.kt
@@ -81,6 +81,6 @@ internal class PodcastNamespaceWriter : NamespaceWriter() {
         if (toMillisPart() == 0) {
             seconds.toString()
         } else {
-            "${seconds}.${toMillisPart().toString().padStart(3, '0')}"
+            "$seconds.${toMillisPart().toString().padStart(3, '0')}"
         }
 }

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/PodcastNamespaceWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/PodcastNamespaceWriter.kt
@@ -1,0 +1,86 @@
+package io.hemin.wien.writer.namespace
+
+import io.hemin.wien.dom.appendElement
+import io.hemin.wien.model.Episode
+import io.hemin.wien.model.Podcast
+import io.hemin.wien.util.BooleanStringStyle
+import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.asBooleanString
+import io.hemin.wien.writer.NamespaceWriter
+import org.w3c.dom.Element
+import java.time.Duration
+
+/**
+ * Writer implementation for the Podcast namespace.
+ *
+ * The namespace URI is: `https://podcastindex.org/namespace/1.0`
+ * but `https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md`
+ * should also be accepted as equivalent. TODO allow both NS
+ */
+internal class PodcastNamespaceWriter : NamespaceWriter() {
+
+    override val namespace = FeedNamespace.PODCAST
+
+    override fun Element.appendPodcastData(podcast: Podcast) {
+        val podcastNs = podcast.podcast ?: return
+
+        if (podcastNs.locked != null && podcastNs.locked.owner.isNotBlank()) {
+            appendElement("locked", namespace) {
+                setAttribute("owner", podcastNs.locked.owner.trim())
+                textContent = podcastNs.locked.locked.asBooleanString(BooleanStringStyle.YES_NO)
+            }
+        }
+
+        for (funding in podcastNs.funding) {
+            if (funding.url.isBlank() || funding.message.isBlank()) continue
+
+            appendElement("funding", namespace) {
+                setAttribute("url", funding.url.trim())
+                textContent = funding.message.trim()
+            }
+        }
+    }
+
+    override fun Element.appendEpisodeData(episode: Episode) {
+        val podcastNs = episode.podcast ?: return
+
+        if (podcastNs.chapters != null && podcastNs.chapters.canBeWritten()) {
+            appendElement("chapters", namespace) {
+                setAttribute("url", podcastNs.chapters.url.trim())
+                setAttribute("type", podcastNs.chapters.type.trim())
+            }
+        }
+
+        for (transcript in podcastNs.transcripts) {
+            if (transcript.url.isBlank()) continue
+
+            appendElement("transcript", namespace) {
+                setAttribute("url", transcript.url.trim())
+                setAttribute("type", transcript.type.rawType.trim())
+                if (transcript.language != null) setAttribute("language", transcript.language.toLanguageTag())
+                if (transcript.rel != null) setAttribute("rel", transcript.rel.trim())
+            }
+        }
+
+        for (soundbite in podcastNs.soundbites) {
+            if (soundbite.startTime.isNegative || !soundbite.duration.isPositive()) continue
+
+            appendElement("soundbite", namespace) {
+                setAttribute("startTime", soundbite.startTime.toSecondsString())
+                setAttribute("duration", soundbite.duration.toSecondsString())
+                if (soundbite.title != null) textContent = soundbite.title.trim()
+            }
+        }
+    }
+
+    private fun Episode.Podcast.Chapters.canBeWritten() = url.isNotBlank() && type.isNotBlank()
+
+    private fun Duration.isPositive(): Boolean = !(isNegative || isZero)
+
+    private fun Duration.toSecondsString(): String =
+        if (toMillisPart() == 0) {
+            seconds.toString()
+        } else {
+            "${seconds}.${toMillisPart().toString().padStart(3, '0')}"
+        }
+}

--- a/src/test/kotlin/io/hemin/wien/Assertions.kt
+++ b/src/test/kotlin/io/hemin/wien/Assertions.kt
@@ -7,6 +7,7 @@ import io.hemin.wien.builder.Builder
 import io.hemin.wien.dom.asListOfNodes
 import io.hemin.wien.dom.asString
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.FeedNamespace.Companion.matches
 import org.w3c.dom.Attr
 import org.w3c.dom.Element
 import org.w3c.dom.Node
@@ -140,5 +141,5 @@ internal fun Assert<Attr>.hasValue(expected: String) = given { element ->
 internal fun Assert<Node>.childNodesNamed(localName: String, namespace: FeedNamespace? = null) =
     transform { node ->
         node.childNodes.asListOfNodes()
-            .filter { it.localName == localName && it.namespaceURI == namespace?.uri }
+            .filter { it.localName == localName && namespace.matches(it.namespaceURI) }
     }

--- a/src/test/kotlin/io/hemin/wien/Assertions.kt
+++ b/src/test/kotlin/io/hemin/wien/Assertions.kt
@@ -1,6 +1,7 @@
 package io.hemin.wien
 
 import assertk.Assert
+import assertk.assertions.isNotEmpty
 import assertk.assertions.support.expected
 import io.hemin.wien.builder.Builder
 import io.hemin.wien.dom.asListOfNodes
@@ -62,6 +63,7 @@ internal fun Assert<File>.isNotEmpty() = given { file ->
 
 /** Asserts none of the [Builder]s [`hasEnoughDataToBuild`][Builder.hasEnoughDataToBuild] is `true`. */
 internal fun Assert<List<Builder<*>>>.noneHasEnoughDataToBuild() = given { builders ->
+    assertThat(builders, this.name).isNotEmpty()
     if (builders.any { it.hasEnoughDataToBuild }) {
         expected(
             message = "none of the builders to have hasEnoughDataToBuild == true",

--- a/src/test/kotlin/io/hemin/wien/PodcastRssWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/PodcastRssWriterTest.kt
@@ -1,5 +1,6 @@
 package io.hemin.wien
 
+import assertk.assertAll
 import assertk.assertThat
 import assertk.assertions.exists
 import assertk.assertions.isEqualTo
@@ -16,7 +17,7 @@ internal class PodcastRssWriterTest {
         val podcast = aPodcast()
         PodcastRssWriter.writeRssFeed(podcast, file)
 
-        assertk.assertAll {
+        assertAll {
             assertThat(file, "written file").exists()
             assertThat(file, "written file").isNotEmpty()
 

--- a/src/test/kotlin/io/hemin/wien/PodcastRssWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/PodcastRssWriterTest.kt
@@ -21,7 +21,8 @@ internal class PodcastRssWriterTest {
             assertThat(file, "written file").exists()
             assertThat(file, "written file").isNotEmpty()
 
-            assertThat(PodcastRssParser.parse(file), "written file matches original Podcast").isEqualTo(podcast)
+            val reparsedPodcast = PodcastRssParser.parse(file)
+            assertThat(reparsedPodcast, "written file matches original Podcast").isEqualTo(podcast)
 
             file.delete()
         }

--- a/src/test/kotlin/io/hemin/wien/builder/fake/FakeBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/FakeBuilder.kt
@@ -9,7 +9,7 @@ import io.hemin.wien.builder.Builder
  */
 internal abstract class FakeBuilder<T> : Builder<T> {
 
-    override val hasEnoughDataToBuild = false
+    final override val hasEnoughDataToBuild = false
 
     /**
      * Calling this method will always make the test fail. Inspect the

--- a/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodeBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodeBuilder.kt
@@ -8,7 +8,6 @@ import io.hemin.wien.builder.RssCategoryBuilder
 import io.hemin.wien.builder.episode.EpisodeBuilder
 import io.hemin.wien.builder.episode.EpisodeEnclosureBuilder
 import io.hemin.wien.builder.episode.EpisodeGuidBuilder
-import io.hemin.wien.builder.episode.EpisodePodcastBuilder
 import io.hemin.wien.builder.episode.EpisodePodcastChaptersBuilder
 import io.hemin.wien.builder.episode.EpisodePodcastSoundbiteBuilder
 import io.hemin.wien.builder.episode.EpisodePodcastTranscriptBuilder
@@ -116,6 +115,7 @@ internal class FakeEpisodeBuilder : FakeBuilder<Episode>(), EpisodeBuilder {
         if (podloveBuilder != other.podloveBuilder) return false
         if (googlePlayBuilder != other.googlePlayBuilder) return false
         if (bitloveBuilder != other.bitloveBuilder) return false
+        if (podcastBuilder != other.podcastBuilder) return false
 
         return true
     }
@@ -137,11 +137,13 @@ internal class FakeEpisodeBuilder : FakeBuilder<Episode>(), EpisodeBuilder {
         result = 31 * result + podloveBuilder.hashCode()
         result = 31 * result + googlePlayBuilder.hashCode()
         result = 31 * result + bitloveBuilder.hashCode()
+        result = 31 * result + podcastBuilder.hashCode()
         return result
     }
 
     override fun toString() =
         "FakeEpisodeBuilder(titleValue=$titleValue, enclosureBuilderValue=$enclosureBuilderValue, link=$link, description=$description, " +
-            "author=$author, categories=$categoryBuilders, comments=$comments, guidBuilder=$guidBuilder, pubDate=$pubDate, source=$source, " +
-            "content=$contentBuilder, iTunes=$iTunesBuilder, atom=$atomBuilder, podlove=$podloveBuilder, googlePlay=$googlePlayBuilder, bitlove=$bitloveBuilder)"
+            "author=$author, categoryBuilders=$categoryBuilders, comments=$comments, guidBuilder=$guidBuilder, pubDate=$pubDate, source=$source, " +
+            "contentBuilder=$contentBuilder, iTunesBuilder=$iTunesBuilder, atomBuilder=$atomBuilder, podloveBuilder=$podloveBuilder, " +
+            "googlePlayBuilder=$googlePlayBuilder, bitloveBuilder=$bitloveBuilder, podcastBuilder=$podcastBuilder)"
 }

--- a/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodeBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodeBuilder.kt
@@ -8,6 +8,10 @@ import io.hemin.wien.builder.RssCategoryBuilder
 import io.hemin.wien.builder.episode.EpisodeBuilder
 import io.hemin.wien.builder.episode.EpisodeEnclosureBuilder
 import io.hemin.wien.builder.episode.EpisodeGuidBuilder
+import io.hemin.wien.builder.episode.EpisodePodcastBuilder
+import io.hemin.wien.builder.episode.EpisodePodcastChaptersBuilder
+import io.hemin.wien.builder.episode.EpisodePodcastSoundbiteBuilder
+import io.hemin.wien.builder.episode.EpisodePodcastTranscriptBuilder
 import io.hemin.wien.builder.episode.EpisodePodloveSimpleChapterBuilder
 import io.hemin.wien.builder.fake.FakeBuilder
 import io.hemin.wien.builder.fake.FakeHrefOnlyImageBuilder
@@ -32,17 +36,19 @@ internal class FakeEpisodeBuilder : FakeBuilder<Episode>(), EpisodeBuilder {
     var pubDate: TemporalAccessor? = null
     var source: String? = null
 
-    override val content: FakeEpisodeContentBuilder = FakeEpisodeContentBuilder()
+    override val contentBuilder: FakeEpisodeContentBuilder = FakeEpisodeContentBuilder()
 
-    override val iTunes: FakeEpisodeITunesBuilder = FakeEpisodeITunesBuilder()
+    override val iTunesBuilder: FakeEpisodeITunesBuilder = FakeEpisodeITunesBuilder()
 
-    override val atom: FakeEpisodeAtomBuilder = FakeEpisodeAtomBuilder()
+    override val atomBuilder: FakeEpisodeAtomBuilder = FakeEpisodeAtomBuilder()
 
-    override val podlove: FakeEpisodePodloveBuilder = FakeEpisodePodloveBuilder()
+    override val podloveBuilder: FakeEpisodePodloveBuilder = FakeEpisodePodloveBuilder()
 
-    override val googlePlay: FakeEpisodeGooglePlayBuilder = FakeEpisodeGooglePlayBuilder()
+    override val googlePlayBuilder: FakeEpisodeGooglePlayBuilder = FakeEpisodeGooglePlayBuilder()
 
-    override val bitlove: FakeEpisodeBitloveBuilder = FakeEpisodeBitloveBuilder()
+    override val bitloveBuilder: FakeEpisodeBitloveBuilder = FakeEpisodeBitloveBuilder()
+
+    override val podcastBuilder: FakeEpisodePodcastBuilder = FakeEpisodePodcastBuilder()
 
     override fun title(title: String): EpisodeBuilder = apply { this.titleValue = title }
 
@@ -82,7 +88,13 @@ internal class FakeEpisodeBuilder : FakeBuilder<Episode>(), EpisodeBuilder {
 
     override fun createRssCategoryBuilder(): RssCategoryBuilder = FakeRssCategoryBuilder()
 
-    override fun createITunesCategoryBuilder(): ITunesStyleCategoryBuilder = FakeITunesStyleCategoryBuilder()
+    override fun createITunesStyleCategoryBuilder(): ITunesStyleCategoryBuilder = FakeITunesStyleCategoryBuilder()
+
+    override fun createEpisodePodcastTranscriptBuilder(): EpisodePodcastTranscriptBuilder = FakeEpisodePodcastTranscriptBuilder()
+
+    override fun createEpisodePodcastChaptersBuilder(): EpisodePodcastChaptersBuilder = FakeEpisodePodcastChaptersBuilder()
+
+    override fun createEpisodePodcastSoundbiteBuilder(): EpisodePodcastSoundbiteBuilder = FakeEpisodePodcastSoundbiteBuilder()
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -98,12 +110,12 @@ internal class FakeEpisodeBuilder : FakeBuilder<Episode>(), EpisodeBuilder {
         if (guidBuilder != other.guidBuilder) return false
         if (pubDate != other.pubDate) return false
         if (source != other.source) return false
-        if (content != other.content) return false
-        if (iTunes != other.iTunes) return false
-        if (atom != other.atom) return false
-        if (podlove != other.podlove) return false
-        if (googlePlay != other.googlePlay) return false
-        if (bitlove != other.bitlove) return false
+        if (contentBuilder != other.contentBuilder) return false
+        if (iTunesBuilder != other.iTunesBuilder) return false
+        if (atomBuilder != other.atomBuilder) return false
+        if (podloveBuilder != other.podloveBuilder) return false
+        if (googlePlayBuilder != other.googlePlayBuilder) return false
+        if (bitloveBuilder != other.bitloveBuilder) return false
 
         return true
     }
@@ -119,17 +131,17 @@ internal class FakeEpisodeBuilder : FakeBuilder<Episode>(), EpisodeBuilder {
         result = 31 * result + (guidBuilder?.hashCode() ?: 0)
         result = 31 * result + (pubDate?.hashCode() ?: 0)
         result = 31 * result + (source?.hashCode() ?: 0)
-        result = 31 * result + content.hashCode()
-        result = 31 * result + iTunes.hashCode()
-        result = 31 * result + atom.hashCode()
-        result = 31 * result + podlove.hashCode()
-        result = 31 * result + googlePlay.hashCode()
-        result = 31 * result + bitlove.hashCode()
+        result = 31 * result + contentBuilder.hashCode()
+        result = 31 * result + iTunesBuilder.hashCode()
+        result = 31 * result + atomBuilder.hashCode()
+        result = 31 * result + podloveBuilder.hashCode()
+        result = 31 * result + googlePlayBuilder.hashCode()
+        result = 31 * result + bitloveBuilder.hashCode()
         return result
     }
 
     override fun toString() =
         "FakeEpisodeBuilder(titleValue=$titleValue, enclosureBuilderValue=$enclosureBuilderValue, link=$link, description=$description, " +
             "author=$author, categories=$categoryBuilders, comments=$comments, guidBuilder=$guidBuilder, pubDate=$pubDate, source=$source, " +
-            "content=$content, iTunes=$iTunes, atom=$atom, podlove=$podlove, googlePlay=$googlePlay, bitlove=$bitlove)"
+            "content=$contentBuilder, iTunes=$iTunesBuilder, atom=$atomBuilder, podlove=$podloveBuilder, googlePlay=$googlePlayBuilder, bitlove=$bitloveBuilder)"
 }

--- a/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodePodcastBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodePodcastBuilder.kt
@@ -45,5 +45,6 @@ internal class FakeEpisodePodcastBuilder : FakeBuilder<Episode.Podcast>(), Episo
     }
 
     override fun toString() =
-        "FakeEpisodePodcastBuilder(chaptersBuilder=$chaptersBuilderValue, transcriptBuilders=$transcriptBuilders, soundbiteBuilders=$soundbiteBuilders)"
+        "FakeEpisodePodcastBuilder(chaptersBuilder=$chaptersBuilderValue, transcriptBuilders=$transcriptBuilders, " +
+            "soundbiteBuilders=$soundbiteBuilders)"
 }

--- a/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodePodcastBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodePodcastBuilder.kt
@@ -1,0 +1,49 @@
+package io.hemin.wien.builder.fake.episode
+
+import io.hemin.wien.builder.episode.EpisodePodcastBuilder
+import io.hemin.wien.builder.episode.EpisodePodcastChaptersBuilder
+import io.hemin.wien.builder.episode.EpisodePodcastSoundbiteBuilder
+import io.hemin.wien.builder.episode.EpisodePodcastTranscriptBuilder
+import io.hemin.wien.builder.fake.FakeBuilder
+import io.hemin.wien.model.Episode
+
+internal class FakeEpisodePodcastBuilder : FakeBuilder<Episode.Podcast>(), EpisodePodcastBuilder {
+
+    var chaptersBuilderValue: EpisodePodcastChaptersBuilder? = null
+
+    val transcriptBuilders: MutableList<EpisodePodcastTranscriptBuilder> = mutableListOf()
+    val soundbiteBuilders: MutableList<EpisodePodcastSoundbiteBuilder> = mutableListOf()
+
+    override fun chaptersBuilder(chaptersBuilder: EpisodePodcastChaptersBuilder): EpisodePodcastBuilder = apply {
+        this.chaptersBuilderValue = chaptersBuilder
+    }
+
+    override fun addSoundbiteBuilder(soundbiteBuilder: EpisodePodcastSoundbiteBuilder): EpisodePodcastBuilder = apply {
+        soundbiteBuilders.add(soundbiteBuilder)
+    }
+
+    override fun addTranscriptBuilder(transcriptBuilder: EpisodePodcastTranscriptBuilder): EpisodePodcastBuilder = apply {
+        transcriptBuilders.add(transcriptBuilder)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is FakeEpisodePodcastBuilder) return false
+
+        if (chaptersBuilderValue != other.chaptersBuilderValue) return false
+        if (transcriptBuilders != other.transcriptBuilders) return false
+        if (soundbiteBuilders != other.soundbiteBuilders) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = chaptersBuilderValue?.hashCode() ?: 0
+        result = 31 * result + transcriptBuilders.hashCode()
+        result = 31 * result + soundbiteBuilders.hashCode()
+        return result
+    }
+
+    override fun toString() =
+        "FakeEpisodePodcastBuilder(chaptersBuilder=$chaptersBuilderValue, transcriptBuilders=$transcriptBuilders, soundbiteBuilders=$soundbiteBuilders)"
+}

--- a/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodePodcastChaptersBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodePodcastChaptersBuilder.kt
@@ -1,0 +1,33 @@
+package io.hemin.wien.builder.fake.episode
+
+import io.hemin.wien.builder.episode.EpisodePodcastChaptersBuilder
+import io.hemin.wien.builder.fake.FakeBuilder
+import io.hemin.wien.model.Episode
+
+internal class FakeEpisodePodcastChaptersBuilder : FakeBuilder<Episode.Podcast.Chapters>(), EpisodePodcastChaptersBuilder {
+
+    var url: String? = null
+    var type: String? = null
+
+    override fun url(url: String): EpisodePodcastChaptersBuilder = apply { this.url = url }
+
+    override fun type(type: String): EpisodePodcastChaptersBuilder = apply { this.type = type }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is FakeEpisodePodcastChaptersBuilder) return false
+
+        if (url != other.url) return false
+        if (type != other.type) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = url?.hashCode() ?: 0
+        result = 31 * result + (type?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString() = "FakeEpisodePodcastChaptersBuilder(url=$url, type=$type)"
+}

--- a/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodePodcastSoundbiteBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodePodcastSoundbiteBuilder.kt
@@ -1,0 +1,39 @@
+package io.hemin.wien.builder.fake.episode
+
+import io.hemin.wien.builder.episode.EpisodePodcastSoundbiteBuilder
+import io.hemin.wien.builder.fake.FakeBuilder
+import io.hemin.wien.model.Episode
+import java.time.Duration
+
+internal class FakeEpisodePodcastSoundbiteBuilder : FakeBuilder<Episode.Podcast.Soundbite>(), EpisodePodcastSoundbiteBuilder {
+
+    var startTime: Duration? = null
+    var duration: Duration? = null
+    var title: String? = null
+
+    override fun startTime(startTime: Duration): EpisodePodcastSoundbiteBuilder = apply { this.startTime = startTime }
+
+    override fun duration(duration: Duration): EpisodePodcastSoundbiteBuilder = apply { this.duration = duration }
+
+    override fun title(title: String?): EpisodePodcastSoundbiteBuilder = apply { this.title = title }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is FakeEpisodePodcastSoundbiteBuilder) return false
+
+        if (startTime != other.startTime) return false
+        if (duration != other.duration) return false
+        if (title != other.title) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = startTime?.hashCode() ?: 0
+        result = 31 * result + (duration?.hashCode() ?: 0)
+        result = 31 * result + (title?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString() = "FakeEpisodePodcastSoundbiteBuilder(startTime=$startTime, duration=$duration, title=$title)"
+}

--- a/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodePodcastTranscriptBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodePodcastTranscriptBuilder.kt
@@ -1,0 +1,44 @@
+package io.hemin.wien.builder.fake.episode
+
+import io.hemin.wien.builder.episode.EpisodePodcastTranscriptBuilder
+import io.hemin.wien.builder.fake.FakeBuilder
+import io.hemin.wien.model.Episode
+import java.util.Locale
+
+internal class FakeEpisodePodcastTranscriptBuilder : FakeBuilder<Episode.Podcast.Transcript>(), EpisodePodcastTranscriptBuilder {
+
+    var url: String? = null
+    var type: Episode.Podcast.Transcript.Type? = null
+    var language: Locale? = null
+    var rel: String? = null
+
+    override fun url(url: String): EpisodePodcastTranscriptBuilder = apply { this.url = url }
+
+    override fun type(type: Episode.Podcast.Transcript.Type): EpisodePodcastTranscriptBuilder = apply { this.type = type }
+
+    override fun language(language: Locale?): EpisodePodcastTranscriptBuilder = apply { this.language = language }
+
+    override fun rel(rel: String?): EpisodePodcastTranscriptBuilder = apply { this.rel = rel }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is FakeEpisodePodcastTranscriptBuilder) return false
+
+        if (url != other.url) return false
+        if (type != other.type) return false
+        if (language != other.language) return false
+        if (rel != other.rel) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = url?.hashCode() ?: 0
+        result = 31 * result + (type?.hashCode() ?: 0)
+        result = 31 * result + (language?.hashCode() ?: 0)
+        result = 31 * result + (rel?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString() = "FakeEpisodePodcastTranscriptBuilder(url=$url, type=$type, language=$language, rel=$rel)"
+}

--- a/src/test/kotlin/io/hemin/wien/builder/fake/podcast/FakePodcastBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/podcast/FakePodcastBuilder.kt
@@ -15,6 +15,8 @@ import io.hemin.wien.builder.fake.FakePersonBuilder
 import io.hemin.wien.builder.fake.FakeRssCategoryBuilder
 import io.hemin.wien.builder.fake.FakeRssImageBuilder
 import io.hemin.wien.builder.podcast.PodcastBuilder
+import io.hemin.wien.builder.podcast.PodcastPodcastFundingBuilder
+import io.hemin.wien.builder.podcast.PodcastPodcastLockedBuilder
 import io.hemin.wien.model.Podcast
 import java.time.temporal.TemporalAccessor
 
@@ -37,15 +39,17 @@ internal class FakePodcastBuilder : FakeBuilder<Podcast>(), PodcastBuilder {
     val episodeBuilders: MutableList<EpisodeBuilder> = mutableListOf()
     val categoryBuilders: MutableList<RssCategoryBuilder> = mutableListOf()
 
-    override val iTunes: FakePodcastITunesBuilder = FakePodcastITunesBuilder()
+    override val iTunesBuilder: FakePodcastITunesBuilder = FakePodcastITunesBuilder()
 
-    override val atom: FakePodcastAtomBuilder = FakePodcastAtomBuilder()
+    override val atomBuilder: FakePodcastAtomBuilder = FakePodcastAtomBuilder()
 
-    override val fyyd: FakePodcastFyydBuilder = FakePodcastFyydBuilder()
+    override val fyydBuilder: FakePodcastFyydBuilder = FakePodcastFyydBuilder()
 
-    override val feedpress: FakePodcastFeedpressBuilder = FakePodcastFeedpressBuilder()
+    override val feedpressBuilder: FakePodcastFeedpressBuilder = FakePodcastFeedpressBuilder()
 
-    override val googlePlay: FakePodcastGooglePlayBuilder = FakePodcastGooglePlayBuilder()
+    override val googlePlayBuilder: FakePodcastGooglePlayBuilder = FakePodcastGooglePlayBuilder()
+
+    override val podcastBuilder: FakePodcastPodcastBuilder = FakePodcastPodcastBuilder()
 
     override fun title(title: String): PodcastBuilder = apply { this.titleValue = title }
 
@@ -89,7 +93,11 @@ internal class FakePodcastBuilder : FakeBuilder<Podcast>(), PodcastBuilder {
 
     override fun createRssCategoryBuilder(): RssCategoryBuilder = FakeRssCategoryBuilder()
 
-    override fun createITunesCategoryBuilder(): ITunesStyleCategoryBuilder = FakeITunesStyleCategoryBuilder()
+    override fun createITunesStyleCategoryBuilder(): ITunesStyleCategoryBuilder = FakeITunesStyleCategoryBuilder()
+
+    override fun createPodcastPodcastLockedBuilder(): PodcastPodcastLockedBuilder = FakePodcastPodcastLockedBuilder()
+
+    override fun createPodcastPodcastFundingBuilder(): PodcastPodcastFundingBuilder = FakePodcastPodcastFundingBuilder()
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -109,11 +117,12 @@ internal class FakePodcastBuilder : FakeBuilder<Podcast>(), PodcastBuilder {
         if (imageBuilder != other.imageBuilder) return false
         if (episodeBuilders != other.episodeBuilders) return false
         if (categoryBuilders != other.categoryBuilders) return false
-        if (iTunes != other.iTunes) return false
-        if (atom != other.atom) return false
-        if (fyyd != other.fyyd) return false
-        if (feedpress != other.feedpress) return false
-        if (googlePlay != other.googlePlay) return false
+        if (iTunesBuilder != other.iTunesBuilder) return false
+        if (atomBuilder != other.atomBuilder) return false
+        if (fyydBuilder != other.fyydBuilder) return false
+        if (feedpressBuilder != other.feedpressBuilder) return false
+        if (googlePlayBuilder != other.googlePlayBuilder) return false
+        if (podcastBuilder != other.podcastBuilder) return false
 
         return true
     }
@@ -133,11 +142,12 @@ internal class FakePodcastBuilder : FakeBuilder<Podcast>(), PodcastBuilder {
         result = 31 * result + (imageBuilder?.hashCode() ?: 0)
         result = 31 * result + episodeBuilders.hashCode()
         result = 31 * result + categoryBuilders.hashCode()
-        result = 31 * result + iTunes.hashCode()
-        result = 31 * result + atom.hashCode()
-        result = 31 * result + fyyd.hashCode()
-        result = 31 * result + feedpress.hashCode()
-        result = 31 * result + googlePlay.hashCode()
+        result = 31 * result + iTunesBuilder.hashCode()
+        result = 31 * result + atomBuilder.hashCode()
+        result = 31 * result + fyydBuilder.hashCode()
+        result = 31 * result + feedpressBuilder.hashCode()
+        result = 31 * result + googlePlayBuilder.hashCode()
+        result = 31 * result + podcastBuilder.hashCode()
         return result
     }
 
@@ -145,5 +155,6 @@ internal class FakePodcastBuilder : FakeBuilder<Podcast>(), PodcastBuilder {
         "FakePodcastBuilder(titleValue=$titleValue, linkValue=$linkValue, descriptionValue=$descriptionValue, languageValue=$languageValue, " +
             "pubDate=$pubDate, lastBuildDate=$lastBuildDate, generator=$generator, copyright=$copyright, docs=$docs, " +
             "managingEditor=$managingEditor, webMaster=$webMaster, imageBuilder=$imageBuilder, episodeBuilders=$episodeBuilders, " +
-            "categoryBuilders=$categoryBuilders, iTunes=$iTunes, atom=$atom, fyyd=$fyyd, feedpress=$feedpress, googlePlay=$googlePlay)"
+            "categoryBuilders=$categoryBuilders, iTunesBuilder=$iTunesBuilder, atomBuilder=$atomBuilder, fyydBuilder=$fyydBuilder, " +
+            "feedpressBuilder=$feedpressBuilder, googlePlayBuilder=$googlePlayBuilder, podcastBuilder=$podcastBuilder)"
 }

--- a/src/test/kotlin/io/hemin/wien/builder/fake/podcast/FakePodcastPodcastBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/podcast/FakePodcastPodcastBuilder.kt
@@ -1,0 +1,39 @@
+package io.hemin.wien.builder.fake.podcast
+
+import io.hemin.wien.builder.fake.FakeBuilder
+import io.hemin.wien.builder.podcast.PodcastPodcastBuilder
+import io.hemin.wien.builder.podcast.PodcastPodcastFundingBuilder
+import io.hemin.wien.builder.podcast.PodcastPodcastLockedBuilder
+import io.hemin.wien.model.Podcast
+
+internal class FakePodcastPodcastBuilder : FakeBuilder<Podcast.Podcast>(), PodcastPodcastBuilder {
+
+    var lockedBuilderValue: PodcastPodcastLockedBuilder? = null
+    val fundingBuilders: MutableList<PodcastPodcastFundingBuilder> = mutableListOf()
+
+    override fun lockedBuilder(lockedBuilder: PodcastPodcastLockedBuilder): PodcastPodcastBuilder = apply {
+        this.lockedBuilderValue = lockedBuilder
+    }
+
+    override fun addFundingBuilder(fundingBuilder: PodcastPodcastFundingBuilder): PodcastPodcastBuilder = apply {
+        fundingBuilders.add(fundingBuilder)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is FakePodcastPodcastBuilder) return false
+
+        if (fundingBuilders != other.fundingBuilders) return false
+        if (lockedBuilderValue != other.lockedBuilderValue) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = fundingBuilders.hashCode()
+        result = 31 * result + lockedBuilderValue.hashCode()
+        return result
+    }
+
+    override fun toString() = "FakePodcastPodcastBuilder(fundingBuilders=$fundingBuilders, lockedBuilder=$lockedBuilderValue)"
+}

--- a/src/test/kotlin/io/hemin/wien/builder/fake/podcast/FakePodcastPodcastFundingBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/podcast/FakePodcastPodcastFundingBuilder.kt
@@ -1,0 +1,37 @@
+package io.hemin.wien.builder.fake.podcast
+
+import io.hemin.wien.builder.fake.FakeBuilder
+import io.hemin.wien.builder.podcast.PodcastPodcastFundingBuilder
+import io.hemin.wien.model.Podcast
+
+internal class FakePodcastPodcastFundingBuilder : FakeBuilder<Podcast.Podcast.Funding>(), PodcastPodcastFundingBuilder {
+
+    var url: String? = null
+    var message: String? = null
+
+    override fun url(url: String): PodcastPodcastFundingBuilder = apply {
+        this.url = url
+    }
+
+    override fun message(message: String): PodcastPodcastFundingBuilder = apply {
+        this.message = message
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is FakePodcastPodcastFundingBuilder) return false
+
+        if (url != other.url) return false
+        if (message != other.message) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = url?.hashCode() ?: 0
+        result = 31 * result + (message?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString() = "FakePodcastPodcastFundingBuilder(url=$url, message=$message)"
+}

--- a/src/test/kotlin/io/hemin/wien/builder/fake/podcast/FakePodcastPodcastLockedBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/podcast/FakePodcastPodcastLockedBuilder.kt
@@ -1,0 +1,37 @@
+package io.hemin.wien.builder.fake.podcast
+
+import io.hemin.wien.builder.fake.FakeBuilder
+import io.hemin.wien.builder.podcast.PodcastPodcastLockedBuilder
+import io.hemin.wien.model.Podcast
+
+internal class FakePodcastPodcastLockedBuilder : FakeBuilder<Podcast.Podcast.Locked>(), PodcastPodcastLockedBuilder {
+
+    var owner: String? = null
+    var locked: Boolean? = null
+
+    override fun owner(owner: String): PodcastPodcastLockedBuilder = apply {
+        this.owner = owner
+    }
+
+    override fun locked(locked: Boolean): PodcastPodcastLockedBuilder = apply {
+        this.locked = locked
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is FakePodcastPodcastLockedBuilder) return false
+
+        if (owner != other.owner) return false
+        if (locked != other.locked) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = owner?.hashCode() ?: 0
+        result = 31 * result + (locked?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString() = "FakePodcastPodcastLockedBuilder(owner=$owner, locked=$locked)"
+}

--- a/src/test/kotlin/io/hemin/wien/builder/validating/episode/ValidatingEpisodeBuilderTest.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/validating/episode/ValidatingEpisodeBuilderTest.kt
@@ -30,7 +30,7 @@ internal class ValidatingEpisodeBuilderTest {
 
     private val expectedAtomAuthorBuilder = ValidatingPersonBuilder().name("atom author")
 
-    private val expectedChapterBuilder = ValidatingEpisodePodloveSimpleChapterBuilder()
+    private val expectedSimpleChapterBuilder = ValidatingEpisodePodloveSimpleChapterBuilder()
         .start("start")
         .title("chapter title")
 
@@ -38,6 +38,10 @@ internal class ValidatingEpisodeBuilderTest {
         ValidatingRssCategoryBuilder().category("category 1").domain("domain"),
         ValidatingRssCategoryBuilder().category("category 2")
     )
+
+    private val expectedPodcastChaptersBuilder = ValidatingEpisodePodcastChaptersBuilder()
+        .url("https://example.com/episode/chapters.json")
+        .type("application/json+chapters")
 
     @Test
     internal fun `should not build a episode when the mandatory fields are missing`() {
@@ -100,6 +104,7 @@ internal class ValidatingEpisodeBuilderTest {
                 prop(Episode::podlove).isNull()
                 prop(Episode::googlePlay).isNull()
                 prop(Episode::bitlove).isNull()
+                prop(Episode::podcast).isNull()
             }
         }
     }
@@ -119,12 +124,13 @@ internal class ValidatingEpisodeBuilderTest {
             .pubDate(expectedDate)
             .source("source")
             .apply {
-                content.encoded("encoded")
-                iTunes.title("iTunes title")
-                atom.addAuthorBuilder(expectedAtomAuthorBuilder)
-                podlove.addSimpleChapterBuilder(expectedChapterBuilder)
-                googlePlay.description("play description")
-                bitlove.guid("bitlove guid")
+                contentBuilder.encoded("encoded")
+                iTunesBuilder.title("iTunes title")
+                atomBuilder.addAuthorBuilder(expectedAtomAuthorBuilder)
+                podloveBuilder.addSimpleChapterBuilder(expectedSimpleChapterBuilder)
+                googlePlayBuilder.description("play description")
+                bitloveBuilder.guid("bitlove guid")
+                podcastBuilder.chaptersBuilder(expectedPodcastChaptersBuilder)
             }
 
         assertAll {
@@ -144,9 +150,10 @@ internal class ValidatingEpisodeBuilderTest {
                 prop(Episode::content).isNotNull().prop(Episode.Content::encoded).isEqualTo("encoded")
                 prop(Episode::iTunes).isNotNull().prop(Episode.ITunes::title).isEqualTo("iTunes title")
                 prop(Episode::atom).isNotNull().prop(Episode.Atom::authors).containsExactly(expectedAtomAuthorBuilder.build())
-                prop(Episode::podlove).isNotNull().prop(Episode.Podlove::simpleChapters).containsExactly(expectedChapterBuilder.build())
+                prop(Episode::podlove).isNotNull().prop(Episode.Podlove::simpleChapters).containsExactly(expectedSimpleChapterBuilder.build())
                 prop(Episode::googlePlay).isNotNull().prop(Episode.GooglePlay::description).isEqualTo("play description")
                 prop(Episode::bitlove).isNotNull().prop(Episode.Bitlove::guid).isEqualTo("bitlove guid")
+                prop(Episode::podcast).isNotNull().prop(Episode.Podcast::chapters).isEqualTo(expectedPodcastChaptersBuilder.build())
             }
         }
     }

--- a/src/test/kotlin/io/hemin/wien/builder/validating/episode/ValidatingEpisodePodcastBuilderTest.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/validating/episode/ValidatingEpisodePodcastBuilderTest.kt
@@ -1,0 +1,150 @@
+package io.hemin.wien.builder.validating.episode
+
+import assertk.all
+import assertk.assertAll
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import assertk.assertions.prop
+import io.hemin.wien.builder.episode.EpisodePodcastBuilder
+import io.hemin.wien.model.Episode
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.Locale
+
+internal class ValidatingEpisodePodcastBuilderTest {
+
+    private val expectedChaptersBuilder = ValidatingEpisodePodcastChaptersBuilder()
+        .url("https://example.com/episode/chapters.json")
+        .type("application/json+chapters")
+
+    private val firstExpectedSoundbiteBuilder = ValidatingEpisodePodcastSoundbiteBuilder()
+        .startTime(Duration.ofSeconds(1))
+        .duration(Duration.ofSeconds(15))
+        .title("First soundbite")
+
+    private val secondExpectedSoundbiteBuilder = ValidatingEpisodePodcastSoundbiteBuilder()
+        .startTime(Duration.ofSeconds(2))
+        .duration(Duration.ofSeconds(12))
+        .title("Second soundbite")
+
+    private val firstExpectedTranscriptBuilder = ValidatingEpisodePodcastTranscriptBuilder()
+        .url("https://example.com/episode/transcript.srt")
+        .type(Episode.Podcast.Transcript.Type.SRT)
+        .language(Locale.ITALIAN)
+        .rel("captions")
+
+    private val secondExpectedTranscriptBuilder = ValidatingEpisodePodcastTranscriptBuilder()
+        .url("https://example.com/episode/transcript.txt")
+        .type(Episode.Podcast.Transcript.Type.PLAIN_TEXT)
+        .language(Locale.ITALIAN)
+
+    @Test
+    internal fun `should not build an Episode Podcast with when all the fields are empty`() {
+        val episodePodcastBuilder = ValidatingEpisodePodcastBuilder()
+
+        assertAll {
+            assertThat(episodePodcastBuilder).prop(EpisodePodcastBuilder::hasEnoughDataToBuild).isFalse()
+
+            assertThat(episodePodcastBuilder.build()).isNull()
+        }
+    }
+
+    @Test
+    internal fun `should build an Episode Podcast with at least a chapters builder`() {
+        val episodePodcastBuilder = ValidatingEpisodePodcastBuilder()
+            .chaptersBuilder(expectedChaptersBuilder)
+
+        assertAll {
+            assertThat(episodePodcastBuilder).prop(EpisodePodcastBuilder::hasEnoughDataToBuild).isTrue()
+
+            assertThat(episodePodcastBuilder.build()).isNotNull().prop(Episode.Podcast::chapters).isEqualTo(expectedChaptersBuilder.build())
+        }
+    }
+
+    @Test
+    internal fun `should not build an Episode Podcast when there is only a chapters builder that doesn't build`() {
+        val episodePodcastBuilder = ValidatingEpisodePodcastBuilder()
+            .chaptersBuilder(ValidatingEpisodePodcastChaptersBuilder())
+
+        assertAll {
+            assertThat(episodePodcastBuilder).prop(EpisodePodcastBuilder::hasEnoughDataToBuild).isFalse()
+
+            assertThat(episodePodcastBuilder.build()).isNull()
+        }
+    }
+
+    @Test
+    internal fun `should build an Episode Podcast with at least one soundbite builder`() {
+        val episodePodcastBuilder = ValidatingEpisodePodcastBuilder()
+            .addSoundbiteBuilder(firstExpectedSoundbiteBuilder)
+
+        assertAll {
+            assertThat(episodePodcastBuilder).prop(EpisodePodcastBuilder::hasEnoughDataToBuild).isTrue()
+
+            assertThat(episodePodcastBuilder.build()).isNotNull()
+                .prop(Episode.Podcast::soundbites).containsExactly(firstExpectedSoundbiteBuilder.build())
+        }
+    }
+
+    @Test
+    internal fun `should not build an Episode Podcast when there is only a soundbite builder that doesn't build`() {
+        val episodePodcastBuilder = ValidatingEpisodePodcastBuilder()
+            .addSoundbiteBuilder(ValidatingEpisodePodcastSoundbiteBuilder())
+
+        assertAll {
+            assertThat(episodePodcastBuilder).prop(EpisodePodcastBuilder::hasEnoughDataToBuild).isFalse()
+
+            assertThat(episodePodcastBuilder.build()).isNull()
+        }
+    }
+
+    @Test
+    internal fun `should build an Episode Podcast with at least a transcript builder`() {
+        val episodePodcastBuilder = ValidatingEpisodePodcastBuilder()
+            .addTranscriptBuilder(firstExpectedTranscriptBuilder)
+
+        assertAll {
+            assertThat(episodePodcastBuilder).prop(EpisodePodcastBuilder::hasEnoughDataToBuild).isTrue()
+
+            assertThat(episodePodcastBuilder.build()).isNotNull()
+                .prop(Episode.Podcast::transcripts).containsExactly(firstExpectedTranscriptBuilder.build())
+        }
+    }
+
+    @Test
+    internal fun `should not build an Episode Podcast when there is only a transcript builder that doesn't build`() {
+        val episodePodcastBuilder = ValidatingEpisodePodcastBuilder()
+            .addTranscriptBuilder(ValidatingEpisodePodcastTranscriptBuilder())
+
+        assertAll {
+            assertThat(episodePodcastBuilder).prop(EpisodePodcastBuilder::hasEnoughDataToBuild).isFalse()
+
+            assertThat(episodePodcastBuilder.build()).isNull()
+        }
+    }
+
+    @Test
+    internal fun `should build an Episode Podcast with with all the added entries to its fields`() {
+        val episodePodcastBuilder = ValidatingEpisodePodcastBuilder()
+            .chaptersBuilder(expectedChaptersBuilder)
+            .addSoundbiteBuilder(firstExpectedSoundbiteBuilder)
+            .addSoundbiteBuilder(secondExpectedSoundbiteBuilder)
+            .addTranscriptBuilder(firstExpectedTranscriptBuilder)
+            .addTranscriptBuilder(secondExpectedTranscriptBuilder)
+
+        assertAll {
+            assertThat(episodePodcastBuilder).prop(EpisodePodcastBuilder::hasEnoughDataToBuild).isTrue()
+
+            assertThat(episodePodcastBuilder.build()).isNotNull().all {
+                prop(Episode.Podcast::chapters).isEqualTo(expectedChaptersBuilder.build())
+                prop(Episode.Podcast::soundbites).containsExactly(firstExpectedSoundbiteBuilder.build(), secondExpectedSoundbiteBuilder.build())
+                prop(Episode.Podcast::transcripts).containsExactly(firstExpectedTranscriptBuilder.build(), secondExpectedTranscriptBuilder.build())
+            }
+        }
+    }
+}

--- a/src/test/kotlin/io/hemin/wien/builder/validating/episode/ValidatingEpisodePodcastChaptersBuilderTest.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/validating/episode/ValidatingEpisodePodcastChaptersBuilderTest.kt
@@ -1,0 +1,68 @@
+package io.hemin.wien.builder.validating.episode
+
+import assertk.all
+import assertk.assertAll
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import assertk.assertions.prop
+import io.hemin.wien.builder.episode.EpisodePodcastChaptersBuilder
+import io.hemin.wien.model.Episode
+import org.junit.jupiter.api.Test
+
+internal class ValidatingEpisodePodcastChaptersBuilderTest {
+
+    @Test
+    internal fun `should not build an Episode Podcast Chapters with when all the fields are missing`() {
+        val chaptersBuilder = ValidatingEpisodePodcastChaptersBuilder()
+
+        assertAll {
+            assertThat(chaptersBuilder).prop(EpisodePodcastChaptersBuilder::hasEnoughDataToBuild).isFalse()
+
+            assertThat(chaptersBuilder.build()).isNull()
+        }
+    }
+
+    @Test
+    internal fun `should not build an Episode Podcast Chapters with when the url field is missing`() {
+        val chaptersBuilder = ValidatingEpisodePodcastChaptersBuilder()
+            .type("text/json+chapters")
+
+        assertAll {
+            assertThat(chaptersBuilder).prop(EpisodePodcastChaptersBuilder::hasEnoughDataToBuild).isFalse()
+
+            assertThat(chaptersBuilder.build()).isNull()
+        }
+    }
+
+    @Test
+    internal fun `should not build an Episode Podcast Chapters with when the type field is missing`() {
+        val chaptersBuilder = ValidatingEpisodePodcastChaptersBuilder()
+            .url("https://example.com/episode/chapters.json")
+
+        assertAll {
+            assertThat(chaptersBuilder).prop(EpisodePodcastChaptersBuilder::hasEnoughDataToBuild).isFalse()
+
+            assertThat(chaptersBuilder.build()).isNull()
+        }
+    }
+
+    @Test
+    internal fun `should build an Episode Podcast Chapters with with all the added entries to its fields`() {
+        val chaptersBuilder = ValidatingEpisodePodcastChaptersBuilder()
+            .url("https://example.com/episode/chapters.json")
+            .type("text/json+chapters")
+
+        assertAll {
+            assertThat(chaptersBuilder).prop(EpisodePodcastChaptersBuilder::hasEnoughDataToBuild).isTrue()
+
+            assertThat(chaptersBuilder.build()).isNotNull().all {
+                prop(Episode.Podcast.Chapters::url).isEqualTo("https://example.com/episode/chapters.json")
+                prop(Episode.Podcast.Chapters::type).isEqualTo("text/json+chapters")
+            }
+        }
+    }
+}

--- a/src/test/kotlin/io/hemin/wien/builder/validating/episode/ValidatingEpisodePodcastSoundbiteBuilderTest.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/validating/episode/ValidatingEpisodePodcastSoundbiteBuilderTest.kt
@@ -1,0 +1,71 @@
+package io.hemin.wien.builder.validating.episode
+
+import assertk.all
+import assertk.assertAll
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import assertk.assertions.prop
+import io.hemin.wien.builder.episode.EpisodePodcastSoundbiteBuilder
+import io.hemin.wien.model.Episode
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+internal class ValidatingEpisodePodcastSoundbiteBuilderTest {
+
+    @Test
+    internal fun `should not build an Episode Podcast Soundbite with when all the fields are missing`() {
+        val soundbiteBuilder = ValidatingEpisodePodcastSoundbiteBuilder()
+
+        assertAll {
+            assertThat(soundbiteBuilder).prop(EpisodePodcastSoundbiteBuilder::hasEnoughDataToBuild).isFalse()
+
+            assertThat(soundbiteBuilder.build()).isNull()
+        }
+    }
+
+    @Test
+    internal fun `should not build an Episode Podcast Soundbite with when the startTime field is missing`() {
+        val soundbiteBuilder = ValidatingEpisodePodcastSoundbiteBuilder()
+            .duration(Duration.ofSeconds(15))
+
+        assertAll {
+            assertThat(soundbiteBuilder).prop(EpisodePodcastSoundbiteBuilder::hasEnoughDataToBuild).isFalse()
+
+            assertThat(soundbiteBuilder.build()).isNull()
+        }
+    }
+
+    @Test
+    internal fun `should not build an Episode Podcast Soundbite with when the duration field is missing`() {
+        val soundbiteBuilder = ValidatingEpisodePodcastSoundbiteBuilder()
+            .startTime(Duration.ofSeconds(1))
+
+        assertAll {
+            assertThat(soundbiteBuilder).prop(EpisodePodcastSoundbiteBuilder::hasEnoughDataToBuild).isFalse()
+
+            assertThat(soundbiteBuilder.build()).isNull()
+        }
+    }
+
+    @Test
+    internal fun `should build an Episode Podcast Soundbite with with all the added entries to its fields`() {
+        val soundbiteBuilder = ValidatingEpisodePodcastSoundbiteBuilder()
+            .startTime(Duration.ofSeconds(1))
+            .duration(Duration.ofSeconds(15))
+            .title("soundbite")
+
+        assertAll {
+            assertThat(soundbiteBuilder).prop(EpisodePodcastSoundbiteBuilder::hasEnoughDataToBuild).isTrue()
+
+            assertThat(soundbiteBuilder.build()).isNotNull().all {
+                prop(Episode.Podcast.Soundbite::startTime).isEqualTo(Duration.ofSeconds(1))
+                prop(Episode.Podcast.Soundbite::duration).isEqualTo(Duration.ofSeconds(15))
+                prop(Episode.Podcast.Soundbite::title).isEqualTo("soundbite")
+            }
+        }
+    }
+}

--- a/src/test/kotlin/io/hemin/wien/builder/validating/episode/ValidatingEpisodePodcastTranscriptBuilderTest.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/validating/episode/ValidatingEpisodePodcastTranscriptBuilderTest.kt
@@ -1,0 +1,73 @@
+package io.hemin.wien.builder.validating.episode
+
+import assertk.all
+import assertk.assertAll
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import assertk.assertions.prop
+import io.hemin.wien.builder.episode.EpisodePodcastTranscriptBuilder
+import io.hemin.wien.model.Episode
+import org.junit.jupiter.api.Test
+import java.util.Locale
+
+internal class ValidatingEpisodePodcastTranscriptBuilderTest {
+
+    @Test
+    internal fun `should not build an Episode Podcast Transcript with when all the fields are missing`() {
+        val transcriptBuilder = ValidatingEpisodePodcastTranscriptBuilder()
+
+        assertAll {
+            assertThat(transcriptBuilder).prop(EpisodePodcastTranscriptBuilder::hasEnoughDataToBuild).isFalse()
+
+            assertThat(transcriptBuilder.build()).isNull()
+        }
+    }
+
+    @Test
+    internal fun `should not build an Episode Podcast Transcript with when the url field is missing`() {
+        val transcriptBuilder = ValidatingEpisodePodcastTranscriptBuilder()
+            .type(Episode.Podcast.Transcript.Type.PLAIN_TEXT)
+
+        assertAll {
+            assertThat(transcriptBuilder).prop(EpisodePodcastTranscriptBuilder::hasEnoughDataToBuild).isFalse()
+
+            assertThat(transcriptBuilder.build()).isNull()
+        }
+    }
+
+    @Test
+    internal fun `should not build an Episode Podcast Transcript with when the type field is missing`() {
+        val transcriptBuilder = ValidatingEpisodePodcastTranscriptBuilder()
+            .url("https://example.com/episode/transcript.txt")
+
+        assertAll {
+            assertThat(transcriptBuilder).prop(EpisodePodcastTranscriptBuilder::hasEnoughDataToBuild).isFalse()
+
+            assertThat(transcriptBuilder.build()).isNull()
+        }
+    }
+
+    @Test
+    internal fun `should build an Episode Podcast Transcript with with all the added entries to its fields`() {
+        val transcriptBuilder = ValidatingEpisodePodcastTranscriptBuilder()
+            .url("https://example.com/episode/transcript.txt")
+            .type(Episode.Podcast.Transcript.Type.PLAIN_TEXT)
+            .language(Locale.ITALIAN)
+            .rel("captions")
+
+        assertAll {
+            assertThat(transcriptBuilder).prop(EpisodePodcastTranscriptBuilder::hasEnoughDataToBuild).isTrue()
+
+            assertThat(transcriptBuilder.build()).isNotNull().all {
+                prop(Episode.Podcast.Transcript::url).isEqualTo("https://example.com/episode/transcript.txt")
+                prop(Episode.Podcast.Transcript::type).isEqualTo(Episode.Podcast.Transcript.Type.PLAIN_TEXT)
+                prop(Episode.Podcast.Transcript::language).isEqualTo(Locale.ITALIAN)
+                prop(Episode.Podcast.Transcript::rel).isEqualTo("captions")
+            }
+        }
+    }
+}

--- a/src/test/kotlin/io/hemin/wien/builder/validating/podcast/ValidatingPodcastBuilderTest.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/validating/podcast/ValidatingPodcastBuilderTest.kt
@@ -56,6 +56,10 @@ internal class ValidatingPodcastBuilderTest {
         ValidatingRssCategoryBuilder().category("category 2")
     )
 
+    private val expectedLockedBuilder = ValidatingPodcastPodcastLockedBuilder()
+        .locked(true)
+        .owner("owner@example.com")
+
     @Test
     internal fun `should not build a Podcast when the mandatory fields are missing`() {
         val podcastBuilder = ValidatingPodcastBuilder()
@@ -173,6 +177,7 @@ internal class ValidatingPodcastBuilderTest {
                 prop(Podcast::feedpress).isNull()
                 prop(Podcast::fyyd).isNull()
                 prop(Podcast::googlePlay).isNull()
+                prop(Podcast::podcast).isNull()
             }
         }
     }
@@ -196,13 +201,14 @@ internal class ValidatingPodcastBuilderTest {
             .addCategoryBuilder(expectedCategoryBuilders[0])
             .addCategoryBuilder(expectedCategoryBuilders[1])
             .apply {
-                iTunes.imageBuilder(expectedITunesImageBuilder)
+                iTunesBuilder.imageBuilder(expectedITunesImageBuilder)
                     .addCategoryBuilder(expectedITunesCategoryBuilder)
                     .explicit(false)
-                atom.addAuthorBuilder(expectedAtomAuthorBuilder)
-                feedpress.newsletterId("feedpress newsletterId")
-                fyyd.verify("fyyd verify")
-                googlePlay.description("play description")
+                atomBuilder.addAuthorBuilder(expectedAtomAuthorBuilder)
+                feedpressBuilder.newsletterId("feedpress newsletterId")
+                fyydBuilder.verify("fyyd verify")
+                googlePlayBuilder.description("play description")
+                podcastBuilder.lockedBuilder(expectedLockedBuilder)
             }
 
         assertAll {
@@ -230,6 +236,7 @@ internal class ValidatingPodcastBuilderTest {
                     .isEqualTo("feedpress newsletterId")
                 prop(Podcast::fyyd).isNotNull().prop(Podcast.Fyyd::verify).isEqualTo("fyyd verify")
                 prop(Podcast::googlePlay).isNotNull().prop(Podcast.GooglePlay::description).isEqualTo("play description")
+                prop(Podcast::podcast).isNotNull().prop(Podcast.Podcast::locked).isEqualTo(expectedLockedBuilder.build())
             }
         }
     }

--- a/src/test/kotlin/io/hemin/wien/builder/validating/podcast/ValidatingPodcastPodcastBuilderTest.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/validating/podcast/ValidatingPodcastPodcastBuilderTest.kt
@@ -1,0 +1,107 @@
+package io.hemin.wien.builder.validating.podcast
+
+import assertk.all
+import assertk.assertAll
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import assertk.assertions.prop
+import io.hemin.wien.builder.podcast.PodcastPodcastBuilder
+import io.hemin.wien.model.Podcast
+import org.junit.jupiter.api.Test
+
+internal class ValidatingPodcastPodcastBuilderTest {
+
+    private val expectedLockedBuilder = ValidatingPodcastPodcastLockedBuilder()
+        .locked(true)
+        .owner("owner@example.com")
+
+    private val firstExpectedFundingBuilder = ValidatingPodcastPodcastFundingBuilder()
+        .url("https://example.com/donate")
+        .message("First funding")
+
+    private val secondExpectedFundingBuilder = ValidatingPodcastPodcastFundingBuilder()
+        .url("https://example.com/donate-more")
+        .message("Second funding")
+
+    @Test
+    internal fun `should not build a Podcast Podcast with when all the fields are empty`() {
+        val podcastPodcastBuilder = ValidatingPodcastPodcastBuilder()
+
+        assertAll {
+            assertThat(podcastPodcastBuilder).prop(PodcastPodcastBuilder::hasEnoughDataToBuild).isFalse()
+
+            assertThat(podcastPodcastBuilder.build()).isNull()
+        }
+    }
+
+    @Test
+    internal fun `should build a Podcast Podcast with at least a locked builder`() {
+        val podcastPodcastBuilder = ValidatingPodcastPodcastBuilder()
+            .lockedBuilder(expectedLockedBuilder)
+
+        assertAll {
+            assertThat(podcastPodcastBuilder).prop(PodcastPodcastBuilder::hasEnoughDataToBuild).isTrue()
+
+            assertThat(podcastPodcastBuilder.build()).isNotNull().prop(Podcast.Podcast::locked).isEqualTo(expectedLockedBuilder.build())
+        }
+    }
+
+    @Test
+    internal fun `should not build a Podcast Podcast when there is only a locked builder that doesn't build`() {
+        val podcastPodcastBuilder = ValidatingPodcastPodcastBuilder()
+            .lockedBuilder(ValidatingPodcastPodcastLockedBuilder())
+
+        assertAll {
+            assertThat(podcastPodcastBuilder).prop(PodcastPodcastBuilder::hasEnoughDataToBuild).isFalse()
+
+            assertThat(podcastPodcastBuilder.build()).isNull()
+        }
+    }
+
+    @Test
+    internal fun `should build a Podcast Podcast with at least one funding builder`() {
+        val podcastPodcastBuilder = ValidatingPodcastPodcastBuilder()
+            .addFundingBuilder(firstExpectedFundingBuilder)
+
+        assertAll {
+            assertThat(podcastPodcastBuilder).prop(PodcastPodcastBuilder::hasEnoughDataToBuild).isTrue()
+
+            assertThat(podcastPodcastBuilder.build()).isNotNull()
+                .prop(Podcast.Podcast::funding).containsExactly(firstExpectedFundingBuilder.build())
+        }
+    }
+
+    @Test
+    internal fun `should not build a Podcast Podcast when there is only a funding builder that doesn't build`() {
+        val podcastPodcastBuilder = ValidatingPodcastPodcastBuilder()
+            .addFundingBuilder(ValidatingPodcastPodcastFundingBuilder())
+
+        assertAll {
+            assertThat(podcastPodcastBuilder).prop(PodcastPodcastBuilder::hasEnoughDataToBuild).isFalse()
+
+            assertThat(podcastPodcastBuilder.build()).isNull()
+        }
+    }
+
+    @Test
+    internal fun `should build a Podcast Podcast with with all the added entries to its fields`() {
+        val podcastPodcastBuilder = ValidatingPodcastPodcastBuilder()
+            .lockedBuilder(expectedLockedBuilder)
+            .addFundingBuilder(firstExpectedFundingBuilder)
+            .addFundingBuilder(secondExpectedFundingBuilder)
+
+        assertAll {
+            assertThat(podcastPodcastBuilder).prop(PodcastPodcastBuilder::hasEnoughDataToBuild).isTrue()
+
+            assertThat(podcastPodcastBuilder.build()).isNotNull().all {
+                prop(Podcast.Podcast::locked).isEqualTo(expectedLockedBuilder.build())
+                prop(Podcast.Podcast::funding).containsExactly(firstExpectedFundingBuilder.build(), secondExpectedFundingBuilder.build())
+            }
+        }
+    }
+}

--- a/src/test/kotlin/io/hemin/wien/builder/validating/podcast/ValidatingPodcastPodcastFundingBuilderTest.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/validating/podcast/ValidatingPodcastPodcastFundingBuilderTest.kt
@@ -1,0 +1,68 @@
+package io.hemin.wien.builder.validating.podcast
+
+import assertk.all
+import assertk.assertAll
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import assertk.assertions.prop
+import io.hemin.wien.builder.podcast.PodcastPodcastFundingBuilder
+import io.hemin.wien.model.Podcast
+import org.junit.jupiter.api.Test
+
+internal class ValidatingPodcastPodcastFundingBuilderTest {
+
+    @Test
+    internal fun `should not build a Podcast Podcast Funding with when all the fields are missing`() {
+        val fundingBuilder = ValidatingPodcastPodcastFundingBuilder()
+
+        assertAll {
+            assertThat(fundingBuilder).prop(PodcastPodcastFundingBuilder::hasEnoughDataToBuild).isFalse()
+
+            assertThat(fundingBuilder.build()).isNull()
+        }
+    }
+
+    @Test
+    internal fun `should not build a Podcast Podcast Funding with when the url field is missing`() {
+        val fundingBuilder = ValidatingPodcastPodcastFundingBuilder()
+            .message("Send me money please, kthxbye")
+
+        assertAll {
+            assertThat(fundingBuilder).prop(PodcastPodcastFundingBuilder::hasEnoughDataToBuild).isFalse()
+
+            assertThat(fundingBuilder.build()).isNull()
+        }
+    }
+
+    @Test
+    internal fun `should not build a Podcast Podcast Funding with when the message field is missing`() {
+        val fundingBuilder = ValidatingPodcastPodcastFundingBuilder()
+            .url("https://example.com/donate")
+
+        assertAll {
+            assertThat(fundingBuilder).prop(PodcastPodcastFundingBuilder::hasEnoughDataToBuild).isFalse()
+
+            assertThat(fundingBuilder.build()).isNull()
+        }
+    }
+
+    @Test
+    internal fun `should build a Podcast Podcast Funding with with all the added entries to its fields`() {
+        val fundingBuilder = ValidatingPodcastPodcastFundingBuilder()
+            .url("https://example.com/donate")
+            .message("Send me money please, kthxbye")
+
+        assertAll {
+            assertThat(fundingBuilder).prop(PodcastPodcastFundingBuilder::hasEnoughDataToBuild).isTrue()
+
+            assertThat(fundingBuilder.build()).isNotNull().all {
+                prop(Podcast.Podcast.Funding::url).isEqualTo("https://example.com/donate")
+                prop(Podcast.Podcast.Funding::message).isEqualTo("Send me money please, kthxbye")
+            }
+        }
+    }
+}

--- a/src/test/kotlin/io/hemin/wien/builder/validating/podcast/ValidatingPodcastPodcastLockedBuilderTest.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/validating/podcast/ValidatingPodcastPodcastLockedBuilderTest.kt
@@ -1,0 +1,68 @@
+package io.hemin.wien.builder.validating.podcast
+
+import assertk.all
+import assertk.assertAll
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import assertk.assertions.prop
+import io.hemin.wien.builder.podcast.PodcastPodcastLockedBuilder
+import io.hemin.wien.model.Podcast
+import org.junit.jupiter.api.Test
+
+internal class ValidatingPodcastPodcastLockedBuilderTest {
+
+    @Test
+    internal fun `should not build a Podcast Podcast Locked with when all the fields are missing`() {
+        val lockedBuilder = ValidatingPodcastPodcastLockedBuilder()
+
+        assertAll {
+            assertThat(lockedBuilder).prop(PodcastPodcastLockedBuilder::hasEnoughDataToBuild).isFalse()
+
+            assertThat(lockedBuilder.build()).isNull()
+        }
+    }
+
+    @Test
+    internal fun `should not build a Podcast Podcast Locked with when the locked field is missing`() {
+        val lockedBuilder = ValidatingPodcastPodcastLockedBuilder()
+            .owner("Send me money please, kthxbye")
+
+        assertAll {
+            assertThat(lockedBuilder).prop(PodcastPodcastLockedBuilder::hasEnoughDataToBuild).isFalse()
+
+            assertThat(lockedBuilder.build()).isNull()
+        }
+    }
+
+    @Test
+    internal fun `should not build a Podcast Podcast Locked with when the owner field is missing`() {
+        val lockedBuilder = ValidatingPodcastPodcastLockedBuilder()
+            .locked(true)
+
+        assertAll {
+            assertThat(lockedBuilder).prop(PodcastPodcastLockedBuilder::hasEnoughDataToBuild).isFalse()
+
+            assertThat(lockedBuilder.build()).isNull()
+        }
+    }
+
+    @Test
+    internal fun `should build a Podcast Podcast Locked with with all the added entries to its fields`() {
+        val lockedBuilder = ValidatingPodcastPodcastLockedBuilder()
+            .locked(true)
+            .owner("Send me money please, kthxbye")
+
+        assertAll {
+            assertThat(lockedBuilder).prop(PodcastPodcastLockedBuilder::hasEnoughDataToBuild).isTrue()
+
+            assertThat(lockedBuilder.build()).isNotNull().all {
+                prop(Podcast.Podcast.Locked::locked).isTrue()
+                prop(Podcast.Podcast.Locked::owner).isEqualTo("Send me money please, kthxbye")
+            }
+        }
+    }
+}

--- a/src/test/kotlin/io/hemin/wien/dom/XPath.kt
+++ b/src/test/kotlin/io/hemin/wien/dom/XPath.kt
@@ -1,6 +1,7 @@
 package io.hemin.wien.dom
 
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.FeedNamespace.Companion.matches
 import org.w3c.dom.Node
 import org.w3c.dom.NodeList
 import javax.xml.namespace.NamespaceContext
@@ -26,7 +27,7 @@ private object FeedNamespaceContext : NamespaceContext {
 
     override fun getPrefix(namespaceURI: String?): String? {
         if (namespaceURI == null) return null
-        return FeedNamespace.values().find { it.uri == namespaceURI }?.prefix
+        return FeedNamespace.values().find { it.matches(namespaceURI) }?.prefix
     }
 
     override fun getPrefixes(namespaceURI: String?): Iterator<String> {

--- a/src/test/kotlin/io/hemin/wien/model/episode/EpisodeFixtures.kt
+++ b/src/test/kotlin/io/hemin/wien/model/episode/EpisodeFixtures.kt
@@ -132,4 +132,4 @@ fun anEpisodePodcastSoundbite(
 internal fun anEpisodePodcastChapters(
     url: String = "episode podcast: chapters url",
     type: String = "episode podcast: chapters type"
-)= Episode.Podcast.Chapters(url, type)
+) = Episode.Podcast.Chapters(url, type)

--- a/src/test/kotlin/io/hemin/wien/model/episode/EpisodeFixtures.kt
+++ b/src/test/kotlin/io/hemin/wien/model/episode/EpisodeFixtures.kt
@@ -10,8 +10,10 @@ import io.hemin.wien.model.aLink
 import io.hemin.wien.model.aPerson
 import io.hemin.wien.model.anHrefOnlyImage
 import io.hemin.wien.model.anRssCategory
+import java.time.Duration
 import java.time.Month
 import java.time.temporal.TemporalAccessor
+import java.util.Locale
 
 internal fun anEpisode(
     title: String = "episode title",
@@ -29,7 +31,8 @@ internal fun anEpisode(
     atom: Episode.Atom? = anEpisodeAtom(),
     podlove: Episode.Podlove? = anEpisodePodlove(),
     googlePlay: Episode.GooglePlay? = anEpisodeGooglePlay(),
-    bitlove: Episode.Bitlove? = anEpisodeBitlove()
+    bitlove: Episode.Bitlove? = anEpisodeBitlove(),
+    podcast: Episode.Podcast? = anEpisodePodcast()
 ) = Episode(
     title,
     link,
@@ -46,7 +49,8 @@ internal fun anEpisode(
     atom,
     podlove,
     googlePlay,
-    bitlove
+    bitlove,
+    podcast
 )
 
 internal fun anEpisodeEnclosure(
@@ -105,3 +109,27 @@ internal fun anEpisodeGooglePlay(
 internal fun anEpisodeBitlove(
     guid: String = "episode bitlove guid"
 ) = Episode.Bitlove(guid)
+
+internal fun anEpisodePodcast(
+    transcripts: List<Episode.Podcast.Transcript> = listOf(anEpisodePodcastTranscript()),
+    soundbites: List<Episode.Podcast.Soundbite> = listOf(anEpisodePodcastSoundbite()),
+    chapters: Episode.Podcast.Chapters? = anEpisodePodcastChapters()
+) = Episode.Podcast(transcripts, soundbites, chapters)
+
+fun anEpisodePodcastTranscript(
+    url: String = "episode podcast: transcript url",
+    type: Episode.Podcast.Transcript.Type = Episode.Podcast.Transcript.Type.SRT,
+    language: Locale? = Locale.ITALY,
+    rel: String? = "captions"
+) = Episode.Podcast.Transcript(url, type, language, rel)
+
+fun anEpisodePodcastSoundbite(
+    startTime: Duration = Duration.ofSeconds(1),
+    duration: Duration = Duration.ofSeconds(15).plusMillis(123),
+    title: String? = "episode podcast: soundbite title"
+) = Episode.Podcast.Soundbite(startTime, duration, title)
+
+internal fun anEpisodePodcastChapters(
+    url: String = "episode podcast: chapters url",
+    type: String = "episode podcast: chapters type"
+)= Episode.Podcast.Chapters(url, type)

--- a/src/test/kotlin/io/hemin/wien/model/podcast/PodcastFixtures.kt
+++ b/src/test/kotlin/io/hemin/wien/model/podcast/PodcastFixtures.kt
@@ -38,6 +38,7 @@ internal fun aPodcast(
     fyyd: Podcast.Fyyd? = aPodcastFyyd(),
     feedpress: Podcast.Feedpress? = aPodcastFeedpress(),
     googlePlay: Podcast.GooglePlay? = aPodcastGooglePlay(),
+    podcast: Podcast.Podcast? = aPodcastPodcast(),
     categories: List<RssCategory> = listOf(anRssCategory("podcast category"))
 ) = Podcast(
     title,
@@ -58,7 +59,8 @@ internal fun aPodcast(
     fyyd,
     feedpress,
     googlePlay,
-    categories
+    categories,
+    podcast
 )
 
 internal fun aPodcastITunes(
@@ -104,3 +106,18 @@ internal fun aPodcastGooglePlay(
     block: Boolean? = true,
     image: HrefOnlyImage? = anHrefOnlyImage(href = "podcast googleplay image url")
 ) = Podcast.GooglePlay(author, owner, categories, description, explicit, block, image)
+
+internal fun aPodcastPodcast(
+    locked: Podcast.Podcast.Locked? = aPodcastPodcastLocked(),
+    funding: List<Podcast.Podcast.Funding> = listOf(aPodcastPodcastFunding())
+) = Podcast.Podcast(locked, funding)
+
+internal fun aPodcastPodcastLocked(
+    owner: String = "podcast podcast: locked owner",
+    locked: Boolean = true
+) = Podcast.Podcast.Locked(owner, locked)
+
+internal fun aPodcastPodcastFunding(
+    url: String = "podcast podcast: funding url",
+    message: String = "podcast podcast: funding message"
+) = Podcast.Podcast.Funding(url, message)

--- a/src/test/kotlin/io/hemin/wien/parser/namespace/AtomParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/namespace/AtomParserTest.kt
@@ -38,7 +38,7 @@ internal class AtomParserTest : NamespaceParserTest() {
         val builder = FakePodcastBuilder()
         channel.parseChannelChildNodes(builder)
 
-        assertThat(builder.atom, "atom podcast data").all {
+        assertThat(builder.atomBuilder, "atom podcast data").all {
             prop(FakePodcastAtomBuilder::authorBuilders).containsExactly(expectedPersonBuilder)
             prop(FakePodcastAtomBuilder::contributorBuilders).containsExactly(expectedPersonBuilder)
             prop(FakePodcastAtomBuilder::linkBuilders).containsExactly(expectedLinkBuilder)
@@ -51,10 +51,10 @@ internal class AtomParserTest : NamespaceParserTest() {
         val builder = FakePodcastBuilder()
         channel.parseChannelChildNodes(builder)
 
-        assertThat(builder.atom, "atom episode data").all {
+        assertThat(builder.atomBuilder, "atom episode data").all {
             prop(FakePodcastAtomBuilder::authorBuilders).noneHasEnoughDataToBuild()
             prop(FakePodcastAtomBuilder::contributorBuilders).noneHasEnoughDataToBuild()
-            prop(FakePodcastAtomBuilder::linkBuilders).noneHasEnoughDataToBuild()
+            prop(FakePodcastAtomBuilder::linkBuilders).isEmpty()
         }
     }
 
@@ -64,7 +64,7 @@ internal class AtomParserTest : NamespaceParserTest() {
         val builder = FakePodcastBuilder()
         channel.parseChannelChildNodes(builder)
 
-        assertThat(builder.atom, "atom episode data").all {
+        assertThat(builder.atomBuilder, "atom episode data").all {
             prop(FakePodcastAtomBuilder::authorBuilders).isEmpty()
             prop(FakePodcastAtomBuilder::contributorBuilders).isEmpty()
             prop(FakePodcastAtomBuilder::linkBuilders).isEmpty()
@@ -77,7 +77,7 @@ internal class AtomParserTest : NamespaceParserTest() {
         val builder = FakeEpisodeBuilder()
         item.parseItemChildNodes(builder)
 
-        assertThat(builder.atom, "atom item data").all {
+        assertThat(builder.atomBuilder, "atom item data").all {
             prop(FakeEpisodeAtomBuilder::authorBuilders).containsExactly(expectedPersonBuilder)
             prop(FakeEpisodeAtomBuilder::contributorBuilders).containsExactly(expectedPersonBuilder)
             prop(FakeEpisodeAtomBuilder::linkBuilders).containsExactly(expectedLinkBuilder)
@@ -90,7 +90,7 @@ internal class AtomParserTest : NamespaceParserTest() {
         val builder = FakeEpisodeBuilder()
         item.parseItemChildNodes(builder)
 
-        assertThat(builder.atom, "atom item data").all {
+        assertThat(builder.atomBuilder, "atom item data").all {
             prop(FakeEpisodeAtomBuilder::authorBuilders).isEmpty()
             prop(FakeEpisodeAtomBuilder::contributorBuilders).isEmpty()
             prop(FakeEpisodeAtomBuilder::linkBuilders).isEmpty()
@@ -103,10 +103,10 @@ internal class AtomParserTest : NamespaceParserTest() {
         val builder = FakeEpisodeBuilder()
         item.parseItemChildNodes(builder)
 
-        assertThat(builder.atom, "atom item data").all {
+        assertThat(builder.atomBuilder, "atom item data").all {
             prop(FakeEpisodeAtomBuilder::authorBuilders).noneHasEnoughDataToBuild()
             prop(FakeEpisodeAtomBuilder::contributorBuilders).noneHasEnoughDataToBuild()
-            prop(FakeEpisodeAtomBuilder::linkBuilders).noneHasEnoughDataToBuild()
+            prop(FakeEpisodeAtomBuilder::linkBuilders).isEmpty()
         }
     }
 }

--- a/src/test/kotlin/io/hemin/wien/parser/namespace/AtomParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/namespace/AtomParserTest.kt
@@ -1,4 +1,4 @@
-package io.hemin.wien.parser
+package io.hemin.wien.parser.namespace
 
 import assertk.all
 import assertk.assertThat
@@ -13,7 +13,7 @@ import io.hemin.wien.builder.fake.podcast.FakePodcastAtomBuilder
 import io.hemin.wien.builder.fake.podcast.FakePodcastBuilder
 import io.hemin.wien.dom.XmlRes
 import io.hemin.wien.noneHasEnoughDataToBuild
-import io.hemin.wien.parser.namespace.AtomParser
+import io.hemin.wien.parser.NamespaceParserTest
 import org.junit.jupiter.api.Test
 import org.w3c.dom.Node
 

--- a/src/test/kotlin/io/hemin/wien/parser/namespace/BitloveParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/namespace/BitloveParserTest.kt
@@ -1,4 +1,4 @@
-package io.hemin.wien.parser
+package io.hemin.wien.parser.namespace
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
@@ -7,7 +7,7 @@ import assertk.assertions.prop
 import io.hemin.wien.builder.fake.episode.FakeEpisodeBitloveBuilder
 import io.hemin.wien.builder.fake.episode.FakeEpisodeBuilder
 import io.hemin.wien.dom.XmlRes
-import io.hemin.wien.parser.namespace.BitloveParser
+import io.hemin.wien.parser.NamespaceParserTest
 import org.junit.jupiter.api.Test
 import org.w3c.dom.Node
 

--- a/src/test/kotlin/io/hemin/wien/parser/namespace/BitloveParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/namespace/BitloveParserTest.kt
@@ -21,7 +21,7 @@ internal class BitloveParserTest : NamespaceParserTest() {
         val builder = FakeEpisodeBuilder()
         node.parseItemChildNodes(builder)
 
-        assertThat(builder.bitlove, "item bitlove data")
+        assertThat(builder.bitloveBuilder, "item bitlove data")
             .prop(FakeEpisodeBitloveBuilder::guid).isEqualTo("abcdefg")
     }
 
@@ -31,7 +31,7 @@ internal class BitloveParserTest : NamespaceParserTest() {
         val builder = FakeEpisodeBuilder()
         node.parseItemChildNodes(builder)
 
-        assertThat(builder.bitlove, "item bitlove data")
+        assertThat(builder.bitloveBuilder, "item bitlove data")
             .prop(FakeEpisodeBitloveBuilder::guid).isNull()
     }
 
@@ -41,7 +41,7 @@ internal class BitloveParserTest : NamespaceParserTest() {
         val builder = FakeEpisodeBuilder()
         channel.parseItemChildNodes(builder)
 
-        assertThat(builder.bitlove, "item bitlove data")
+        assertThat(builder.bitloveBuilder, "item bitlove data")
             .prop(FakeEpisodeBitloveBuilder::guid).isNull()
     }
 }

--- a/src/test/kotlin/io/hemin/wien/parser/namespace/ContentParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/namespace/ContentParserTest.kt
@@ -1,4 +1,4 @@
-package io.hemin.wien.parser
+package io.hemin.wien.parser.namespace
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
@@ -7,7 +7,8 @@ import assertk.assertions.prop
 import io.hemin.wien.builder.fake.episode.FakeEpisodeBuilder
 import io.hemin.wien.builder.fake.episode.FakeEpisodeContentBuilder
 import io.hemin.wien.dom.XmlRes
-import io.hemin.wien.parser.namespace.ContentParser
+import io.hemin.wien.parser.NamespaceParser
+import io.hemin.wien.parser.NamespaceParserTest
 import org.junit.jupiter.api.Test
 import org.w3c.dom.Node
 

--- a/src/test/kotlin/io/hemin/wien/parser/namespace/ContentParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/namespace/ContentParserTest.kt
@@ -22,7 +22,7 @@ internal class ContentParserTest : NamespaceParserTest() {
         val builder = FakeEpisodeBuilder()
         node.parseItemChildNodes(builder)
 
-        assertThat(builder.content, "item content data")
+        assertThat(builder.contentBuilder, "item content data")
             .prop(FakeEpisodeContentBuilder::encoded).isEqualTo("Lorem Ipsum")
     }
 
@@ -32,7 +32,7 @@ internal class ContentParserTest : NamespaceParserTest() {
         val builder = FakeEpisodeBuilder()
         node.parseItemChildNodes(builder)
 
-        assertThat(builder.content, "item content data")
+        assertThat(builder.contentBuilder, "item content data")
             .prop(FakeEpisodeContentBuilder::encoded).isNull()
     }
 
@@ -42,7 +42,7 @@ internal class ContentParserTest : NamespaceParserTest() {
         val builder = FakeEpisodeBuilder()
         channel.parseItemChildNodes(builder)
 
-        assertThat(builder.content, "item content data")
+        assertThat(builder.contentBuilder, "item content data")
             .prop(FakeEpisodeContentBuilder::encoded).isNull()
     }
 }

--- a/src/test/kotlin/io/hemin/wien/parser/namespace/FeedpressParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/namespace/FeedpressParserTest.kt
@@ -23,7 +23,7 @@ internal class FeedpressParserTest : NamespaceParserTest() {
         val builder = FakePodcastBuilder()
         node.parseChannelChildNodes(builder)
 
-        assertThat(builder.feedpress, "channel feedpress data").all {
+        assertThat(builder.feedpressBuilder, "channel feedpress data").all {
             prop(FakePodcastFeedpressBuilder::newsletterIdValue).isEqualTo("abc123")
             prop(FakePodcastFeedpressBuilder::localeValue).isEqualTo("en")
             prop(FakePodcastFeedpressBuilder::podcastIdValue).isEqualTo("xyz123")
@@ -38,7 +38,7 @@ internal class FeedpressParserTest : NamespaceParserTest() {
         val builder = FakePodcastBuilder()
         node.parseChannelChildNodes(builder)
 
-        assertThat(builder.feedpress, "channel feedpress data").all {
+        assertThat(builder.feedpressBuilder, "channel feedpress data").all {
             prop(FakePodcastFeedpressBuilder::newsletterIdValue).isNull()
             prop(FakePodcastFeedpressBuilder::localeValue).isNull()
             prop(FakePodcastFeedpressBuilder::podcastIdValue).isNull()
@@ -53,7 +53,7 @@ internal class FeedpressParserTest : NamespaceParserTest() {
         val builder = FakePodcastBuilder()
         channel.parseChannelChildNodes(builder)
 
-        assertThat(builder.feedpress, "channel feedpress data").all {
+        assertThat(builder.feedpressBuilder, "channel feedpress data").all {
             prop(FakePodcastFeedpressBuilder::newsletterIdValue).isNull()
             prop(FakePodcastFeedpressBuilder::localeValue).isNull()
             prop(FakePodcastFeedpressBuilder::podcastIdValue).isNull()

--- a/src/test/kotlin/io/hemin/wien/parser/namespace/FeedpressParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/namespace/FeedpressParserTest.kt
@@ -1,4 +1,4 @@
-package io.hemin.wien.parser
+package io.hemin.wien.parser.namespace
 
 import assertk.all
 import assertk.assertThat
@@ -8,7 +8,8 @@ import assertk.assertions.prop
 import io.hemin.wien.builder.fake.podcast.FakePodcastBuilder
 import io.hemin.wien.builder.fake.podcast.FakePodcastFeedpressBuilder
 import io.hemin.wien.dom.XmlRes
-import io.hemin.wien.parser.namespace.FeedpressParser
+import io.hemin.wien.parser.NamespaceParser
+import io.hemin.wien.parser.NamespaceParserTest
 import org.junit.jupiter.api.Test
 import org.w3c.dom.Node
 

--- a/src/test/kotlin/io/hemin/wien/parser/namespace/FyydParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/namespace/FyydParserTest.kt
@@ -1,4 +1,4 @@
-package io.hemin.wien.parser
+package io.hemin.wien.parser.namespace
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
@@ -7,7 +7,8 @@ import assertk.assertions.prop
 import io.hemin.wien.builder.fake.podcast.FakePodcastBuilder
 import io.hemin.wien.builder.fake.podcast.FakePodcastFyydBuilder
 import io.hemin.wien.dom.XmlRes
-import io.hemin.wien.parser.namespace.FyydParser
+import io.hemin.wien.parser.NamespaceParser
+import io.hemin.wien.parser.NamespaceParserTest
 import org.junit.jupiter.api.Test
 import org.w3c.dom.Node
 

--- a/src/test/kotlin/io/hemin/wien/parser/namespace/FyydParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/namespace/FyydParserTest.kt
@@ -22,7 +22,7 @@ internal class FyydParserTest : NamespaceParserTest() {
         val builder = FakePodcastBuilder()
         node.parseChannelChildNodes(builder)
 
-        assertThat(builder.fyyd, "channel.fyyd")
+        assertThat(builder.fyydBuilder, "channel.fyyd")
             .prop(FakePodcastFyydBuilder::verifyValue).isEqualTo("abcdefg")
     }
 
@@ -32,7 +32,7 @@ internal class FyydParserTest : NamespaceParserTest() {
         val builder = FakePodcastBuilder()
         node.parseChannelChildNodes(builder)
 
-        assertThat(builder.fyyd, "channel.fyyd")
+        assertThat(builder.fyydBuilder, "channel.fyyd")
             .prop(FakePodcastFyydBuilder::verifyValue).isNull()
     }
 
@@ -42,7 +42,7 @@ internal class FyydParserTest : NamespaceParserTest() {
         val builder = FakePodcastBuilder()
         channel.parseChannelChildNodes(builder)
 
-        assertThat(builder.fyyd, "channel.fyyd")
+        assertThat(builder.fyydBuilder, "channel.fyyd")
             .prop(FakePodcastFyydBuilder::verifyValue).isNull()
     }
 }

--- a/src/test/kotlin/io/hemin/wien/parser/namespace/GooglePlayParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/namespace/GooglePlayParserTest.kt
@@ -37,7 +37,7 @@ internal class GooglePlayParserTest : NamespaceParserTest() {
         val builder = FakePodcastBuilder()
         node.parseChannelChildNodes(builder)
 
-        assertThat(builder.googlePlay, "channel.googleplay").all {
+        assertThat(builder.googlePlayBuilder, "channel.googleplay").all {
             prop(FakePodcastGooglePlayBuilder::author).isEqualTo("Lorem Ipsum")
             prop(FakePodcastGooglePlayBuilder::owner).isEqualTo("email@example.org")
             prop(FakePodcastGooglePlayBuilder::categoryBuilders).containsExactly(FakeITunesStyleCategoryBuilder().category("Technology"))
@@ -54,7 +54,7 @@ internal class GooglePlayParserTest : NamespaceParserTest() {
         val builder = FakePodcastBuilder()
         node.parseChannelChildNodes(builder)
 
-        assertThat(builder.googlePlay, "channel.googleplay").all {
+        assertThat(builder.googlePlayBuilder, "channel.googleplay").all {
             prop(FakePodcastGooglePlayBuilder::author).isNull()
             prop(FakePodcastGooglePlayBuilder::owner).isNull()
             prop(FakePodcastGooglePlayBuilder::categoryBuilders).isEmpty()
@@ -71,7 +71,7 @@ internal class GooglePlayParserTest : NamespaceParserTest() {
         val builder = FakePodcastBuilder()
         channel.parseChannelChildNodes(builder)
 
-        assertThat(builder.googlePlay, "channel.googleplay").all {
+        assertThat(builder.googlePlayBuilder, "channel.googleplay").all {
             prop(FakePodcastGooglePlayBuilder::author).isNull()
             prop(FakePodcastGooglePlayBuilder::owner).isNull()
             prop(FakePodcastGooglePlayBuilder::categoryBuilders).noneHasEnoughDataToBuild()
@@ -88,7 +88,7 @@ internal class GooglePlayParserTest : NamespaceParserTest() {
         val builder = FakeEpisodeBuilder()
         node.parseItemChildNodes(builder)
 
-        assertThat(builder.googlePlay, "item.googleplay").all {
+        assertThat(builder.googlePlayBuilder, "item.googleplay").all {
             prop(FakeEpisodeGooglePlayBuilder::description).isEqualTo("Lorem Ipsum")
             prop(FakeEpisodeGooglePlayBuilder::explicit).isNotNull().isFalse()
             prop(FakeEpisodeGooglePlayBuilder::block).isNotNull().isFalse()
@@ -102,7 +102,7 @@ internal class GooglePlayParserTest : NamespaceParserTest() {
         val builder = FakeEpisodeBuilder()
         node.parseItemChildNodes(builder)
 
-        assertThat(builder.googlePlay, "item.googleplay").all {
+        assertThat(builder.googlePlayBuilder, "item.googleplay").all {
             prop(FakeEpisodeGooglePlayBuilder::description).isNull()
             prop(FakeEpisodeGooglePlayBuilder::explicit).isNull()
             prop(FakeEpisodeGooglePlayBuilder::block).isNull()
@@ -116,7 +116,7 @@ internal class GooglePlayParserTest : NamespaceParserTest() {
         val builder = FakeEpisodeBuilder()
         channel.parseItemChildNodes(builder)
 
-        assertThat(builder.googlePlay, "item.googleplay").all {
+        assertThat(builder.googlePlayBuilder, "item.googleplay").all {
             prop(FakeEpisodeGooglePlayBuilder::description).isNull()
             prop(FakeEpisodeGooglePlayBuilder::explicit).isNull()
             prop(FakeEpisodeGooglePlayBuilder::block).isNull()

--- a/src/test/kotlin/io/hemin/wien/parser/namespace/GooglePlayParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/namespace/GooglePlayParserTest.kt
@@ -1,4 +1,4 @@
-package io.hemin.wien.parser
+package io.hemin.wien.parser.namespace
 
 import assertk.all
 import assertk.assertThat
@@ -18,7 +18,8 @@ import io.hemin.wien.builder.fake.podcast.FakePodcastGooglePlayBuilder
 import io.hemin.wien.dom.XmlRes
 import io.hemin.wien.hasNotEnoughDataToBuild
 import io.hemin.wien.noneHasEnoughDataToBuild
-import io.hemin.wien.parser.namespace.GooglePlayParser
+import io.hemin.wien.parser.NamespaceParser
+import io.hemin.wien.parser.NamespaceParserTest
 import org.junit.jupiter.api.Test
 import org.w3c.dom.Node
 

--- a/src/test/kotlin/io/hemin/wien/parser/namespace/ITunesParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/namespace/ITunesParserTest.kt
@@ -1,4 +1,4 @@
-package io.hemin.wien.parser
+package io.hemin.wien.parser.namespace
 
 import assertk.all
 import assertk.assertThat
@@ -21,7 +21,7 @@ import io.hemin.wien.hasNotEnoughDataToBuild
 import io.hemin.wien.model.Episode
 import io.hemin.wien.model.Podcast
 import io.hemin.wien.noneHasEnoughDataToBuild
-import io.hemin.wien.parser.namespace.ITunesParser
+import io.hemin.wien.parser.NamespaceParserTest
 import org.junit.jupiter.api.Test
 import org.w3c.dom.Node
 

--- a/src/test/kotlin/io/hemin/wien/parser/namespace/ITunesParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/namespace/ITunesParserTest.kt
@@ -43,7 +43,7 @@ internal class ITunesParserTest : NamespaceParserTest() {
         val builder = FakePodcastBuilder()
         node.parseChannelChildNodes(builder)
 
-        assertThat(builder.iTunes, "channel.itunes").all {
+        assertThat(builder.iTunesBuilder, "channel.itunes").all {
             prop(FakePodcastITunesBuilder::author).isEqualTo("Lorem Ipsum")
             prop(FakePodcastITunesBuilder::ownerBuilder).isEqualTo(expectedOwnerBuilder)
             prop(FakePodcastITunesBuilder::categoryBuilders).containsExactly(
@@ -70,7 +70,7 @@ internal class ITunesParserTest : NamespaceParserTest() {
         val builder = FakePodcastBuilder()
         node.parseChannelChildNodes(builder)
 
-        assertThat(builder.iTunes, "channel.itunes").all {
+        assertThat(builder.iTunesBuilder, "channel.itunes").all {
             prop(FakePodcastITunesBuilder::author).isNull()
             prop(FakePodcastITunesBuilder::ownerBuilder).isNull()
             prop(FakePodcastITunesBuilder::categoryBuilders).isEmpty()
@@ -93,7 +93,7 @@ internal class ITunesParserTest : NamespaceParserTest() {
         val builder = FakePodcastBuilder()
         channel.parseChannelChildNodes(builder)
 
-        assertThat(builder.iTunes, "channel.itunes").all {
+        assertThat(builder.iTunesBuilder, "channel.itunes").all {
             prop(FakePodcastITunesBuilder::author).isNull()
             prop(FakePodcastITunesBuilder::ownerBuilder).isNotNull().hasNotEnoughDataToBuild()
             prop(FakePodcastITunesBuilder::categoryBuilders).noneHasEnoughDataToBuild()
@@ -116,7 +116,7 @@ internal class ITunesParserTest : NamespaceParserTest() {
         val builder = FakeEpisodeBuilder()
         node.parseItemChildNodes(builder)
 
-        assertThat(builder.iTunes, "item.itunes").all {
+        assertThat(builder.iTunesBuilder, "item.itunes").all {
             prop(FakeEpisodeITunesBuilder::title).isEqualTo("Lorem Ipsum")
             prop(FakeEpisodeITunesBuilder::duration).isEqualTo("03:24:27")
             prop(FakeEpisodeITunesBuilder::season).isEqualTo(1)
@@ -137,7 +137,7 @@ internal class ITunesParserTest : NamespaceParserTest() {
         val builder = FakeEpisodeBuilder()
         node.parseItemChildNodes(builder)
 
-        assertThat(builder.iTunes, "item.itunes").all {
+        assertThat(builder.iTunesBuilder, "item.itunes").all {
             prop(FakeEpisodeITunesBuilder::title).isNull()
             prop(FakeEpisodeITunesBuilder::duration).isNull()
             prop(FakeEpisodeITunesBuilder::season).isNull()
@@ -158,7 +158,7 @@ internal class ITunesParserTest : NamespaceParserTest() {
         val builder = FakeEpisodeBuilder()
         channel.parseItemChildNodes(builder)
 
-        assertThat(builder.iTunes, "item.itunes").all {
+        assertThat(builder.iTunesBuilder, "item.itunes").all {
             prop(FakeEpisodeITunesBuilder::title).isNull()
             prop(FakeEpisodeITunesBuilder::duration).isNull()
             prop(FakeEpisodeITunesBuilder::season).isNull()

--- a/src/test/kotlin/io/hemin/wien/parser/namespace/PodcastNamespaceParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/namespace/PodcastNamespaceParserTest.kt
@@ -1,0 +1,126 @@
+package io.hemin.wien.parser.namespace
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.prop
+import io.hemin.wien.builder.fake.episode.FakeEpisodeBuilder
+import io.hemin.wien.builder.fake.episode.FakeEpisodePodcastBuilder
+import io.hemin.wien.builder.fake.episode.FakeEpisodePodcastChaptersBuilder
+import io.hemin.wien.builder.fake.episode.FakeEpisodePodcastSoundbiteBuilder
+import io.hemin.wien.builder.fake.episode.FakeEpisodePodcastTranscriptBuilder
+import io.hemin.wien.builder.fake.podcast.FakePodcastBuilder
+import io.hemin.wien.builder.fake.podcast.FakePodcastPodcastBuilder
+import io.hemin.wien.builder.fake.podcast.FakePodcastPodcastFundingBuilder
+import io.hemin.wien.builder.fake.podcast.FakePodcastPodcastLockedBuilder
+import io.hemin.wien.dom.XmlRes
+import io.hemin.wien.model.Episode
+import io.hemin.wien.parser.NamespaceParser
+import io.hemin.wien.parser.NamespaceParserTest
+import org.junit.jupiter.api.Test
+import org.w3c.dom.Node
+import java.time.Duration
+
+internal class PodcastNamespaceParserTest : NamespaceParserTest() {
+
+    override val parser: NamespaceParser = PodcastNamespaceParser()
+
+    private val expectedLockedBuilder = FakePodcastPodcastLockedBuilder()
+        .locked(true)
+        .owner("podcastowner@example.com")
+
+    private val expectedFundingBuilder = FakePodcastPodcastFundingBuilder()
+        .url("https://example.com/donate")
+        .message("Support the show!")
+
+    private val expectedChaptersBuilder = FakeEpisodePodcastChaptersBuilder()
+        .url("https://example.com/ep3_chapters.json")
+        .type("application/json")
+
+    private val expectedSoundbiteBuilder = FakeEpisodePodcastSoundbiteBuilder()
+        .startTime(Duration.ofMillis(33833))
+        .duration(Duration.ofSeconds(60))
+
+    private val expectedTranscriptBuilder = FakeEpisodePodcastTranscriptBuilder()
+        .url("https://example.com/ep3/transcript.txt")
+        .type(Episode.Podcast.Transcript.Type.PLAIN_TEXT)
+
+    @Test
+    fun `should extract all podcast fields from channel when present`() {
+        val channel: Node = XmlRes("/xml/channel.xml").rootNodeByName("channel")
+        val builder = FakePodcastBuilder()
+        channel.parseChannelChildNodes(builder)
+
+        assertThat(builder.podcastBuilder, "podcast: podcast data").isNotNull().all {
+            prop(FakePodcastPodcastBuilder::lockedBuilderValue).isEqualTo(expectedLockedBuilder)
+            prop(FakePodcastPodcastBuilder::fundingBuilders).containsExactly(expectedFundingBuilder)
+        }
+    }
+
+    @Test
+    fun `should extract nothing from channel when podcast data is all empty`() {
+        val channel: Node = XmlRes("/xml/rss-all-empty.xml").nodeByXPath("/rss/channel")
+        val builder = FakePodcastBuilder()
+        channel.parseChannelChildNodes(builder)
+
+        assertThat(builder.podcastBuilder, "podcast: episode data").all {
+            prop(FakePodcastPodcastBuilder::lockedBuilderValue).isNull()
+            prop(FakePodcastPodcastBuilder::fundingBuilders).isEmpty()
+        }
+    }
+
+    @Test
+    fun `should extract nothing from channel when no podcast data is present`() {
+        val channel: Node = XmlRes("/xml/channel-incomplete.xml").rootNodeByName("channel")
+        val builder = FakePodcastBuilder()
+        channel.parseChannelChildNodes(builder)
+
+        assertThat(builder.podcastBuilder, "podcast: episode data").all {
+            prop(FakePodcastPodcastBuilder::lockedBuilderValue).isNull()
+            prop(FakePodcastPodcastBuilder::fundingBuilders).isEmpty()
+        }
+    }
+
+    @Test
+    fun `should extract all podcast fields from item when present`() {
+        val item: Node = XmlRes("/xml/item.xml").rootNodeByName("item")
+        val builder = FakeEpisodeBuilder()
+        item.parseItemChildNodes(builder)
+
+        assertThat(builder.podcastBuilder, "podcast: item data").all {
+            prop(FakeEpisodePodcastBuilder::chaptersBuilderValue).isEqualTo(expectedChaptersBuilder)
+            prop(FakeEpisodePodcastBuilder::soundbiteBuilders).containsExactly(expectedSoundbiteBuilder)
+            prop(FakeEpisodePodcastBuilder::transcriptBuilders).containsExactly(expectedTranscriptBuilder)
+        }
+    }
+
+    @Test
+    fun `should extract nothing from item when no podcast data is present`() {
+        val item: Node = XmlRes("/xml/item-incomplete.xml").rootNodeByName("item")
+        val builder = FakeEpisodeBuilder()
+        item.parseItemChildNodes(builder)
+
+        assertThat(builder.podcastBuilder, "podcast: item data").all {
+            prop(FakeEpisodePodcastBuilder::chaptersBuilderValue).isNull()
+            prop(FakeEpisodePodcastBuilder::soundbiteBuilders).isEmpty()
+            prop(FakeEpisodePodcastBuilder::transcriptBuilders).isEmpty()
+        }
+    }
+
+    @Test
+    fun `should extract nothing from item when podcast data is all empty`() {
+        val item: Node = XmlRes("/xml/rss-all-empty.xml").nodeByXPath("/rss/channel/item")
+        val builder = FakeEpisodeBuilder()
+        item.parseItemChildNodes(builder)
+
+        assertThat(builder.podcastBuilder, "podcast item data").all {
+            prop(FakeEpisodePodcastBuilder::chaptersBuilderValue).isNull()
+            prop(FakeEpisodePodcastBuilder::soundbiteBuilders).isEmpty()
+            prop(FakeEpisodePodcastBuilder::transcriptBuilders).isEmpty()
+        }
+    }
+}

--- a/src/test/kotlin/io/hemin/wien/parser/namespace/PodcastNamespaceParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/namespace/PodcastNamespaceParserTest.kt
@@ -24,6 +24,7 @@ import io.hemin.wien.parser.NamespaceParserTest
 import org.junit.jupiter.api.Test
 import org.w3c.dom.Node
 import java.time.Duration
+import java.util.Locale
 
 internal class PodcastNamespaceParserTest : NamespaceParserTest() {
 
@@ -44,10 +45,13 @@ internal class PodcastNamespaceParserTest : NamespaceParserTest() {
     private val expectedSoundbiteBuilder = FakeEpisodePodcastSoundbiteBuilder()
         .startTime(Duration.ofMillis(33833))
         .duration(Duration.ofSeconds(60))
+        .title("I'm a soundbite")
 
     private val expectedTranscriptBuilder = FakeEpisodePodcastTranscriptBuilder()
         .url("https://example.com/ep3/transcript.txt")
         .type(Episode.Podcast.Transcript.Type.PLAIN_TEXT)
+        .language(Locale.ITALY)
+        .rel("captions")
 
     @Test
     fun `should extract all podcast fields from channel when present`() {

--- a/src/test/kotlin/io/hemin/wien/parser/namespace/PodloveSimpleChapterParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/namespace/PodloveSimpleChapterParserTest.kt
@@ -23,7 +23,7 @@ internal class PodloveSimpleChapterParserTest : NamespaceParserTest() {
         val builder = FakeEpisodeBuilder()
         node.parseItemChildNodes(builder)
 
-        assertThat(builder.podlove.chapterBuilders, "item.podlove_simple_chapters").isEmpty()
+        assertThat(builder.podloveBuilder.chapterBuilders, "item.podlove_simple_chapters").isEmpty()
     }
 
     @Test
@@ -32,8 +32,8 @@ internal class PodloveSimpleChapterParserTest : NamespaceParserTest() {
         val builder = FakeEpisodeBuilder()
         channel.parseItemChildNodes(builder)
 
-        assertThat(builder.podlove, "item.podlove_simple_chapters")
-            .prop(FakeEpisodePodloveBuilder::chapterBuilders).noneHasEnoughDataToBuild()
+        assertThat(builder.podloveBuilder, "item.podlove_simple_chapters")
+            .prop(FakeEpisodePodloveBuilder::chapterBuilders).isEmpty()
     }
 
     @Test
@@ -42,7 +42,7 @@ internal class PodloveSimpleChapterParserTest : NamespaceParserTest() {
         val builder = FakeEpisodeBuilder()
         node.parseItemChildNodes(builder)
 
-        assertThat(builder.podlove.chapterBuilders, "item.podlove_simple_chapters")
+        assertThat(builder.podloveBuilder.chapterBuilders, "item.podlove_simple_chapters")
             .containsExactly(
                 FakeEpisodePodloveSimpleChapterBuilder()
                     .start("00:00:00.000")

--- a/src/test/kotlin/io/hemin/wien/parser/namespace/PodloveSimpleChapterParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/namespace/PodloveSimpleChapterParserTest.kt
@@ -1,4 +1,4 @@
-package io.hemin.wien.parser
+package io.hemin.wien.parser.namespace
 
 import assertk.assertThat
 import assertk.assertions.containsExactly
@@ -9,7 +9,7 @@ import io.hemin.wien.builder.fake.episode.FakeEpisodePodloveBuilder
 import io.hemin.wien.builder.fake.episode.FakeEpisodePodloveSimpleChapterBuilder
 import io.hemin.wien.dom.XmlRes
 import io.hemin.wien.noneHasEnoughDataToBuild
-import io.hemin.wien.parser.namespace.PodloveSimpleChapterParser
+import io.hemin.wien.parser.NamespaceParserTest
 import org.junit.jupiter.api.Test
 import org.w3c.dom.Node
 

--- a/src/test/kotlin/io/hemin/wien/parser/namespace/PodloveSimpleChapterParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/namespace/PodloveSimpleChapterParserTest.kt
@@ -8,7 +8,6 @@ import io.hemin.wien.builder.fake.episode.FakeEpisodeBuilder
 import io.hemin.wien.builder.fake.episode.FakeEpisodePodloveBuilder
 import io.hemin.wien.builder.fake.episode.FakeEpisodePodloveSimpleChapterBuilder
 import io.hemin.wien.dom.XmlRes
-import io.hemin.wien.noneHasEnoughDataToBuild
 import io.hemin.wien.parser.NamespaceParserTest
 import org.junit.jupiter.api.Test
 import org.w3c.dom.Node

--- a/src/test/kotlin/io/hemin/wien/parser/namespace/RssParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/namespace/RssParserTest.kt
@@ -1,4 +1,4 @@
-package io.hemin.wien.parser
+package io.hemin.wien.parser.namespace
 
 import assertk.all
 import assertk.assertThat
@@ -18,7 +18,7 @@ import io.hemin.wien.dateTime
 import io.hemin.wien.dom.XmlRes
 import io.hemin.wien.hasNotEnoughDataToBuild
 import io.hemin.wien.noneHasEnoughDataToBuild
-import io.hemin.wien.parser.namespace.RssParser
+import io.hemin.wien.parser.NamespaceParserTest
 import org.junit.jupiter.api.Test
 import org.w3c.dom.Node
 import java.time.Month

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/PodcastNamespaceWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/PodcastNamespaceWriterTest.kt
@@ -102,8 +102,8 @@ internal class PodcastNamespaceWriterTest : NamespaceWriterTest() {
     internal fun `should not write podcast tags to the item when the data is blank`() {
         val episode = anEpisode(
             podcast = anEpisodePodcast(
-                  transcripts = listOf(anEpisodePodcastTranscript(" ")),
-                  chapters = anEpisodePodcastChapters(" ")
+                transcripts = listOf(anEpisodePodcastTranscript(" ")),
+                chapters = anEpisodePodcastChapters(" ")
             )
         )
         assertAll {

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/PodcastNamespaceWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/PodcastNamespaceWriterTest.kt
@@ -1,0 +1,144 @@
+package io.hemin.wien.writer.namespace
+
+import assertk.assertAll
+import assertk.assertThat
+import io.hemin.wien.hasNoDifferences
+import io.hemin.wien.model.episode.anEpisode
+import io.hemin.wien.model.episode.anEpisodePodcast
+import io.hemin.wien.model.episode.anEpisodePodcastChapters
+import io.hemin.wien.model.episode.anEpisodePodcastSoundbite
+import io.hemin.wien.model.episode.anEpisodePodcastTranscript
+import io.hemin.wien.model.podcast.aPodcast
+import io.hemin.wien.model.podcast.aPodcastPodcast
+import io.hemin.wien.model.podcast.aPodcastPodcastFunding
+import io.hemin.wien.model.podcast.aPodcastPodcastLocked
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+internal class PodcastNamespaceWriterTest : NamespaceWriterTest() {
+
+    override val writer = PodcastNamespaceWriter()
+
+    @Test
+    internal fun `should write the correct podcast tags to the channel when there is data to write`() {
+        assertAll {
+            writePodcastData("locked") { element ->
+                val diff = element.diffFromExpected("/rss/channel/podcast:locked")
+                assertThat(diff).hasNoDifferences()
+            }
+            writePodcastData("funding") { element ->
+                val diff = element.diffFromExpected("/rss/channel/podcast:funding")
+                assertThat(diff).hasNoDifferences()
+            }
+        }
+    }
+
+    @Test
+    internal fun `should not write podcast tags to the channel when there is no data to write`() {
+        val podcast = aPodcast(podcast = null)
+        assertAll {
+            assertTagIsNotWrittenToPodcast(podcast, "locked")
+            assertTagIsNotWrittenToPodcast(podcast, "funding")
+        }
+    }
+
+    @Test
+    internal fun `should not write podcast tags to the channel when the data is blank`() {
+        val podcast = aPodcast(
+            podcast = aPodcastPodcast(
+                locked = aPodcastPodcastLocked(" "),
+                funding = listOf(aPodcastPodcastFunding(" ", " "))
+            )
+        )
+        assertAll {
+            assertTagIsNotWrittenToPodcast(podcast, "locked")
+            assertTagIsNotWrittenToPodcast(podcast, "funding")
+        }
+    }
+
+    @Test
+    internal fun `should not write podcast tags to the channel when the data is empty`() {
+        val podcast = aPodcast(
+            podcast = aPodcastPodcast(
+                locked = aPodcastPodcastLocked(""),
+                funding = listOf(aPodcastPodcastFunding("", ""))
+            )
+        )
+        assertAll {
+            assertTagIsNotWrittenToPodcast(podcast, "locked")
+            assertTagIsNotWrittenToPodcast(podcast, "funding")
+        }
+    }
+
+    @Test
+    internal fun `should write the correct podcast tags to the item when there is data to write`() {
+        assertAll {
+            writeEpisodeData("transcript") { element ->
+                val diff = element.diffFromExpected("/rss/channel/item[1]/podcast:transcript")
+                assertThat(diff).hasNoDifferences()
+            }
+            writeEpisodeData("soundbite") { element ->
+                val diff = element.diffFromExpected("/rss/channel/item[1]/podcast:soundbite")
+                assertThat(diff).hasNoDifferences()
+            }
+            writeEpisodeData("chapters") { element ->
+                val diff = element.diffFromExpected("/rss/channel/item[1]/podcast:chapters")
+                assertThat(diff).hasNoDifferences()
+            }
+        }
+    }
+
+    @Test
+    internal fun `should not write podcast tags to the item when there is no data to write`() {
+        val episode = anEpisode(podcast = null)
+        assertAll {
+            assertTagIsNotWrittenToEpisode(episode, "transcript")
+            assertTagIsNotWrittenToEpisode(episode, "soundbite")
+            assertTagIsNotWrittenToEpisode(episode, "chapters")
+        }
+    }
+
+    @Test
+    internal fun `should not write podcast tags to the item when the data is blank`() {
+        val episode = anEpisode(
+            podcast = anEpisodePodcast(
+                  transcripts = listOf(anEpisodePodcastTranscript(" ")),
+                  chapters = anEpisodePodcastChapters(" ")
+            )
+        )
+        assertAll {
+            assertTagIsNotWrittenToEpisode(episode, "transcript")
+            assertTagIsNotWrittenToEpisode(episode, "chapters")
+        }
+    }
+
+    @Test
+    internal fun `should not write podcast tags to the item when the data is empty`() {
+        val episode = anEpisode(
+            podcast = anEpisodePodcast(
+                transcripts = listOf(anEpisodePodcastTranscript("")),
+                chapters = anEpisodePodcastChapters("")
+            )
+        )
+        assertAll {
+            assertTagIsNotWrittenToEpisode(episode, "transcript")
+            assertTagIsNotWrittenToEpisode(episode, "chapters")
+        }
+    }
+
+    @Test
+    internal fun `should not write podcast soundbite tags to the item when the durations are invalid`() {
+        val episode = anEpisode(
+            podcast = anEpisodePodcast(
+                soundbites = listOf(
+                    anEpisodePodcastSoundbite(startTime = Duration.ofSeconds(-1)),
+                    anEpisodePodcastSoundbite(duration = Duration.ZERO),
+                    anEpisodePodcastSoundbite(duration = Duration.ofSeconds(-1))
+                )
+            )
+        )
+        assertAll {
+            assertTagIsNotWrittenToEpisode(episode, "soundbite")
+        }
+    }
+}

--- a/src/test/resources/xml/channel.xml
+++ b/src/test/resources/xml/channel.xml
@@ -4,7 +4,8 @@
     xmlns:atom="http://www.w3.org/2005/Atom"
     xmlns:fyyd="https://fyyd.de/fyyd-ns/"
     xmlns:feedpress="https://feed.press/xmlns"
-    xmlns:googleplay="http://www.google.com/schemas/play-podcasts/1.0">
+    xmlns:googleplay="http://www.google.com/schemas/play-podcasts/1.0"
+    xmlns:podcast="https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md">
     <title>Lorem Ipsum</title>
     <link>http://example.org</link>
     <description>Lorem Ipsum</description>
@@ -72,4 +73,6 @@
     <feedpress:podcastId>xyz123</feedpress:podcastId>
     <feedpress:cssFile>http://example.org/style.css</feedpress:cssFile>
     <feedpress:link>http://example.org/my-link</feedpress:link>
+    <podcast:locked owner="podcastowner@example.com">yes</podcast:locked>
+    <podcast:funding url="https://example.com/donate">Support the show!</podcast:funding>
 </channel>

--- a/src/test/resources/xml/item.xml
+++ b/src/test/resources/xml/item.xml
@@ -55,6 +55,6 @@
         <psc:chapter start="00:02:12.641" title="Lorem Ipsum" href="http://example.org" image="http://example.org/cover"/>
     </psc:chapters>
     <podcast:chapters url="https://example.com/ep3_chapters.json" type="application/json"/>
-    <podcast:soundbite startTime="33.833" duration="60.0"/>
-    <podcast:transcript url="https://example.com/ep3/transcript.txt" type="text/plain"/>
+    <podcast:soundbite startTime="33.833" duration="60.0">I'm a soundbite</podcast:soundbite>
+    <podcast:transcript url="https://example.com/ep3/transcript.txt" type="text/plain" language="it-IT" rel="captions"/>
 </item>

--- a/src/test/resources/xml/item.xml
+++ b/src/test/resources/xml/item.xml
@@ -5,7 +5,8 @@
     xmlns:atom="http://www.w3.org/2005/Atom"
     xmlns:psc="http://podlove.org/simple-chapters"
     xmlns:googleplay="http://www.google.com/schemas/play-podcasts/1.0"
-    xmlns:bitlove="http://bitlove.org">
+    xmlns:bitlove="http://bitlove.org"
+    xmlns:podcast="https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md">
     <title>Lorem Ipsum</title>
     <link>http://example.org/episode1</link>
     <description><![CDATA[Lorem Ipsum]]></description>
@@ -53,4 +54,7 @@
         <psc:chapter start="00:01:03.856" title="Lorem Ipsum" href="http://example.org" image="http://example.org/cover"/>
         <psc:chapter start="00:02:12.641" title="Lorem Ipsum" href="http://example.org" image="http://example.org/cover"/>
     </psc:chapters>
+    <podcast:chapters url="https://example.com/ep3_chapters.json" type="application/json"/>
+    <podcast:soundbite startTime="33.833" duration="60.0"/>
+    <podcast:transcript url="https://example.com/ep3/transcript.txt" type="text/plain"/>
 </item>

--- a/src/test/resources/xml/writer-fixtures.xml
+++ b/src/test/resources/xml/writer-fixtures.xml
@@ -7,7 +7,8 @@
      xmlns:fyyd="https://fyyd.de/fyyd-ns/"
      xmlns:googleplay="http://www.google.com/schemas/play-podcasts/1.0"
      xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
-     xmlns:psc="http://podlove.org/simple-chapters">
+     xmlns:psc="http://podlove.org/simple-chapters"
+     xmlns:podcast="https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md">
     <channel>
         <title>podcast title</title>
         <link>podcast link</link>
@@ -74,6 +75,8 @@
         <googleplay:explicit>yes</googleplay:explicit>
         <googleplay:block>yes</googleplay:block>
         <googleplay:image href="podcast googleplay image url"/>
+        <podcast:locked owner="podcast podcast: locked owner">yes</podcast:locked>
+        <podcast:funding url="podcast podcast: funding url">podcast podcast: funding message</podcast:funding>
         <item>
             <title>episode title</title>
             <link>episode link</link>
@@ -118,6 +121,9 @@
             <googleplay:image href="episode googleplay image url"/>
             <googleplay:explicit>yes</googleplay:explicit>
             <googleplay:block>yes</googleplay:block>
+            <podcast:transcript url="episode podcast: transcript url" type="application/srt" language="it-IT" rel="captions"/>
+            <podcast:soundbite startTime="1" duration="15.123">episode podcast: soundbite title</podcast:soundbite>
+            <podcast:chapters url="episode podcast: chapters url" type="episode podcast: chapters type"/>
         </item>
     </channel>
 </rss>

--- a/src/test/resources/xml/writer-fixtures.xml
+++ b/src/test/resources/xml/writer-fixtures.xml
@@ -8,7 +8,7 @@
      xmlns:googleplay="http://www.google.com/schemas/play-podcasts/1.0"
      xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
      xmlns:psc="http://podlove.org/simple-chapters"
-     xmlns:podcast="https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md">
+     xmlns:podcast="https://podcastindex.org/namespace/1.0">
     <channel>
         <title>podcast title</title>
         <link>podcast link</link>


### PR DESCRIPTION
This PR adds support for parsing and writing the [`podcast:` namespace](https://github.com/Podcastindex-org/podcast-namespace) tags. The supported tags are just those whose specs are finalised:

<table>
    <thead>
        <tr>
            <th>Scope</th>
            <th>Tag</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td rowspan=2><code>&lt;channel&gt;</code></td>
            <td><code>&lt;podcast:locked&gt;</code></td>
        </tr>
        <tr>
            <td><code>&lt;podcast:funding&gt;</code></td>
        </tr>
        <tr>
            <td rowspan=3><code>&lt;item&gt;</code></td>
            <td><code>&lt;podcast:chapters&gt;</code></td>
        </tr>
        <tr>
            <td><code>&lt;podcast:soundbite&gt;</code></td>
        </tr>
        <tr>
            <td><code>&lt;podcast:transcript&gt;</code></td>
        </tr>
    </tbody>
</table>

To note, parsing and writing of the [chapters file JSON contents](https://github.com/Podcastindex-org/podcast-namespace/blob/main/chapters/jsonChapters.md) is outside the scope of this PR. We may add it in the future, who knows, but we don't need it right now.

This PR also does some cleanup — a lot of the scary diff number is moving the namespace parser tests to the right package, though. Should not impact the review much.

On my roadmap:
 - [x] Ensure parsers read empty fields as null
 - [x] Ensure writers don't write out empty fields/attributes (and trim values we do write)
 - [x] Add parsing/writing of RSS `<categories>` nodes in `<channel>`
 - [x] Add support for `podcast:` namespace
 - [ ] Unify `Atom` and `AtomBuilder` podcast/episode versions since they're exactly the same
 - [ ] Add some end-to-end tests that read a bunch of real-life RSS feeds
 - [ ] Make parsers and writers `object`s, since they are stateless