### PR TITLE
Make stateless parsers and writers Objects

### DIFF
--- a/src/main/kotlin/io/hemin/wien/PodcastRssParser.kt
+++ b/src/main/kotlin/io/hemin/wien/PodcastRssParser.kt
@@ -32,16 +32,16 @@ import javax.xml.parsers.DocumentBuilder
 object PodcastRssParser {
 
     private val parsers: List<NamespaceParser> = listOf(
-        AtomParser(),
-        BitloveParser(),
-        ContentParser(),
-        FeedpressParser(),
-        FyydParser(),
-        GooglePlayParser(),
-        ITunesParser(),
-        PodloveSimpleChapterParser(),
-        RssParser(),
-        PodcastNamespaceParser()
+        AtomParser,
+        BitloveParser,
+        ContentParser,
+        FeedpressParser,
+        FyydParser,
+        GooglePlayParser,
+        ITunesParser,
+        PodloveSimpleChapterParser,
+        RssParser,
+        PodcastNamespaceParser
     )
 
     private val builder: DocumentBuilder = DomBuilderFactory.newDocumentBuilder()

--- a/src/main/kotlin/io/hemin/wien/PodcastRssWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/PodcastRssWriter.kt
@@ -28,16 +28,16 @@ object PodcastRssWriter {
 
     // Writers are sorted in order of "importance"
     private val writers: List<NamespaceWriter> = listOf(
-        RssWriter(),
-        ContentWriter(),
-        ITunesWriter(),
-        GooglePlayWriter(),
-        AtomWriter(),
-        BitloveWriter(),
-        FeedpressWriter(),
-        FyydWriter(),
-        PodloveSimpleChapterWriter(),
-        PodcastNamespaceWriter()
+        RssWriter,
+        ContentWriter,
+        ITunesWriter,
+        GooglePlayWriter,
+        AtomWriter,
+        BitloveWriter,
+        FeedpressWriter,
+        FyydWriter,
+        PodloveSimpleChapterWriter,
+        PodcastNamespaceWriter
     )
 
     private val supportedNamespaces = writers.mapNotNull { it.namespace }

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/AtomParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/AtomParser.kt
@@ -17,7 +17,7 @@ import org.w3c.dom.Node
  *
  * The namespace URI is: `http://www.w3.org/2005/Atom`
  */
-internal class AtomParser : NamespaceParser() {
+internal object AtomParser : NamespaceParser() {
 
     override val namespace = FeedNamespace.ATOM
 

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/BitloveParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/BitloveParser.kt
@@ -13,7 +13,7 @@ import org.w3c.dom.Node
  *
  * The namespace URI is: `http://bitlove.org`
  */
-internal class BitloveParser : NamespaceParser() {
+internal object BitloveParser : NamespaceParser() {
 
     override val namespace = FeedNamespace.BITLOVE
 

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/ContentParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/ContentParser.kt
@@ -12,7 +12,7 @@ import org.w3c.dom.Node
  *
  * The namespace URI is: `http://purl.org/rss/1.0/modules/content/`
  */
-internal class ContentParser : NamespaceParser() {
+internal object ContentParser : NamespaceParser() {
 
     override val namespace = FeedNamespace.CONTENT
 

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/FeedpressParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/FeedpressParser.kt
@@ -12,7 +12,7 @@ import org.w3c.dom.Node
  *
  * The namespace URI is: `https://feed.press/xmlns`
  */
-internal class FeedpressParser : NamespaceParser() {
+internal object FeedpressParser : NamespaceParser() {
 
     override val namespace = FeedNamespace.FEEDPRESS
 

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/FyydParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/FyydParser.kt
@@ -12,7 +12,7 @@ import org.w3c.dom.Node
  *
  * The namespace URI is: `https://fyyd.de/fyyd-ns/`
  */
-internal class FyydParser : NamespaceParser() {
+internal object FyydParser : NamespaceParser() {
 
     override val namespace = FeedNamespace.FYYD
 

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/GooglePlayParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/GooglePlayParser.kt
@@ -15,7 +15,7 @@ import org.w3c.dom.Node
  *
  * The namespace URI is: `http://www.google.com/schemas/play-podcasts/1.0`
  */
-internal class GooglePlayParser : NamespaceParser() {
+internal object GooglePlayParser : NamespaceParser() {
 
     override val namespace = FeedNamespace.GOOGLE_PLAY
 

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/ITunesParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/ITunesParser.kt
@@ -18,7 +18,7 @@ import org.w3c.dom.Node
  *
  * The namespace URI is: `http://www.itunes.com/dtds/podcast-1.0.dtd`
  */
-internal class ITunesParser : NamespaceParser() {
+internal object ITunesParser : NamespaceParser() {
 
     override val namespace = FeedNamespace.ITUNES
 

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/PodcastNamespaceParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/PodcastNamespaceParser.kt
@@ -20,7 +20,7 @@ import java.time.Duration
 import java.time.format.DateTimeParseException
 import java.util.Locale
 
-internal class PodcastNamespaceParser : NamespaceParser() {
+internal object PodcastNamespaceParser : NamespaceParser() {
 
     override val namespace: FeedNamespace = FeedNamespace.PODCAST
 

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/PodloveSimpleChapterParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/PodloveSimpleChapterParser.kt
@@ -14,7 +14,7 @@ import org.w3c.dom.Node
  *
  * The namespace URI is: `http://podlove.org/simple-chapters`
  */
-internal class PodloveSimpleChapterParser : NamespaceParser() {
+internal object PodloveSimpleChapterParser : NamespaceParser() {
 
     override val namespace = FeedNamespace.PODLOVE_SIMPLE_CHAPTER
 

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/RssParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/RssParser.kt
@@ -23,7 +23,7 @@ import org.w3c.dom.Node
  *
  * The RSS specification is described []here][http://www.rssboard.org/rss-2-0].
  */
-internal class RssParser : NamespaceParser() {
+internal object RssParser : NamespaceParser() {
 
     override val namespace: FeedNamespace? = null
 

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/AtomWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/AtomWriter.kt
@@ -16,7 +16,7 @@ import org.w3c.dom.Element
  *
  * The namespace URI is: `http://www.w3.org/2005/Atom`
  */
-internal class AtomWriter : NamespaceWriter() {
+internal object AtomWriter : NamespaceWriter() {
 
     override val namespace = FeedNamespace.ATOM
 

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/BitloveWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/BitloveWriter.kt
@@ -13,7 +13,7 @@ import org.w3c.dom.Element
  *
  * The namespace URI is: `http://bitlove.org`
  */
-internal class BitloveWriter : NamespaceWriter() {
+internal object BitloveWriter : NamespaceWriter() {
 
     override val namespace = FeedNamespace.BITLOVE
 

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/ContentWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/ContentWriter.kt
@@ -12,7 +12,7 @@ import org.w3c.dom.Element
  *
  * The namespace URI is: `http://purl.org/rss/1.0/modules/content/`
  */
-internal class ContentWriter : NamespaceWriter() {
+internal object ContentWriter : NamespaceWriter() {
 
     override val namespace = FeedNamespace.CONTENT
 

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/FeedpressWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/FeedpressWriter.kt
@@ -13,7 +13,7 @@ import org.w3c.dom.Element
  *
  * The namespace URI is: `https://feed.press/xmlns`
  */
-internal class FeedpressWriter : NamespaceWriter() {
+internal object FeedpressWriter : NamespaceWriter() {
 
     override val namespace = FeedNamespace.FEEDPRESS
 

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/FyydWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/FyydWriter.kt
@@ -12,7 +12,7 @@ import org.w3c.dom.Element
  *
  * The namespace URI is: `https://fyyd.de/fyyd-ns/`
  */
-internal class FyydWriter : NamespaceWriter() {
+internal object FyydWriter : NamespaceWriter() {
 
     override val namespace = FeedNamespace.FYYD
 

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/GooglePlayWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/GooglePlayWriter.kt
@@ -18,7 +18,7 @@ import org.w3c.dom.Element
  *
  * The namespace URI is: `http://www.google.com/schemas/play-podcasts/1.0`
  */
-internal class GooglePlayWriter : NamespaceWriter() {
+internal object GooglePlayWriter : NamespaceWriter() {
 
     override val namespace = FeedNamespace.GOOGLE_PLAY
 

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/ITunesWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/ITunesWriter.kt
@@ -19,7 +19,7 @@ import org.w3c.dom.Element
  *
  * The namespace URI is: `http://www.itunes.com/dtds/podcast-1.0.dtd`
  */
-internal class ITunesWriter : NamespaceWriter() {
+internal object ITunesWriter : NamespaceWriter() {
 
     override val namespace = FeedNamespace.ITUNES
 

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/PodcastNamespaceWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/PodcastNamespaceWriter.kt
@@ -17,7 +17,7 @@ import java.time.Duration
  * but `https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md`
  * should also be accepted as equivalent. TODO allow both NS
  */
-internal class PodcastNamespaceWriter : NamespaceWriter() {
+internal object PodcastNamespaceWriter : NamespaceWriter() {
 
     override val namespace = FeedNamespace.PODCAST
 

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/PodloveSimpleChapterWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/PodloveSimpleChapterWriter.kt
@@ -13,7 +13,7 @@ import org.w3c.dom.Element
  *
  * The namespace URI is: `http://podlove.org/simple-chapters`
  */
-internal class PodloveSimpleChapterWriter : NamespaceWriter() {
+internal object PodloveSimpleChapterWriter : NamespaceWriter() {
 
     override val namespace = FeedNamespace.PODLOVE_SIMPLE_CHAPTER
 

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/RssWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/RssWriter.kt
@@ -20,7 +20,7 @@ import org.w3c.dom.Element
  *
  * `http://www.rssboard.org/rss-2-0`
  */
-internal class RssWriter : NamespaceWriter() {
+internal object RssWriter : NamespaceWriter() {
 
     /** Standard RSS 2.0 elements do not have a namespace. This value is therefore null. */
     override val namespace: FeedNamespace? = null

--- a/src/test/kotlin/io/hemin/wien/parser/namespace/AtomParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/namespace/AtomParserTest.kt
@@ -18,7 +18,7 @@ import org.w3c.dom.Node
 
 internal class AtomParserTest : NamespaceParserTest() {
 
-    override val parser = AtomParser()
+    override val parser = AtomParser
 
     private val expectedLinkBuilder = FakeLinkBuilder()
         .href("http://example.org/feed/m4a")

--- a/src/test/kotlin/io/hemin/wien/parser/namespace/BitloveParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/namespace/BitloveParserTest.kt
@@ -13,7 +13,7 @@ import org.w3c.dom.Node
 
 internal class BitloveParserTest : NamespaceParserTest() {
 
-    override val parser = BitloveParser()
+    override val parser = BitloveParser
 
     @Test
     fun `should extract the Bitlove guid attribute from enclosure nodes when it's present`() {

--- a/src/test/kotlin/io/hemin/wien/parser/namespace/ContentParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/namespace/ContentParserTest.kt
@@ -7,14 +7,13 @@ import assertk.assertions.prop
 import io.hemin.wien.builder.fake.episode.FakeEpisodeBuilder
 import io.hemin.wien.builder.fake.episode.FakeEpisodeContentBuilder
 import io.hemin.wien.dom.XmlRes
-import io.hemin.wien.parser.NamespaceParser
 import io.hemin.wien.parser.NamespaceParserTest
 import org.junit.jupiter.api.Test
 import org.w3c.dom.Node
 
 internal class ContentParserTest : NamespaceParserTest() {
 
-    override val parser: NamespaceParser = ContentParser()
+    override val parser = ContentParser
 
     @Test
     fun `should extract content data from item when present`() {

--- a/src/test/kotlin/io/hemin/wien/parser/namespace/FeedpressParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/namespace/FeedpressParserTest.kt
@@ -8,14 +8,13 @@ import assertk.assertions.prop
 import io.hemin.wien.builder.fake.podcast.FakePodcastBuilder
 import io.hemin.wien.builder.fake.podcast.FakePodcastFeedpressBuilder
 import io.hemin.wien.dom.XmlRes
-import io.hemin.wien.parser.NamespaceParser
 import io.hemin.wien.parser.NamespaceParserTest
 import org.junit.jupiter.api.Test
 import org.w3c.dom.Node
 
 internal class FeedpressParserTest : NamespaceParserTest() {
 
-    override val parser: NamespaceParser = FeedpressParser()
+    override val parser = FeedpressParser
 
     @Test
     fun `should extract feedpress data from channel when present`() {

--- a/src/test/kotlin/io/hemin/wien/parser/namespace/FyydParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/namespace/FyydParserTest.kt
@@ -7,14 +7,13 @@ import assertk.assertions.prop
 import io.hemin.wien.builder.fake.podcast.FakePodcastBuilder
 import io.hemin.wien.builder.fake.podcast.FakePodcastFyydBuilder
 import io.hemin.wien.dom.XmlRes
-import io.hemin.wien.parser.NamespaceParser
 import io.hemin.wien.parser.NamespaceParserTest
 import org.junit.jupiter.api.Test
 import org.w3c.dom.Node
 
 internal class FyydParserTest : NamespaceParserTest() {
 
-    override val parser: NamespaceParser = FyydParser()
+    override val parser = FyydParser
 
     @Test
     fun `should extract fyyd data from channel when present`() {

--- a/src/test/kotlin/io/hemin/wien/parser/namespace/GooglePlayParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/namespace/GooglePlayParserTest.kt
@@ -18,14 +18,13 @@ import io.hemin.wien.builder.fake.podcast.FakePodcastGooglePlayBuilder
 import io.hemin.wien.dom.XmlRes
 import io.hemin.wien.hasNotEnoughDataToBuild
 import io.hemin.wien.noneHasEnoughDataToBuild
-import io.hemin.wien.parser.NamespaceParser
 import io.hemin.wien.parser.NamespaceParserTest
 import org.junit.jupiter.api.Test
 import org.w3c.dom.Node
 
 internal class GooglePlayParserTest : NamespaceParserTest() {
 
-    override val parser: NamespaceParser = GooglePlayParser()
+    override val parser = GooglePlayParser
 
     private val expectedPodcastImageBuilder = FakeHrefOnlyImageBuilder().href("http://example.org/podcast-cover.jpg")
 

--- a/src/test/kotlin/io/hemin/wien/parser/namespace/ITunesParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/namespace/ITunesParserTest.kt
@@ -27,7 +27,7 @@ import org.w3c.dom.Node
 
 internal class ITunesParserTest : NamespaceParserTest() {
 
-    override val parser = ITunesParser()
+    override val parser = ITunesParser
 
     private val expectedPodcastImageBuilder = FakeHrefOnlyImageBuilder().href("http://example.org/podcast-cover.jpg")
 

--- a/src/test/kotlin/io/hemin/wien/parser/namespace/PodcastNamespaceParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/namespace/PodcastNamespaceParserTest.kt
@@ -19,7 +19,6 @@ import io.hemin.wien.builder.fake.podcast.FakePodcastPodcastFundingBuilder
 import io.hemin.wien.builder.fake.podcast.FakePodcastPodcastLockedBuilder
 import io.hemin.wien.dom.XmlRes
 import io.hemin.wien.model.Episode
-import io.hemin.wien.parser.NamespaceParser
 import io.hemin.wien.parser.NamespaceParserTest
 import org.junit.jupiter.api.Test
 import org.w3c.dom.Node
@@ -28,7 +27,7 @@ import java.util.Locale
 
 internal class PodcastNamespaceParserTest : NamespaceParserTest() {
 
-    override val parser: NamespaceParser = PodcastNamespaceParser()
+    override val parser = PodcastNamespaceParser
 
     private val expectedLockedBuilder = FakePodcastPodcastLockedBuilder()
         .locked(true)

--- a/src/test/kotlin/io/hemin/wien/parser/namespace/PodloveSimpleChapterParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/namespace/PodloveSimpleChapterParserTest.kt
@@ -14,7 +14,7 @@ import org.w3c.dom.Node
 
 internal class PodloveSimpleChapterParserTest : NamespaceParserTest() {
 
-    override val parser = PodloveSimpleChapterParser()
+    override val parser = PodloveSimpleChapterParser
 
     @Test
     fun `should not extract podlove chapter data from item when absent`() {

--- a/src/test/kotlin/io/hemin/wien/parser/namespace/RssParserTest.kt
+++ b/src/test/kotlin/io/hemin/wien/parser/namespace/RssParserTest.kt
@@ -24,7 +24,7 @@ import java.time.Month
 
 internal class RssParserTest : NamespaceParserTest() {
 
-    override val parser = RssParser()
+    override val parser = RssParser
 
     // "Fri, 16 Mar 2018 22:49:08 +0000"
     private val expectedDate = dateTime(year = 2018, month = Month.MARCH, day = 16, hour = 22, minute = 49, second = 8)

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/AtomWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/AtomWriterTest.kt
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test
 
 internal class AtomWriterTest : NamespaceWriterTest() {
 
-    override val writer = AtomWriter()
+    override val writer = AtomWriter
 
     @Test
     internal fun `should write the correct atom tags to the channel when there is data to write`() {

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/BitloveWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/BitloveWriterTest.kt
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test
 
 internal class BitloveWriterTest : NamespaceWriterTest() {
 
-    override val writer = BitloveWriter()
+    override val writer = BitloveWriter
 
     @Test
     internal fun `should write a the correct bitlove_guid attribute to the item enclosure tag when there is data to write`() {
@@ -20,7 +20,7 @@ internal class BitloveWriterTest : NamespaceWriterTest() {
 
         // We need to run the RSS writer first, to create the <enclosure> tag (among others)
         val episode = anEpisode()
-        RssWriter().tryWritingEpisodeData(episode, itemElement)
+        RssWriter.tryWritingEpisodeData(episode, itemElement)
         val enclosureItem = itemElement.findElementByName("enclosure")
             ?: throw IllegalStateException("The RssWriter did not create an <enclosure> tag, but was expected to")
 

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/ContentWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/ContentWriterTest.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test
 
 internal class ContentWriterTest : NamespaceWriterTest() {
 
-    override val writer = ContentWriter()
+    override val writer = ContentWriter
 
     @Test
     internal fun `should write a the correct content_encoded tag to the item when there is data to write`() {

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/FeedpressWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/FeedpressWriterTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test
 
 internal class FeedpressWriterTest : NamespaceWriterTest() {
 
-    override val writer = FeedpressWriter()
+    override val writer = FeedpressWriter
 
     @Test
     internal fun `should write the correct feedpress tags to the channel when there is data to write`() {

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/FyydWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/FyydWriterTest.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test
 
 internal class FyydWriterTest : NamespaceWriterTest() {
 
-    override val writer = FyydWriter()
+    override val writer = FyydWriter
 
     @Test
     internal fun `should write a the correct fyyd_verify tag to the channel when there is data to write`() {

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/GooglePlayWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/GooglePlayWriterTest.kt
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test
 
 internal class GooglePlayWriterTest : NamespaceWriterTest() {
 
-    override val writer = GooglePlayWriter()
+    override val writer = GooglePlayWriter
 
     @Test
     internal fun `should write the correct googleplay tags to the channel when there is data to write`() {

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/ITunesWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/ITunesWriterTest.kt
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test
 
 internal class ITunesWriterTest : NamespaceWriterTest() {
 
-    override val writer = ITunesWriter()
+    override val writer = ITunesWriter
 
     @Test
     internal fun `should write the correct itunes tags to the channel when there is data to write`() {

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/PodcastNamespaceWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/PodcastNamespaceWriterTest.kt
@@ -17,7 +17,7 @@ import java.time.Duration
 
 internal class PodcastNamespaceWriterTest : NamespaceWriterTest() {
 
-    override val writer = PodcastNamespaceWriter()
+    override val writer = PodcastNamespaceWriter
 
     @Test
     internal fun `should write the correct podcast tags to the channel when there is data to write`() {

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/PodloveSimpleChapterWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/PodloveSimpleChapterWriterTest.kt
@@ -16,7 +16,7 @@ import org.w3c.dom.Element
 
 internal class PodloveSimpleChapterWriterTest : NamespaceWriterTest() {
 
-    override val writer = PodloveSimpleChapterWriter()
+    override val writer = PodloveSimpleChapterWriter
 
     @Test
     internal fun `should write the correct psc tags to the item when there is data to write`() {

--- a/src/test/kotlin/io/hemin/wien/writer/namespace/RssWriterTest.kt
+++ b/src/test/kotlin/io/hemin/wien/writer/namespace/RssWriterTest.kt
@@ -21,7 +21,7 @@ import org.w3c.dom.Element
 
 internal class RssWriterTest : NamespaceWriterTest() {
 
-    override val writer = RssWriter()
+    override val writer = RssWriter
 
     @Test
     internal fun `should write the correct RSS tags to the channel when there is data to write`() {


### PR DESCRIPTION
This small PR turns all parsers and writers from classes into objects. They're all `internal` API, so this changes nothing for our Java interop story.