### PR TITLE
Annotate internal APIs

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -13,6 +13,10 @@
     </JetCodeStyleSettings>
     <codeStyleSettings language="kotlin">
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+      <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+      <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
+      <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />
     </codeStyleSettings>
   </code_scheme>
 </component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -31,6 +31,18 @@
     </inspection_tool>
     <inspection_tool class="GwtUiFieldErrors" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="GwtUiHandlerErrors" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="HttpUrlsUsage" enabled="false" level="WEAK WARNING" enabled_by_default="false">
+      <option name="ignoredUrls">
+        <list>
+          <option value="http://localhost" />
+          <option value="http://127.0.0.1" />
+          <option value="http://www.w3.org/2000/svg" />
+          <option value="http://www.w3.org/2001/XMLSchema-instance" />
+          <option value="http://example.org" />
+          <option value="http://www.w3.org" />
+        </list>
+      </option>
+    </inspection_tool>
     <inspection_tool class="IfMayBeConditional" enabled="true" level="INFO" enabled_by_default="true" />
     <inspection_tool class="IfStatementWithIdenticalBranches" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="InstanceofThis" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -91,8 +103,6 @@
     </inspection_tool>
     <inspection_tool class="NonFinalFieldInEnum" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="PointlessIndexOfComparison" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="QsPrivateBeanMembersInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="QsUndeclaredPathMimeTypesInspection" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ReplaceAssignmentWithOperatorAssignment" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreLazyOperators" value="true" />
       <option name="ignoreObscureOperators" value="true" />

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,9 +53,15 @@ dependencies {
     testImplementation("org.xmlunit:xmlunit-core:2.8.2")
 }
 
+kotlin {
+    explicitApi()
+}
+
 tasks {
     withType<KotlinCompile> {
-        kotlinOptions.jvmTarget = "1.8"
+        kotlinOptions {
+            jvmTarget = "1.8"
+        }
     }
 
     withType<Test> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ buildscript {
 }
 
 plugins {
-    id("org.jetbrains.kotlin.jvm").version("1.4.21")
+    id("org.jetbrains.kotlin.jvm").version("1.4.30")
     id("org.jetbrains.dokka") version "1.4.20"
     id("jacoco")
     id("java")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,7 +61,7 @@ tasks {
     withType<KotlinCompile> {
         kotlinOptions {
             jvmTarget = "1.8"
-            freeCompilerArgs = listOf("-Xopt-in=kotlin.RequiresOptIn")
+            freeCompilerArgs = listOf("-Xopt-in=kotlin.RequiresOptIn", "-Xopt-in=io.hemin.wien.util.InternalApi")
         }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,6 +61,7 @@ tasks {
     withType<KotlinCompile> {
         kotlinOptions {
             jvmTarget = "1.8"
+            freeCompilerArgs = listOf("-Xopt-in=kotlin.RequiresOptIn")
         }
     }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/io/hemin/wien/PodcastRssParser.kt
+++ b/src/main/kotlin/io/hemin/wien/PodcastRssParser.kt
@@ -29,7 +29,7 @@ import java.io.InputStream
 import javax.xml.parsers.DocumentBuilder
 
 @Suppress("unused")
-object PodcastRssParser {
+public object PodcastRssParser {
 
     private val parsers: List<NamespaceParser> = listOf(
         AtomParser,
@@ -53,7 +53,7 @@ object PodcastRssParser {
      * @param uri The location of the content to be parsed.
      * @return A [Podcast] if the XML document behind the URI is an RSS document, otherwise null.
      */
-    fun parse(uri: String): Podcast? = parse(builder.parse(uri))
+    public fun parse(uri: String): Podcast? = parse(builder.parse(uri))
 
     /**
      * Parse the content of the given input stream as an XML document
@@ -62,7 +62,7 @@ object PodcastRssParser {
      * @param inputStream InputStream containing the content to be parsed.
      * @return A [Podcast] if the XML document behind the input stream is an RSS document, otherwise null.
      */
-    fun parse(inputStream: InputStream): Podcast? = parse(builder.parse(inputStream))
+    public fun parse(inputStream: InputStream): Podcast? = parse(builder.parse(inputStream))
 
     /**
      * Parse the content of the given input stream as an XML document
@@ -72,7 +72,7 @@ object PodcastRssParser {
      * @param systemId Provide a base for resolving relative URIs.
      * @return A [Podcast] if the XML document behind the input stream is an RSS document, otherwise null.
      */
-    fun parse(inputStream: InputStream, systemId: String): Podcast? = parse(builder.parse(inputStream, systemId))
+    public fun parse(inputStream: InputStream, systemId: String): Podcast? = parse(builder.parse(inputStream, systemId))
 
     /**
      * Parse the content of the given file as an XML document
@@ -81,7 +81,7 @@ object PodcastRssParser {
      * @param file File containing the content to be parsed.
      * @return A [Podcast] if the XML document behind the file is an RSS document, otherwise null.
      */
-    fun parse(file: File): Podcast? = parse(builder.parse(file))
+    public fun parse(file: File): Podcast? = parse(builder.parse(file))
 
     /**
      * Parse the content of the given input source as an XML document
@@ -90,7 +90,7 @@ object PodcastRssParser {
      * @param inputSource InputSource containing the content to be parsed.
      * @return A [Podcast] if the XML document behind the input source is an RSS document, otherwise null.
      */
-    fun parse(inputSource: InputSource): Podcast? = parse(builder.parse(inputSource))
+    public fun parse(inputSource: InputSource): Podcast? = parse(builder.parse(inputSource))
 
     /**
      * Parse the content of the given XML document and return a [Podcast] if the XML document is an RSS feed.
@@ -98,7 +98,7 @@ object PodcastRssParser {
      * @param document Document containing the content to be parsed.
      * @return A [Podcast] if the XML document is an RSS document, otherwise null.
      */
-    fun parse(document: Document): Podcast? {
+    public fun parse(document: Document): Podcast? {
         val channel = document.findRssChannelElement() ?: return null
         return channel.parseChannelElement()
     }

--- a/src/main/kotlin/io/hemin/wien/PodcastRssWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/PodcastRssWriter.kt
@@ -24,7 +24,7 @@ import javax.xml.transform.TransformerFactory
 import javax.xml.transform.dom.DOMSource
 import javax.xml.transform.stream.StreamResult
 
-object PodcastRssWriter {
+public object PodcastRssWriter {
 
     // Writers are sorted in order of "importance"
     private val writers: List<NamespaceWriter> = listOf(
@@ -57,7 +57,7 @@ object PodcastRssWriter {
      * @param podcast The [Podcast] to write out.
      * @param file The [File] to write to. Any contents will be overwritten.
      */
-    fun writeRssFeed(podcast: Podcast, file: File) {
+    public fun writeRssFeed(podcast: Podcast, file: File) {
         file.outputStream()
             .use { outputStream -> writeRssFeed(podcast, outputStream) }
     }
@@ -68,7 +68,7 @@ object PodcastRssWriter {
      * @param podcast The [Podcast] to write out.
      * @param stream The [OutputStream] to write to.
      */
-    fun writeRssFeed(podcast: Podcast, stream: OutputStream) {
+    public fun writeRssFeed(podcast: Podcast, stream: OutputStream) {
         val document = writeToDocument(podcast)
         val source = DOMSource(document)
 

--- a/src/main/kotlin/io/hemin/wien/builder/AtomBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/AtomBuilder.kt
@@ -6,29 +6,29 @@ import io.hemin.wien.model.Person
 import io.hemin.wien.util.whenNotNull
 
 /** Builder for constructing [Atom] instances. */
-interface AtomBuilder : Builder<Atom> {
+public interface AtomBuilder : Builder<Atom> {
 
     /** Adds a [PersonBuilder] to the list of author builders. */
-    fun addAuthorBuilder(authorBuilder: PersonBuilder): AtomBuilder
+    public fun addAuthorBuilder(authorBuilder: PersonBuilder): AtomBuilder
 
     /** Adds multiple [PersonBuilder] to the list of author builders. */
-    fun addAuthorBuilders(authorBuilders: List<PersonBuilder>): AtomBuilder = apply {
+    public fun addAuthorBuilders(authorBuilders: List<PersonBuilder>): AtomBuilder = apply {
         authorBuilders.forEach(::addAuthorBuilder)
     }
 
     /** Adds a [PersonBuilder] to the list of contributor builders. */
-    fun addContributorBuilder(contributorBuilder: PersonBuilder): AtomBuilder
+    public fun addContributorBuilder(contributorBuilder: PersonBuilder): AtomBuilder
 
     /** Adds multiple [PersonBuilder] to the list of contributor builders. */
-    fun addContributorBuilders(contributorBuilders: List<PersonBuilder>): AtomBuilder = apply {
+    public fun addContributorBuilders(contributorBuilders: List<PersonBuilder>): AtomBuilder = apply {
         contributorBuilders.forEach(::addContributorBuilder)
     }
 
     /** Adds a [LinkBuilder] to the list of links. */
-    fun addLinkBuilder(linkBuilder: LinkBuilder): AtomBuilder
+    public fun addLinkBuilder(linkBuilder: LinkBuilder): AtomBuilder
 
     /** Adds multiple [LinkBuilder] to the list of links. */
-    fun addLinkBuilders(linkBuilders: List<LinkBuilder>): AtomBuilder = apply {
+    public fun addLinkBuilders(linkBuilders: List<LinkBuilder>): AtomBuilder = apply {
         linkBuilders.forEach(::addLinkBuilder)
     }
 

--- a/src/main/kotlin/io/hemin/wien/builder/Builder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/Builder.kt
@@ -5,14 +5,14 @@ package io.hemin.wien.builder
  *
  * @param T The type that a builder implementation creates instances for.
  */
-interface Builder<T> {
+public interface Builder<T> {
 
     /**
      * Creates a model instance with the properties set in this builder.
      *
      * @return The created model instance.
      */
-    fun build(): T?
+    public fun build(): T?
 
     /**
      * Applies the properties of [model] to this builder.
@@ -20,7 +20,7 @@ interface Builder<T> {
      * @param model The model prototype for this builder.
      * @return This builder instance.
      */
-    fun from(model: T?): Builder<T>
+    public fun from(model: T?): Builder<T>
 
     /**
      * This property is `true` when the builder has been provided with enough data to be able to
@@ -35,5 +35,5 @@ interface Builder<T> {
      * more mandatory fields, this property will be `true` only after _all_ the mandatory
      * fields are set.
      */
-    val hasEnoughDataToBuild: Boolean
+    public val hasEnoughDataToBuild: Boolean
 }

--- a/src/main/kotlin/io/hemin/wien/builder/HrefOnlyImageBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/HrefOnlyImageBuilder.kt
@@ -4,10 +4,10 @@ import io.hemin.wien.model.HrefOnlyImage
 import io.hemin.wien.util.whenNotNull
 
 /** Builder for constructing [HrefOnlyImage] instances. */
-interface HrefOnlyImageBuilder : Builder<HrefOnlyImage> {
+public interface HrefOnlyImageBuilder : Builder<HrefOnlyImage> {
 
     /** Set the href value. */
-    fun href(href: String): HrefOnlyImageBuilder
+    public fun href(href: String): HrefOnlyImageBuilder
 
     override fun from(model: HrefOnlyImage?): HrefOnlyImageBuilder = whenNotNull(model) { image ->
         href(image.href)

--- a/src/main/kotlin/io/hemin/wien/builder/ITunesStyleCategoryBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/ITunesStyleCategoryBuilder.kt
@@ -4,13 +4,13 @@ import io.hemin.wien.model.ITunesStyleCategory
 import io.hemin.wien.util.whenNotNull
 
 /** Builder for constructing [ITunesStyleCategory] instances. */
-interface ITunesStyleCategoryBuilder : Builder<ITunesStyleCategory> {
+public interface ITunesStyleCategoryBuilder : Builder<ITunesStyleCategory> {
 
     /** Set the category value. */
-    fun category(category: String): ITunesStyleCategoryBuilder
+    public fun category(category: String): ITunesStyleCategoryBuilder
 
     /** Set the subcategory value. */
-    fun subcategory(subcategory: String?): ITunesStyleCategoryBuilder
+    public fun subcategory(subcategory: String?): ITunesStyleCategoryBuilder
 
     override fun from(model: ITunesStyleCategory?): ITunesStyleCategoryBuilder = whenNotNull(model) { category ->
         when (category) {

--- a/src/main/kotlin/io/hemin/wien/builder/LinkBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/LinkBuilder.kt
@@ -4,28 +4,28 @@ import io.hemin.wien.model.Link
 import io.hemin.wien.util.whenNotNull
 
 /** Builder for constructing [Link] instances. */
-interface LinkBuilder : Builder<Link> {
+public interface LinkBuilder : Builder<Link> {
 
     /** Set the href value. */
-    fun href(href: String): LinkBuilder
+    public fun href(href: String): LinkBuilder
 
     /** Set the hrefLang value. */
-    fun hrefLang(hrefLang: String?): LinkBuilder
+    public fun hrefLang(hrefLang: String?): LinkBuilder
 
     /** Set the hrefResolved value. */
-    fun hrefResolved(hrefResolved: String?): LinkBuilder
+    public fun hrefResolved(hrefResolved: String?): LinkBuilder
 
     /** Set the length value. */
-    fun length(length: String?): LinkBuilder
+    public fun length(length: String?): LinkBuilder
 
     /** Set the rel value. */
-    fun rel(rel: String?): LinkBuilder
+    public fun rel(rel: String?): LinkBuilder
 
     /** Set the title value. */
-    fun title(title: String?): LinkBuilder
+    public fun title(title: String?): LinkBuilder
 
     /** Set the type value. */
-    fun type(type: String?): LinkBuilder
+    public fun type(type: String?): LinkBuilder
 
     override fun from(model: Link?): LinkBuilder = whenNotNull(model) { link ->
         href(link.href)

--- a/src/main/kotlin/io/hemin/wien/builder/LinkBuilderProvider.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/LinkBuilderProvider.kt
@@ -1,7 +1,7 @@
 package io.hemin.wien.builder
 
-interface LinkBuilderProvider {
+public interface LinkBuilderProvider {
 
     /** Creates an instance of [LinkBuilder] to use with this builder. */
-    fun createLinkBuilder(): LinkBuilder
+    public fun createLinkBuilder(): LinkBuilder
 }

--- a/src/main/kotlin/io/hemin/wien/builder/PersonBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/PersonBuilder.kt
@@ -4,16 +4,16 @@ import io.hemin.wien.model.Person
 import io.hemin.wien.util.whenNotNull
 
 /** Builder for constructing [Person] instances. */
-interface PersonBuilder : Builder<Person> {
+public interface PersonBuilder : Builder<Person> {
 
     /** Set the name value. */
-    fun name(name: String): PersonBuilder
+    public fun name(name: String): PersonBuilder
 
     /** Set the email value. */
-    fun email(email: String?): PersonBuilder
+    public fun email(email: String?): PersonBuilder
 
     /** Set the uri value. */
-    fun uri(uri: String?): PersonBuilder
+    public fun uri(uri: String?): PersonBuilder
 
     override fun from(model: Person?): PersonBuilder = whenNotNull(model) { person ->
         name(person.name)

--- a/src/main/kotlin/io/hemin/wien/builder/PersonBuilderProvider.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/PersonBuilderProvider.kt
@@ -1,7 +1,7 @@
 package io.hemin.wien.builder
 
-interface PersonBuilderProvider {
+public interface PersonBuilderProvider {
 
     /** Creates an instance of [PersonBuilder] to use with this builder. */
-    fun createPersonBuilder(): PersonBuilder
+    public fun createPersonBuilder(): PersonBuilder
 }

--- a/src/main/kotlin/io/hemin/wien/builder/RssCategoryBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/RssCategoryBuilder.kt
@@ -4,13 +4,13 @@ import io.hemin.wien.model.RssCategory
 import io.hemin.wien.util.whenNotNull
 
 /** Builder for constructing [RssCategory] instances. */
-interface RssCategoryBuilder : Builder<RssCategory> {
+public interface RssCategoryBuilder : Builder<RssCategory> {
 
     /** Set the category value. */
-    fun category(category: String): RssCategoryBuilder
+    public fun category(category: String): RssCategoryBuilder
 
     /** Set the domain value. */
-    fun domain(domain: String?): RssCategoryBuilder
+    public fun domain(domain: String?): RssCategoryBuilder
 
     override fun from(model: RssCategory?): RssCategoryBuilder = whenNotNull(model) { category ->
         category(category.name)

--- a/src/main/kotlin/io/hemin/wien/builder/RssImageBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/RssImageBuilder.kt
@@ -4,25 +4,25 @@ import io.hemin.wien.model.RssImage
 import io.hemin.wien.util.whenNotNull
 
 /** Builder for constructing [RssImage] instances. */
-interface RssImageBuilder : Builder<RssImage> {
+public interface RssImageBuilder : Builder<RssImage> {
 
     /** Set the url value. */
-    fun url(url: String): RssImageBuilder
+    public fun url(url: String): RssImageBuilder
 
     /** Set the title value. */
-    fun title(title: String): RssImageBuilder
+    public fun title(title: String): RssImageBuilder
 
     /** Set the link value. */
-    fun link(link: String): RssImageBuilder
+    public fun link(link: String): RssImageBuilder
 
     /** Set the width value. */
-    fun width(width: Int?): RssImageBuilder
+    public fun width(width: Int?): RssImageBuilder
 
     /** Set the height value. */
-    fun height(height: Int?): RssImageBuilder
+    public fun height(height: Int?): RssImageBuilder
 
     /** Set the description value. */
-    fun description(description: String?): RssImageBuilder
+    public fun description(description: String?): RssImageBuilder
 
     override fun from(model: RssImage?): RssImageBuilder = whenNotNull(model) { image ->
         url(image.url)

--- a/src/main/kotlin/io/hemin/wien/builder/episode/EpisodeBitloveBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/episode/EpisodeBitloveBuilder.kt
@@ -5,10 +5,10 @@ import io.hemin.wien.model.Episode
 import io.hemin.wien.util.whenNotNull
 
 /** Builder for constructing [Episode.Bitlove] instances. */
-interface EpisodeBitloveBuilder : Builder<Episode.Bitlove> {
+public interface EpisodeBitloveBuilder : Builder<Episode.Bitlove> {
 
     /** Set the guid value. */
-    fun guid(guid: String): EpisodeBitloveBuilder
+    public fun guid(guid: String): EpisodeBitloveBuilder
 
     override fun from(model: Episode.Bitlove?): EpisodeBitloveBuilder = whenNotNull(model) { bitlove ->
         guid(bitlove.guid)

--- a/src/main/kotlin/io/hemin/wien/builder/episode/EpisodeBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/episode/EpisodeBuilder.kt
@@ -13,90 +13,90 @@ import io.hemin.wien.util.whenNotNull
 import java.time.temporal.TemporalAccessor
 
 /** Builder for constructing [Episode] instances. */
-interface EpisodeBuilder : Builder<Episode>, PersonBuilderProvider, LinkBuilderProvider {
+public interface EpisodeBuilder : Builder<Episode>, PersonBuilderProvider, LinkBuilderProvider {
 
     /** The builder for data from the Content namespace. */
-    val contentBuilder: EpisodeContentBuilder
+    public val contentBuilder: EpisodeContentBuilder
 
     /** The builder for data from the iTunes namespace. */
-    val iTunesBuilder: EpisodeITunesBuilder
+    public val iTunesBuilder: EpisodeITunesBuilder
 
     /** The builder for data from the Atom namespace. */
-    val atomBuilder: AtomBuilder
+    public val atomBuilder: AtomBuilder
 
     /** The builder for data from namespaces of the Podlove standards. */
-    val podloveBuilder: EpisodePodloveBuilder
+    public val podloveBuilder: EpisodePodloveBuilder
 
     /** The builder for data from the Google Play namespace. */
-    val googlePlayBuilder: EpisodeGooglePlayBuilder
+    public val googlePlayBuilder: EpisodeGooglePlayBuilder
 
     /** The builder for data from the Bitlove namespace. */
-    val bitloveBuilder: EpisodeBitloveBuilder
+    public val bitloveBuilder: EpisodeBitloveBuilder
 
     /** The builder for data from the Podcast namespace. */
-    val podcastBuilder: EpisodePodcastBuilder
+    public val podcastBuilder: EpisodePodcastBuilder
 
     /** Set the title value. */
-    fun title(title: String): EpisodeBuilder
+    public fun title(title: String): EpisodeBuilder
 
     /** Set the link value. */
-    fun link(link: String?): EpisodeBuilder
+    public fun link(link: String?): EpisodeBuilder
 
     /** Set the description value. */
-    fun description(description: String?): EpisodeBuilder
+    public fun description(description: String?): EpisodeBuilder
 
     /** Set the author value. */
-    fun author(author: String?): EpisodeBuilder
+    public fun author(author: String?): EpisodeBuilder
 
     /** Adds an [RssCategoryBuilder] to the list of category builders. */
-    fun addCategoryBuilder(categoryBuilder: RssCategoryBuilder): EpisodeBuilder
+    public fun addCategoryBuilder(categoryBuilder: RssCategoryBuilder): EpisodeBuilder
 
     /** Adds multiple [RssCategoryBuilder] to the list of category builders. */
-    fun addCategoryBuilderys(categoryBuilders: List<RssCategoryBuilder>): EpisodeBuilder = apply {
+    public fun addCategoryBuilderys(categoryBuilders: List<RssCategoryBuilder>): EpisodeBuilder = apply {
         categoryBuilders.forEach(::addCategoryBuilder)
     }
 
     /** Set the comments value. */
-    fun comments(comments: String?): EpisodeBuilder
+    public fun comments(comments: String?): EpisodeBuilder
 
     /** Set the [EpisodeEnclosureBuilder]. */
-    fun enclosureBuilder(enclosureBuilder: EpisodeEnclosureBuilder): EpisodeBuilder
+    public fun enclosureBuilder(enclosureBuilder: EpisodeEnclosureBuilder): EpisodeBuilder
 
     /** Set the [EpisodeGuidBuilder]. */
-    fun guidBuilder(guidBuilder: EpisodeGuidBuilder?): EpisodeBuilder
+    public fun guidBuilder(guidBuilder: EpisodeGuidBuilder?): EpisodeBuilder
 
     /** Set the pubDate value. */
-    fun pubDate(pubDate: TemporalAccessor?): EpisodeBuilder
+    public fun pubDate(pubDate: TemporalAccessor?): EpisodeBuilder
 
     /** Set the source value. */
-    fun source(source: String?): EpisodeBuilder
+    public fun source(source: String?): EpisodeBuilder
 
     /** Creates an instance of [EpisodeEnclosureBuilder] to use with this builder. */
-    fun createEnclosureBuilder(): EpisodeEnclosureBuilder
+    public fun createEnclosureBuilder(): EpisodeEnclosureBuilder
 
     /** Creates an instance of [EpisodeGuidBuilder] to use with this builder. */
-    fun createGuidBuilder(): EpisodeGuidBuilder
+    public fun createGuidBuilder(): EpisodeGuidBuilder
 
     /** Creates an instance of [HrefOnlyImageBuilder] to use with this builder. */
-    fun createHrefOnlyImageBuilder(): HrefOnlyImageBuilder
+    public fun createHrefOnlyImageBuilder(): HrefOnlyImageBuilder
 
     /** Creates an instance of [EpisodePodloveSimpleChapterBuilder] to use with this builder. */
-    fun createPodloveSimpleChapterBuilder(): EpisodePodloveSimpleChapterBuilder
+    public fun createPodloveSimpleChapterBuilder(): EpisodePodloveSimpleChapterBuilder
 
     /** Creates an instance of [RssCategoryBuilder] to use with this builder. */
-    fun createRssCategoryBuilder(): RssCategoryBuilder
+    public fun createRssCategoryBuilder(): RssCategoryBuilder
 
     /** Creates an instance of [ITunesStyleCategoryBuilder] to use with this builder. */
-    fun createITunesStyleCategoryBuilder(): ITunesStyleCategoryBuilder
+    public fun createITunesStyleCategoryBuilder(): ITunesStyleCategoryBuilder
 
     /** Creates an instance of [EpisodePodcastTranscriptBuilder] to use with this builder. */
-    fun createEpisodePodcastTranscriptBuilder(): EpisodePodcastTranscriptBuilder
+    public fun createEpisodePodcastTranscriptBuilder(): EpisodePodcastTranscriptBuilder
 
     /** Creates an instance of [EpisodePodcastChaptersBuilder] to use with this builder. */
-    fun createEpisodePodcastChaptersBuilder(): EpisodePodcastChaptersBuilder
+    public fun createEpisodePodcastChaptersBuilder(): EpisodePodcastChaptersBuilder
 
     /** Creates an instance of [EpisodePodcastSoundbiteBuilder] to use with this builder. */
-    fun createEpisodePodcastSoundbiteBuilder(): EpisodePodcastSoundbiteBuilder
+    public fun createEpisodePodcastSoundbiteBuilder(): EpisodePodcastSoundbiteBuilder
 
     override fun from(model: Episode?): EpisodeBuilder = whenNotNull(model) { episode ->
         contentBuilder.from(episode.content)

--- a/src/main/kotlin/io/hemin/wien/builder/episode/EpisodeContentBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/episode/EpisodeContentBuilder.kt
@@ -5,10 +5,10 @@ import io.hemin.wien.model.Episode
 import io.hemin.wien.util.whenNotNull
 
 /** Builder for constructing [Episode.Content] instances. */
-interface EpisodeContentBuilder : Builder<Episode.Content> {
+public interface EpisodeContentBuilder : Builder<Episode.Content> {
 
     /** Set the encoded value. */
-    fun encoded(encoded: String): EpisodeContentBuilder
+    public fun encoded(encoded: String): EpisodeContentBuilder
 
     override fun from(model: Episode.Content?): EpisodeContentBuilder = whenNotNull(model) { content ->
         encoded(content.encoded)

--- a/src/main/kotlin/io/hemin/wien/builder/episode/EpisodeEnclosureBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/episode/EpisodeEnclosureBuilder.kt
@@ -5,16 +5,16 @@ import io.hemin.wien.model.Episode
 import io.hemin.wien.util.whenNotNull
 
 /** Builder for constructing [Episode.Enclosure] instances. */
-interface EpisodeEnclosureBuilder : Builder<Episode.Enclosure> {
+public interface EpisodeEnclosureBuilder : Builder<Episode.Enclosure> {
 
     /** Set the url value. */
-    fun url(url: String): EpisodeEnclosureBuilder
+    public fun url(url: String): EpisodeEnclosureBuilder
 
     /** Set the length value. */
-    fun length(length: Long): EpisodeEnclosureBuilder
+    public fun length(length: Long): EpisodeEnclosureBuilder
 
     /** Set the type value. */
-    fun type(type: String): EpisodeEnclosureBuilder
+    public fun type(type: String): EpisodeEnclosureBuilder
 
     override fun from(model: Episode.Enclosure?): EpisodeEnclosureBuilder = whenNotNull(model) { enclosure ->
         url(enclosure.url)

--- a/src/main/kotlin/io/hemin/wien/builder/episode/EpisodeGooglePlayBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/episode/EpisodeGooglePlayBuilder.kt
@@ -7,19 +7,19 @@ import io.hemin.wien.model.HrefOnlyImage
 import io.hemin.wien.util.whenNotNull
 
 /** Builder for constructing [Episode.GooglePlay] instances. */
-interface EpisodeGooglePlayBuilder : Builder<Episode.GooglePlay> {
+public interface EpisodeGooglePlayBuilder : Builder<Episode.GooglePlay> {
 
     /** Set the description value. */
-    fun description(description: String?): EpisodeGooglePlayBuilder
+    public fun description(description: String?): EpisodeGooglePlayBuilder
 
     /** Set the explicit value. */
-    fun explicit(explicit: Boolean?): EpisodeGooglePlayBuilder
+    public fun explicit(explicit: Boolean?): EpisodeGooglePlayBuilder
 
     /** Set the block value. */
-    fun block(block: Boolean): EpisodeGooglePlayBuilder
+    public fun block(block: Boolean): EpisodeGooglePlayBuilder
 
     /** Set the [HrefOnlyImageBuilder]. */
-    fun imageBuilder(imageBuilder: HrefOnlyImageBuilder?): EpisodeGooglePlayBuilder
+    public fun imageBuilder(imageBuilder: HrefOnlyImageBuilder?): EpisodeGooglePlayBuilder
 
     override fun from(model: Episode.GooglePlay?): EpisodeGooglePlayBuilder = whenNotNull(model) { googlePlay ->
         description(googlePlay.description)

--- a/src/main/kotlin/io/hemin/wien/builder/episode/EpisodeGuidBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/episode/EpisodeGuidBuilder.kt
@@ -5,13 +5,13 @@ import io.hemin.wien.model.Episode
 import io.hemin.wien.util.whenNotNull
 
 /** Builder for constructing [Episode.Guid] instances. */
-interface EpisodeGuidBuilder : Builder<Episode.Guid> {
+public interface EpisodeGuidBuilder : Builder<Episode.Guid> {
 
     /** Set the textContent value. */
-    fun textContent(textContent: String): EpisodeGuidBuilder
+    public fun textContent(textContent: String): EpisodeGuidBuilder
 
     /** Set the isPermalink value. */
-    fun isPermalink(isPermalink: Boolean?): EpisodeGuidBuilder
+    public fun isPermalink(isPermalink: Boolean?): EpisodeGuidBuilder
 
     override fun from(model: Episode.Guid?): EpisodeGuidBuilder = whenNotNull(model) { guid ->
         textContent(guid.guid)

--- a/src/main/kotlin/io/hemin/wien/builder/episode/EpisodeITunesBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/episode/EpisodeITunesBuilder.kt
@@ -7,40 +7,40 @@ import io.hemin.wien.model.HrefOnlyImage
 import io.hemin.wien.util.whenNotNull
 
 /** Builder for constructing [Episode.ITunes] instances. */
-interface EpisodeITunesBuilder : Builder<Episode.ITunes> {
+public interface EpisodeITunesBuilder : Builder<Episode.ITunes> {
 
     /** Set the title value. */
-    fun title(title: String?): EpisodeITunesBuilder
+    public fun title(title: String?): EpisodeITunesBuilder
 
     /** Set the duration value. */
-    fun duration(duration: String?): EpisodeITunesBuilder
+    public fun duration(duration: String?): EpisodeITunesBuilder
 
     /** Set the [HrefOnlyImageBuilder]. */
-    fun imageBuilder(imageBuilder: HrefOnlyImageBuilder?): EpisodeITunesBuilder
+    public fun imageBuilder(imageBuilder: HrefOnlyImageBuilder?): EpisodeITunesBuilder
 
     /** Set the explicit flag value. */
-    fun explicit(explicit: Boolean?): EpisodeITunesBuilder
+    public fun explicit(explicit: Boolean?): EpisodeITunesBuilder
 
     /** Set the block flag value. */
-    fun block(block: Boolean): EpisodeITunesBuilder
+    public fun block(block: Boolean): EpisodeITunesBuilder
 
     /** Set the season value. */
-    fun season(season: Int?): EpisodeITunesBuilder
+    public fun season(season: Int?): EpisodeITunesBuilder
 
     /** Set the episode value. */
-    fun episode(episode: Int?): EpisodeITunesBuilder
+    public fun episode(episode: Int?): EpisodeITunesBuilder
 
     /** Set the episodeType value. */
-    fun episodeType(episodeType: String?): EpisodeITunesBuilder
+    public fun episodeType(episodeType: String?): EpisodeITunesBuilder
 
     /** Set the author value. */
-    fun author(author: String?): EpisodeITunesBuilder
+    public fun author(author: String?): EpisodeITunesBuilder
 
     /** Set the subtitle value. */
-    fun subtitle(subtitle: String?): EpisodeITunesBuilder
+    public fun subtitle(subtitle: String?): EpisodeITunesBuilder
 
     /** Set the summary value. */
-    fun summary(summary: String?): EpisodeITunesBuilder
+    public fun summary(summary: String?): EpisodeITunesBuilder
 
     override fun from(model: Episode.ITunes?): EpisodeITunesBuilder = whenNotNull(model) { itunes ->
         title(itunes.title)

--- a/src/main/kotlin/io/hemin/wien/builder/episode/EpisodePodcastBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/episode/EpisodePodcastBuilder.kt
@@ -6,34 +6,34 @@ import io.hemin.wien.util.asBuilders
 import io.hemin.wien.util.whenNotNull
 
 /** Builder for constructing [Episode.Podcast] instances. */
-interface EpisodePodcastBuilder : Builder<Episode.Podcast> {
+public interface EpisodePodcastBuilder : Builder<Episode.Podcast> {
 
     /**
      * Set the [EpisodePodcastChaptersBuilder] for the Podcast namespace `<chapters>` info.
      */
-    fun chaptersBuilder(chaptersBuilder: EpisodePodcastChaptersBuilder): EpisodePodcastBuilder
+    public fun chaptersBuilder(chaptersBuilder: EpisodePodcastChaptersBuilder): EpisodePodcastBuilder
 
     /**
      * Adds a [EpisodePodcastSoundbiteBuilder] for the Podcast namespace `<soundbite>` info to the list of soundbite builders.
      */
-    fun addSoundbiteBuilder(soundbiteBuilder: EpisodePodcastSoundbiteBuilder): EpisodePodcastBuilder
+    public fun addSoundbiteBuilder(soundbiteBuilder: EpisodePodcastSoundbiteBuilder): EpisodePodcastBuilder
 
     /**
      * Adds multiple [EpisodePodcastSoundbiteBuilder] for the Podcast namespace `<soundbite>` info to the list of soundbite builders.
      */
-    fun addSoundbiteBuilders(soundbiteBuilders: List<EpisodePodcastSoundbiteBuilder>): EpisodePodcastBuilder = apply {
+    public fun addSoundbiteBuilders(soundbiteBuilders: List<EpisodePodcastSoundbiteBuilder>): EpisodePodcastBuilder = apply {
         soundbiteBuilders.forEach(::addSoundbiteBuilder)
     }
 
     /**
      * Adds a [EpisodePodcastTranscriptBuilder] for the Podcast namespace `<transcript>` info to the list of transcript builders.
      */
-    fun addTranscriptBuilder(transcriptBuilder: EpisodePodcastTranscriptBuilder): EpisodePodcastBuilder
+    public fun addTranscriptBuilder(transcriptBuilder: EpisodePodcastTranscriptBuilder): EpisodePodcastBuilder
 
     /**
      * Adds multiple [EpisodePodcastTranscriptBuilder] for the Podcast namespace `<transcript>` info to the list of transcript builders.
      */
-    fun addTranscriptBuilders(transcriptBuilders: List<EpisodePodcastTranscriptBuilder>): EpisodePodcastBuilder = apply {
+    public fun addTranscriptBuilders(transcriptBuilders: List<EpisodePodcastTranscriptBuilder>): EpisodePodcastBuilder = apply {
         transcriptBuilders.forEach(::addTranscriptBuilder)
     }
 

--- a/src/main/kotlin/io/hemin/wien/builder/episode/EpisodePodcastChaptersBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/episode/EpisodePodcastChaptersBuilder.kt
@@ -5,13 +5,13 @@ import io.hemin.wien.model.Episode
 import io.hemin.wien.util.whenNotNull
 
 /** Builder for constructing [Episode.Podcast.Chapters] instances. */
-interface EpisodePodcastChaptersBuilder : Builder<Episode.Podcast.Chapters> {
+public interface EpisodePodcastChaptersBuilder : Builder<Episode.Podcast.Chapters> {
 
     /** Set the url value . */
-    fun url(url: String): EpisodePodcastChaptersBuilder
+    public fun url(url: String): EpisodePodcastChaptersBuilder
 
     /** Set the type value. */
-    fun type(type: String): EpisodePodcastChaptersBuilder
+    public fun type(type: String): EpisodePodcastChaptersBuilder
 
     override fun from(model: Episode.Podcast.Chapters?): EpisodePodcastChaptersBuilder = whenNotNull(model) { chapters ->
         url(chapters.url)

--- a/src/main/kotlin/io/hemin/wien/builder/episode/EpisodePodcastSoundbiteBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/episode/EpisodePodcastSoundbiteBuilder.kt
@@ -6,16 +6,16 @@ import io.hemin.wien.util.whenNotNull
 import java.time.Duration
 
 /** Builder for constructing [Episode.Podcast.Soundbite] instances. */
-interface EpisodePodcastSoundbiteBuilder : Builder<Episode.Podcast.Soundbite> {
+public interface EpisodePodcastSoundbiteBuilder : Builder<Episode.Podcast.Soundbite> {
 
     /** Set the starTime value. */
-    fun startTime(startTime: Duration): EpisodePodcastSoundbiteBuilder
+    public fun startTime(startTime: Duration): EpisodePodcastSoundbiteBuilder
 
     /** Set the duration value. */
-    fun duration(duration: Duration): EpisodePodcastSoundbiteBuilder
+    public fun duration(duration: Duration): EpisodePodcastSoundbiteBuilder
 
     /** Set the title value. */
-    fun title(title: String?): EpisodePodcastSoundbiteBuilder
+    public fun title(title: String?): EpisodePodcastSoundbiteBuilder
 
     override fun from(model: Episode.Podcast.Soundbite?): EpisodePodcastSoundbiteBuilder = whenNotNull(model) { soundbite ->
         startTime(soundbite.startTime)

--- a/src/main/kotlin/io/hemin/wien/builder/episode/EpisodePodcastTranscriptBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/episode/EpisodePodcastTranscriptBuilder.kt
@@ -6,19 +6,19 @@ import io.hemin.wien.util.whenNotNull
 import java.util.Locale
 
 /** Builder for constructing [Episode.Podcast.Transcript] instances. */
-interface EpisodePodcastTranscriptBuilder : Builder<Episode.Podcast.Transcript> {
+public interface EpisodePodcastTranscriptBuilder : Builder<Episode.Podcast.Transcript> {
 
     /** Set the url value. */
-    fun url(url: String): EpisodePodcastTranscriptBuilder
+    public fun url(url: String): EpisodePodcastTranscriptBuilder
 
     /** Set the [Episode.Podcast.Transcript.Type] value. */
-    fun type(type: Episode.Podcast.Transcript.Type): EpisodePodcastTranscriptBuilder
+    public fun type(type: Episode.Podcast.Transcript.Type): EpisodePodcastTranscriptBuilder
 
     /** Set the language value. */
-    fun language(language: Locale?): EpisodePodcastTranscriptBuilder
+    public fun language(language: Locale?): EpisodePodcastTranscriptBuilder
 
     /** Set the rel value. */
-    fun rel(rel: String?): EpisodePodcastTranscriptBuilder
+    public fun rel(rel: String?): EpisodePodcastTranscriptBuilder
 
     override fun from(model: Episode.Podcast.Transcript?): EpisodePodcastTranscriptBuilder = whenNotNull(model) { transcript ->
         url(transcript.url)

--- a/src/main/kotlin/io/hemin/wien/builder/episode/EpisodePodloveBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/episode/EpisodePodloveBuilder.kt
@@ -6,13 +6,13 @@ import io.hemin.wien.util.asBuilders
 import io.hemin.wien.util.whenNotNull
 
 /** Builder for constructing [Episode.Podlove] instances. */
-interface EpisodePodloveBuilder : Builder<Episode.Podlove> {
+public interface EpisodePodloveBuilder : Builder<Episode.Podlove> {
 
     /** Adds a [EpisodePodloveSimpleChapterBuilder] to the list of chapter builders. */
-    fun addSimpleChapterBuilder(chapterBuilder: EpisodePodloveSimpleChapterBuilder): EpisodePodloveBuilder
+    public fun addSimpleChapterBuilder(chapterBuilder: EpisodePodloveSimpleChapterBuilder): EpisodePodloveBuilder
 
     /** Adds multiple [EpisodePodloveSimpleChapterBuilder] to the list of chapter builders. */
-    fun addSimpleChapterBuilders(chapterBuilders: List<EpisodePodloveSimpleChapterBuilder>): EpisodePodloveBuilder
+    public fun addSimpleChapterBuilders(chapterBuilders: List<EpisodePodloveSimpleChapterBuilder>): EpisodePodloveBuilder
 
     override fun from(model: Episode.Podlove?): EpisodePodloveBuilder = whenNotNull(model) { podlove ->
         addSimpleChapterBuilders(podlove.simpleChapters.asBuilders())

--- a/src/main/kotlin/io/hemin/wien/builder/episode/EpisodePodloveSimpleChapterBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/episode/EpisodePodloveSimpleChapterBuilder.kt
@@ -5,19 +5,19 @@ import io.hemin.wien.model.Episode
 import io.hemin.wien.util.whenNotNull
 
 /** Builder for constructing [Episode.Podlove.SimpleChapter] instances. */
-interface EpisodePodloveSimpleChapterBuilder : Builder<Episode.Podlove.SimpleChapter> {
+public interface EpisodePodloveSimpleChapterBuilder : Builder<Episode.Podlove.SimpleChapter> {
 
     /** Set the start value. */
-    fun start(start: String): EpisodePodloveSimpleChapterBuilder
+    public fun start(start: String): EpisodePodloveSimpleChapterBuilder
 
     /** Set the title value. */
-    fun title(title: String): EpisodePodloveSimpleChapterBuilder
+    public fun title(title: String): EpisodePodloveSimpleChapterBuilder
 
     /** Set the href value. */
-    fun href(href: String?): EpisodePodloveSimpleChapterBuilder
+    public fun href(href: String?): EpisodePodloveSimpleChapterBuilder
 
     /** Set the image value. */
-    fun image(image: String?): EpisodePodloveSimpleChapterBuilder
+    public fun image(image: String?): EpisodePodloveSimpleChapterBuilder
 
     override fun from(model: Episode.Podlove.SimpleChapter?): EpisodePodloveSimpleChapterBuilder = whenNotNull(model) { simpleChapter ->
         start(simpleChapter.start)

--- a/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastBuilder.kt
@@ -16,98 +16,98 @@ import io.hemin.wien.util.whenNotNull
 import java.time.temporal.TemporalAccessor
 
 /** Builder for constructing [Podcast] instances. */
-interface PodcastBuilder : Builder<Podcast>, PersonBuilderProvider, LinkBuilderProvider {
+public interface PodcastBuilder : Builder<Podcast>, PersonBuilderProvider, LinkBuilderProvider {
 
     /** The builder for data from the iTunes namespace. */
-    val iTunesBuilder: PodcastITunesBuilder
+    public val iTunesBuilder: PodcastITunesBuilder
 
     /** The builder for data from the Atom namespace. */
-    val atomBuilder: AtomBuilder
+    public val atomBuilder: AtomBuilder
 
     /** The builder for data from the Fyyd namespace. */
-    val fyydBuilder: PodcastFyydBuilder
+    public val fyydBuilder: PodcastFyydBuilder
 
     /** The builder for data from the Feedpress namespace. */
-    val feedpressBuilder: PodcastFeedpressBuilder
+    public val feedpressBuilder: PodcastFeedpressBuilder
 
     /** The builder for data from the Google Play namespace. */
-    val googlePlayBuilder: PodcastGooglePlayBuilder
+    public val googlePlayBuilder: PodcastGooglePlayBuilder
 
     /** Set the Podcast namespace builder. */
-    val podcastBuilder: PodcastPodcastBuilder
+    public val podcastBuilder: PodcastPodcastBuilder
 
     /** Set the title value. */
-    fun title(title: String): PodcastBuilder
+    public fun title(title: String): PodcastBuilder
 
     /** Set the link value. */
-    fun link(link: String): PodcastBuilder
+    public fun link(link: String): PodcastBuilder
 
     /** Set the description value. */
-    fun description(description: String): PodcastBuilder
+    public fun description(description: String): PodcastBuilder
 
     /** Set the pubDate value. */
-    fun pubDate(pubDate: TemporalAccessor?): PodcastBuilder
+    public fun pubDate(pubDate: TemporalAccessor?): PodcastBuilder
 
     /** Set the lastBuildDate value. */
-    fun lastBuildDate(lastBuildDate: TemporalAccessor?): PodcastBuilder
+    public fun lastBuildDate(lastBuildDate: TemporalAccessor?): PodcastBuilder
 
     /** Set the language value. */
-    fun language(language: String): PodcastBuilder
+    public fun language(language: String): PodcastBuilder
 
     /** Set the generator value. */
-    fun generator(generator: String?): PodcastBuilder
+    public fun generator(generator: String?): PodcastBuilder
 
     /** Set the copyright value. */
-    fun copyright(copyright: String?): PodcastBuilder
+    public fun copyright(copyright: String?): PodcastBuilder
 
     /** Set the docs value. */
-    fun docs(docs: String?): PodcastBuilder
+    public fun docs(docs: String?): PodcastBuilder
 
     /** Set the managingEditor value. */
-    fun managingEditor(managingEditor: String?): PodcastBuilder
+    public fun managingEditor(managingEditor: String?): PodcastBuilder
 
     /** Set the webMaster value. */
-    fun webMaster(webMaster: String?): PodcastBuilder
+    public fun webMaster(webMaster: String?): PodcastBuilder
 
     /** Set the time to live (ttl) value. */
-    fun ttl(ttl: Int?): PodcastBuilder
+    public fun ttl(ttl: Int?): PodcastBuilder
 
     /** Set the [RssImageBuilder]. */
-    fun imageBuilder(imageBuilder: RssImageBuilder?): PodcastBuilder
+    public fun imageBuilder(imageBuilder: RssImageBuilder?): PodcastBuilder
 
     /** Adds an [EpisodeBuilder] to the list of episode builders. */
-    fun addEpisodeBuilder(episodeBuilder: EpisodeBuilder): PodcastBuilder
+    public fun addEpisodeBuilder(episodeBuilder: EpisodeBuilder): PodcastBuilder
 
     /** Adds multiple [EpisodeBuilder] to the list of episode builders. */
-    fun addEpisodeBuilders(episodeBuilders: List<EpisodeBuilder>): PodcastBuilder = apply {
+    public fun addEpisodeBuilders(episodeBuilders: List<EpisodeBuilder>): PodcastBuilder = apply {
         episodeBuilders.forEach(::addEpisodeBuilder)
     }
 
     /** Adds an [RssCategoryBuilder] to the list of category builders. */
-    fun addCategoryBuilder(categoryBuilder: RssCategoryBuilder): PodcastBuilder
+    public fun addCategoryBuilder(categoryBuilder: RssCategoryBuilder): PodcastBuilder
 
     /** Adds multiple [RssCategoryBuilder] to the list of category builders. */
-    fun addCategoryBuilders(categoryBuilders: List<RssCategoryBuilder>): PodcastBuilder = apply {
+    public fun addCategoryBuilders(categoryBuilders: List<RssCategoryBuilder>): PodcastBuilder = apply {
         categoryBuilders.forEach(::addCategoryBuilder)
     }
 
     /** Creates an instance of [RssImageBuilder] to use with this builder. */
-    fun createRssImageBuilder(): RssImageBuilder
+    public fun createRssImageBuilder(): RssImageBuilder
 
     /** Creates an instance of [HrefOnlyImageBuilder] to use with this builder. */
-    fun createHrefOnlyImageBuilder(): HrefOnlyImageBuilder
+    public fun createHrefOnlyImageBuilder(): HrefOnlyImageBuilder
 
     /** Creates an instance of [RssCategoryBuilder] to use with this builder. */
-    fun createRssCategoryBuilder(): RssCategoryBuilder
+    public fun createRssCategoryBuilder(): RssCategoryBuilder
 
     /** Creates an instance of [ITunesStyleCategoryBuilder] to use with this builder. */
-    fun createITunesStyleCategoryBuilder(): ITunesStyleCategoryBuilder
+    public fun createITunesStyleCategoryBuilder(): ITunesStyleCategoryBuilder
 
     /** Creates an instance of [PodcastPodcastLockedBuilder] to use with this builder. */
-    fun createPodcastPodcastLockedBuilder(): PodcastPodcastLockedBuilder
+    public fun createPodcastPodcastLockedBuilder(): PodcastPodcastLockedBuilder
 
     /** Creates an instance of [PodcastPodcastFundingBuilder] to use with this builder. */
-    fun createPodcastPodcastFundingBuilder(): PodcastPodcastFundingBuilder
+    public fun createPodcastPodcastFundingBuilder(): PodcastPodcastFundingBuilder
 
     override fun from(model: Podcast?): PodcastBuilder = whenNotNull(model) { podcast ->
         iTunesBuilder.from(podcast.iTunes)

--- a/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastFeedpressBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastFeedpressBuilder.kt
@@ -5,22 +5,22 @@ import io.hemin.wien.model.Podcast
 import io.hemin.wien.util.whenNotNull
 
 /** Builder for constructing [Podcast.Feedpress] instances. */
-interface PodcastFeedpressBuilder : Builder<Podcast.Feedpress> {
+public interface PodcastFeedpressBuilder : Builder<Podcast.Feedpress> {
 
     /** Set the newsletterId value. */
-    fun newsletterId(newsletterId: String?): PodcastFeedpressBuilder
+    public fun newsletterId(newsletterId: String?): PodcastFeedpressBuilder
 
     /** Set the locale value. */
-    fun locale(locale: String?): PodcastFeedpressBuilder
+    public fun locale(locale: String?): PodcastFeedpressBuilder
 
     /** Set the podcastId value. */
-    fun podcastId(podcastId: String?): PodcastFeedpressBuilder
+    public fun podcastId(podcastId: String?): PodcastFeedpressBuilder
 
     /** Set the cssFile value. */
-    fun cssFile(cssFile: String?): PodcastFeedpressBuilder
+    public fun cssFile(cssFile: String?): PodcastFeedpressBuilder
 
     /** Set the link value. */
-    fun link(link: String?): PodcastFeedpressBuilder
+    public fun link(link: String?): PodcastFeedpressBuilder
 
     override fun from(model: Podcast.Feedpress?): PodcastFeedpressBuilder = whenNotNull(model) { feedpress ->
         newsletterId(feedpress.newsletterId)

--- a/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastFyydBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastFyydBuilder.kt
@@ -5,10 +5,10 @@ import io.hemin.wien.model.Podcast
 import io.hemin.wien.util.whenNotNull
 
 /** Builder for constructing [Podcast.Fyyd] instances. */
-interface PodcastFyydBuilder : Builder<Podcast.Fyyd> {
+public interface PodcastFyydBuilder : Builder<Podcast.Fyyd> {
 
     /** Set the verify value. */
-    fun verify(verify: String): PodcastFyydBuilder
+    public fun verify(verify: String): PodcastFyydBuilder
 
     override fun from(model: Podcast.Fyyd?): PodcastFyydBuilder = whenNotNull(model) { fyyd ->
         verify(fyyd.verify)

--- a/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastGooglePlayBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastGooglePlayBuilder.kt
@@ -9,33 +9,33 @@ import io.hemin.wien.util.asBuilders
 import io.hemin.wien.util.whenNotNull
 
 /** Builder for constructing [Podcast.GooglePlay] instances. */
-interface PodcastGooglePlayBuilder : Builder<Podcast.GooglePlay> {
+public interface PodcastGooglePlayBuilder : Builder<Podcast.GooglePlay> {
 
     /** Set the author value. */
-    fun author(author: String?): PodcastGooglePlayBuilder
+    public fun author(author: String?): PodcastGooglePlayBuilder
 
     /** Set the owner email value. */
-    fun owner(email: String?): PodcastGooglePlayBuilder
+    public fun owner(email: String?): PodcastGooglePlayBuilder
 
     /** Adds an [ITunesStyleCategoryBuilder] to the list of category builders. */
-    fun addCategoryBuilder(categoryBuilder: ITunesStyleCategoryBuilder): PodcastGooglePlayBuilder
+    public fun addCategoryBuilder(categoryBuilder: ITunesStyleCategoryBuilder): PodcastGooglePlayBuilder
 
     /** Adds multiple [ITunesStyleCategoryBuilder] to the list of category builders. */
-    fun addCategoryBuilders(categoryBuilders: List<ITunesStyleCategoryBuilder>): PodcastGooglePlayBuilder = apply {
+    public fun addCategoryBuilders(categoryBuilders: List<ITunesStyleCategoryBuilder>): PodcastGooglePlayBuilder = apply {
         categoryBuilders.forEach(::addCategoryBuilder)
     }
 
     /** Set the description value. */
-    fun description(description: String?): PodcastGooglePlayBuilder
+    public fun description(description: String?): PodcastGooglePlayBuilder
 
     /** Set the explicit flag value. */
-    fun explicit(explicit: Boolean?): PodcastGooglePlayBuilder
+    public fun explicit(explicit: Boolean?): PodcastGooglePlayBuilder
 
     /** Set the block flag value. */
-    fun block(block: Boolean): PodcastGooglePlayBuilder
+    public fun block(block: Boolean): PodcastGooglePlayBuilder
 
     /** Set the [HrefOnlyImageBuilder]. */
-    fun imageBuilder(imageBuilder: HrefOnlyImageBuilder?): PodcastGooglePlayBuilder
+    public fun imageBuilder(imageBuilder: HrefOnlyImageBuilder?): PodcastGooglePlayBuilder
 
     override fun from(model: Podcast.GooglePlay?): PodcastGooglePlayBuilder = whenNotNull(model) { googlePlay ->
         author(googlePlay.author)

--- a/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastITunesBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastITunesBuilder.kt
@@ -11,51 +11,51 @@ import io.hemin.wien.util.asBuilders
 import io.hemin.wien.util.whenNotNull
 
 /** Builder for constructing [Podcast.ITunes] instances. */
-interface PodcastITunesBuilder : Builder<Podcast.ITunes> {
+public interface PodcastITunesBuilder : Builder<Podcast.ITunes> {
 
     /** Set the subtitle value. */
-    fun subtitle(subtitle: String?): PodcastITunesBuilder
+    public fun subtitle(subtitle: String?): PodcastITunesBuilder
 
     /** Set the summary value. */
-    fun summary(summary: String?): PodcastITunesBuilder
+    public fun summary(summary: String?): PodcastITunesBuilder
 
     /** Set the ImageBuilder. */
-    fun imageBuilder(imageBuilder: HrefOnlyImageBuilder): PodcastITunesBuilder
+    public fun imageBuilder(imageBuilder: HrefOnlyImageBuilder): PodcastITunesBuilder
 
     /** Set the keywords value. */
-    fun keywords(keywords: String?): PodcastITunesBuilder
+    public fun keywords(keywords: String?): PodcastITunesBuilder
 
     /** Set the author value. */
-    fun author(author: String?): PodcastITunesBuilder
+    public fun author(author: String?): PodcastITunesBuilder
 
     /** Adds an [ITunesStyleCategoryBuilder] to the list of category builders. */
-    fun addCategoryBuilder(categoryBuilder: ITunesStyleCategoryBuilder): PodcastITunesBuilder
+    public fun addCategoryBuilder(categoryBuilder: ITunesStyleCategoryBuilder): PodcastITunesBuilder
 
     /** Adds multiple [ITunesStyleCategoryBuilder] to the list of category builders. */
-    fun addCategoryBuilders(categoryBuilders: List<ITunesStyleCategoryBuilder>): PodcastITunesBuilder = apply {
+    public fun addCategoryBuilders(categoryBuilders: List<ITunesStyleCategoryBuilder>): PodcastITunesBuilder = apply {
         categoryBuilders.forEach(::addCategoryBuilder)
     }
 
     /** Set the explicit flag value. */
-    fun explicit(explicit: Boolean): PodcastITunesBuilder
+    public fun explicit(explicit: Boolean): PodcastITunesBuilder
 
     /** Set the block flag value. */
-    fun block(block: Boolean): PodcastITunesBuilder
+    public fun block(block: Boolean): PodcastITunesBuilder
 
     /** Set the complete flag value. */
-    fun complete(complete: Boolean): PodcastITunesBuilder
+    public fun complete(complete: Boolean): PodcastITunesBuilder
 
     /** Set the type value. */
-    fun type(type: String?): PodcastITunesBuilder
+    public fun type(type: String?): PodcastITunesBuilder
 
     /** Set the Person representing the owner. */
-    fun ownerBuilder(ownerBuilder: PersonBuilder?): PodcastITunesBuilder
+    public fun ownerBuilder(ownerBuilder: PersonBuilder?): PodcastITunesBuilder
 
     /** Set the episode title. */
-    fun title(title: String?): PodcastITunesBuilder
+    public fun title(title: String?): PodcastITunesBuilder
 
     /** Set the new URL at which this feed is located. */
-    fun newFeedUrl(newFeedUrl: String?): PodcastITunesBuilder
+    public fun newFeedUrl(newFeedUrl: String?): PodcastITunesBuilder
 
     override fun from(model: Podcast.ITunes?): PodcastITunesBuilder = whenNotNull(model) { itunes ->
         subtitle(itunes.subtitle)

--- a/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastPodcastBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastPodcastBuilder.kt
@@ -6,20 +6,20 @@ import io.hemin.wien.util.asBuilders
 import io.hemin.wien.util.whenNotNull
 
 /** Builder for constructing [Podcast.Podcast] instances. */
-interface PodcastPodcastBuilder : Builder<Podcast.Podcast> {
+public interface PodcastPodcastBuilder : Builder<Podcast.Podcast> {
 
     /** Set the [PodcastPodcastLockedBuilder]. */
-    fun lockedBuilder(lockedBuilder: PodcastPodcastLockedBuilder): PodcastPodcastBuilder
+    public fun lockedBuilder(lockedBuilder: PodcastPodcastLockedBuilder): PodcastPodcastBuilder
 
     /**
      * Adds a [PodcastPodcastFundingBuilder] for the Podcast namespace `<funding>` info to the list of funding builders.
      */
-    fun addFundingBuilder(fundingBuilder: PodcastPodcastFundingBuilder): PodcastPodcastBuilder
+    public fun addFundingBuilder(fundingBuilder: PodcastPodcastFundingBuilder): PodcastPodcastBuilder
 
     /**
      * Adds multiple [PodcastPodcastFundingBuilder] for the Podcast namespace `<funding>` info to the list of funding builders.
      */
-    fun addFundingBuilders(fundingBuilders: List<PodcastPodcastFundingBuilder>): PodcastPodcastBuilder = apply {
+    public fun addFundingBuilders(fundingBuilders: List<PodcastPodcastFundingBuilder>): PodcastPodcastBuilder = apply {
         fundingBuilders.forEach(::addFundingBuilder)
     }
 

--- a/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastPodcastFundingBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastPodcastFundingBuilder.kt
@@ -5,13 +5,13 @@ import io.hemin.wien.model.Podcast
 import io.hemin.wien.util.whenNotNull
 
 /** Builder for constructing [Podcast.Podcast.Funding] instances. */
-interface PodcastPodcastFundingBuilder : Builder<Podcast.Podcast.Funding> {
+public interface PodcastPodcastFundingBuilder : Builder<Podcast.Podcast.Funding> {
 
     /** Set the url value. */
-    fun url(url: String): PodcastPodcastFundingBuilder
+    public fun url(url: String): PodcastPodcastFundingBuilder
 
     /** Set the message value */
-    fun message(message: String): PodcastPodcastFundingBuilder
+    public fun message(message: String): PodcastPodcastFundingBuilder
 
     override fun from(model: Podcast.Podcast.Funding?): PodcastPodcastFundingBuilder = whenNotNull(model) { funding ->
         url(funding.url)

--- a/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastPodcastLockedBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/podcast/PodcastPodcastLockedBuilder.kt
@@ -5,13 +5,13 @@ import io.hemin.wien.model.Podcast
 import io.hemin.wien.util.whenNotNull
 
 /** Builder for constructing [Podcast.Podcast.Locked] instances. */
-interface PodcastPodcastLockedBuilder : Builder<Podcast.Podcast.Locked> {
+public interface PodcastPodcastLockedBuilder : Builder<Podcast.Podcast.Locked> {
 
     /** Set the owner value. */
-    fun owner(owner: String): PodcastPodcastLockedBuilder
+    public fun owner(owner: String): PodcastPodcastLockedBuilder
 
     /** Set the locked value. */
-    fun locked(locked: Boolean): PodcastPodcastLockedBuilder
+    public fun locked(locked: Boolean): PodcastPodcastLockedBuilder
 
     override fun from(model: Podcast.Podcast.Locked?): PodcastPodcastLockedBuilder = whenNotNull(model) { podcastLocked ->
         owner(podcastLocked.owner)

--- a/src/main/kotlin/io/hemin/wien/builder/validating/episode/ValidatingEpisodeITunesBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/validating/episode/ValidatingEpisodeITunesBuilder.kt
@@ -34,7 +34,7 @@ internal class ValidatingEpisodeITunesBuilder : EpisodeITunesBuilder {
     override fun episode(episode: Int?): EpisodeITunesBuilder = apply { this.episode = episode }
 
     override fun episodeType(episodeType: String?): EpisodeITunesBuilder = apply {
-        this.episodeType = Episode.ITunes.EpisodeType.of(episodeType)
+        this.episodeType = Episode.ITunes.EpisodeType.from(episodeType)
     }
 
     override fun author(author: String?): EpisodeITunesBuilder = apply { this.author = author }

--- a/src/main/kotlin/io/hemin/wien/builder/validating/podcast/ValidatingPodcastITunesBuilder.kt
+++ b/src/main/kotlin/io/hemin/wien/builder/validating/podcast/ValidatingPodcastITunesBuilder.kt
@@ -43,7 +43,7 @@ internal class ValidatingPodcastITunesBuilder : PodcastITunesBuilder {
 
     override fun complete(complete: Boolean): PodcastITunesBuilder = apply { this.complete = complete }
 
-    override fun type(type: String?): PodcastITunesBuilder = apply { this.type = Podcast.ITunes.ShowType.of(type) }
+    override fun type(type: String?): PodcastITunesBuilder = apply { this.type = Podcast.ITunes.ShowType.from(type) }
 
     override fun ownerBuilder(ownerBuilder: PersonBuilder?): PodcastITunesBuilder = apply { this.ownerBuilder = ownerBuilder }
 

--- a/src/main/kotlin/io/hemin/wien/dom/DomBuilderFactory.kt
+++ b/src/main/kotlin/io/hemin/wien/dom/DomBuilderFactory.kt
@@ -1,5 +1,6 @@
 package io.hemin.wien.dom
 
+import io.hemin.wien.util.InternalApi
 import javax.xml.parsers.DocumentBuilder
 import javax.xml.parsers.DocumentBuilderFactory
 import javax.xml.parsers.ParserConfigurationException
@@ -9,6 +10,7 @@ import javax.xml.parsers.ParserConfigurationException
  * XML documents. This factory applies required configuration
  * to the API instance, for consistent usage in this library.
  */
+@InternalApi
 internal object DomBuilderFactory {
 
     private val factory: DocumentBuilderFactory = DocumentBuilderFactory.newInstance()

--- a/src/main/kotlin/io/hemin/wien/dom/DomExtensions.kt
+++ b/src/main/kotlin/io/hemin/wien/dom/DomExtensions.kt
@@ -2,6 +2,7 @@ package io.hemin.wien.dom
 
 import io.hemin.wien.util.FeedNamespace
 import io.hemin.wien.util.FeedNamespace.Companion.matches
+import io.hemin.wien.util.InternalApi
 import io.hemin.wien.util.trimmedOrNullIfBlank
 import org.w3c.dom.Attr
 import org.w3c.dom.Element
@@ -10,6 +11,7 @@ import org.w3c.dom.Node
 import org.w3c.dom.NodeList
 
 /** Finds the first element matching the given (local)[name], [namespace] and [filter], if any. */
+@InternalApi
 internal fun Node.findElementByName(
     name: String,
     namespace: FeedNamespace? = null,
@@ -26,6 +28,7 @@ private fun Node.getTagName(): String? = when (this) {
 /**
  * Checks whether the node is a direct child of a tag with the given name.
  */
+@InternalApi
 internal fun Node.isDirectChildOf(tagName: String) =
     parentNode.nodeName == tagName && parentNode.namespaceURI == null
 
@@ -36,6 +39,7 @@ internal fun Node.isDirectChildOf(tagName: String) =
  * @param namespace The namespace to use, if any.
  * @return The textContent of the node's attribute.
  */
+@InternalApi
 internal fun Node.getAttributeValueByName(attributeName: String, namespace: FeedNamespace? = null): String? =
     getAttributeByName(attributeName, namespace)?.value?.trimmedOrNullIfBlank()
 
@@ -46,22 +50,27 @@ internal fun Node.getAttributeValueByName(attributeName: String, namespace: Feed
  * @param namespace The namespace to use, if any.
  * @return The textContent of the node's attribute.
  */
+@InternalApi
 internal fun Node.getAttributeByName(attributeName: String, namespace: FeedNamespace? = null): Attr? =
     attributes?.getNamedItemNS(namespace?.uri, attributeName) as? Attr
 
 /** Returns true if the [NodeList] is empty. */
+@InternalApi
 internal fun NodeList.isEmpty() = length == 0
 
 /** Returns true if the [NodeList] contains at least one node. */
+@InternalApi
 internal fun NodeList.isNotEmpty() = length > 0
 
 /** Converts this [NodeList] to a [List] of [Node]s. */
+@InternalApi
 internal fun NodeList.asListOfNodes(): List<Node> {
     if (length == 0) return emptyList()
     return NodeListWrapper(this)
 }
 
 /** Converts this [NamedNodeMap] to a [List] of [Attr]s. */
+@InternalApi
 internal fun NamedNodeMap.asListOfAttrs(): List<Attr> {
     if (length == 0) return emptyList()
     return (0 until length).map { index -> item(index) }
@@ -69,4 +78,5 @@ internal fun NamedNodeMap.asListOfAttrs(): List<Attr> {
 }
 
 /** Casts the [Node] to an [Element]. */
+@InternalApi
 internal fun Node.asElement() = this as Element

--- a/src/main/kotlin/io/hemin/wien/dom/DomParsingExtensions.kt
+++ b/src/main/kotlin/io/hemin/wien/dom/DomParsingExtensions.kt
@@ -8,6 +8,7 @@ import io.hemin.wien.builder.RssImageBuilder
 import io.hemin.wien.parser.DateParser
 import io.hemin.wien.util.FeedNamespace
 import io.hemin.wien.util.FeedNamespace.Companion.matches
+import io.hemin.wien.util.InternalApi
 import io.hemin.wien.util.trimmedOrNullIfBlank
 import org.w3c.dom.Element
 import org.w3c.dom.Node
@@ -20,6 +21,7 @@ import java.util.Locale
  *
  * @return The content of the DOM node in string representation, or null.
  */
+@InternalApi
 internal fun Node.textOrNull(): String? = textContent.trimmedOrNullIfBlank()
 
 /**
@@ -29,6 +31,7 @@ internal fun Node.textOrNull(): String? = textContent.trimmedOrNullIfBlank()
  * @see parseAsBooleanOrNull
  * @return The logical interpretation of the DOM node's text content as boolean, or `null`.
  */
+@InternalApi
 internal fun Node.textAsBooleanOrNull(): Boolean? = textOrNull().parseAsBooleanOrNull()
 
 /**
@@ -37,6 +40,7 @@ internal fun Node.textAsBooleanOrNull(): Boolean? = textOrNull().parseAsBooleanO
  *
  * @return The logical interpretation of the string parameter, or `null`.
  */
+@InternalApi
 internal fun String?.parseAsBooleanOrNull(): Boolean? =
     when (this.trimmedOrNullIfBlank()?.toLowerCase(Locale.ROOT)) {
         "true", "yes" -> true
@@ -49,6 +53,7 @@ internal fun String?.parseAsBooleanOrNull(): Boolean? =
  *
  * @return The DOM node content as an [Int], or `null` if conversion failed.
  */
+@InternalApi
 internal fun Node.parseAsInt(): Int? = textOrNull()?.toIntOrNull()
 
 /**
@@ -57,6 +62,7 @@ internal fun Node.parseAsInt(): Int? = textOrNull()?.toIntOrNull()
  *
  * @return The DOM node content as a [TemporalAccessor], or `null` if parsing failed.
  */
+@InternalApi
 internal fun Node.parseAsTemporalAccessor(): TemporalAccessor? = DateParser.parse(textOrNull())
 
 /**
@@ -71,6 +77,7 @@ internal fun Node.parseAsTemporalAccessor(): TemporalAccessor? = DateParser.pars
  *
  * @return The [imageBuilder] populated with the DOM node contents.
  */
+@InternalApi
 internal fun Node.toRssImageBuilder(imageBuilder: RssImageBuilder, namespace: FeedNamespace? = null): RssImageBuilder {
     for (node in childNodes.asListOfNodes()) {
         if (!namespace.matches(node.namespaceURI)) continue
@@ -107,6 +114,7 @@ internal fun Node.toRssImageBuilder(imageBuilder: RssImageBuilder, namespace: Fe
  *
  * @return The [imageBuilder] populated with the DOM node contents.
  */
+@InternalApi
 internal fun Node.toHrefOnlyImageBuilder(imageBuilder: HrefOnlyImageBuilder): HrefOnlyImageBuilder {
     val href: String? = getAttributeValueByName("href")
     if (!href.isNullOrBlank()) imageBuilder.href(href)
@@ -123,6 +131,7 @@ internal fun Node.toHrefOnlyImageBuilder(imageBuilder: HrefOnlyImageBuilder): Hr
  *
  * @return The [personBuilder] populated with the DOM node contents.
  */
+@InternalApi
 internal fun Node.toPersonBuilder(personBuilder: PersonBuilder, namespace: FeedNamespace? = null): PersonBuilder {
     for (child in childNodes.asListOfNodes()) {
         if (child !is Element) continue
@@ -147,6 +156,7 @@ internal fun Node.toPersonBuilder(personBuilder: PersonBuilder, namespace: FeedN
  *
  * @return The [categoryBuilder] populated with the DOM node contents.
  */
+@InternalApi
 internal fun Node.toRssCategoryBuilder(categoryBuilder: RssCategoryBuilder): RssCategoryBuilder? {
     val categoryValue = textOrNull() ?: return null
     return categoryBuilder.category(categoryValue)
@@ -163,6 +173,7 @@ internal fun Node.toRssCategoryBuilder(categoryBuilder: RssCategoryBuilder): Rss
  *
  * @return The [categoryBuilder] populated with the DOM node contents.
  */
+@InternalApi
 internal fun Node.toITunesCategoryBuilder(categoryBuilder: ITunesStyleCategoryBuilder, namespace: FeedNamespace? = null): ITunesStyleCategoryBuilder {
     val category = getAttributeValueByName("text")?.trim() ?: return categoryBuilder
     categoryBuilder.category(category)

--- a/src/main/kotlin/io/hemin/wien/dom/DomWritingExtensions.kt
+++ b/src/main/kotlin/io/hemin/wien/dom/DomWritingExtensions.kt
@@ -7,6 +7,7 @@ import io.hemin.wien.model.RssCategory
 import io.hemin.wien.model.RssImage
 import io.hemin.wien.util.BooleanStringStyle
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.InternalApi
 import io.hemin.wien.util.asBooleanString
 import io.hemin.wien.util.isNeitherNullNorBlank
 import org.w3c.dom.Attr
@@ -23,6 +24,7 @@ import org.w3c.dom.Node
  * @param image The image to represent with the new element.
  * @param namespace The namespace to use for the new element.
  */
+@InternalApi
 internal fun Node.appendHrefOnlyImageElement(image: HrefOnlyImage, namespace: FeedNamespace): Element? {
     require(namespace == FeedNamespace.ITUNES || namespace == FeedNamespace.GOOGLE_PLAY) {
         "Only 'itunes:image' and 'googleplay:image' tags are supported, but the desired prefix was '${namespace.prefix}:'"
@@ -38,6 +40,7 @@ internal fun Node.appendHrefOnlyImageElement(image: HrefOnlyImage, namespace: Fe
  *
  * @param image The image to represent with the new element.
  */
+@InternalApi
 internal fun Node.appendRssImageElement(image: RssImage): Element? {
     if (image.url.isBlank()) return null
     return appendElement("image") {
@@ -70,6 +73,7 @@ internal fun Node.appendRssImageElement(image: RssImage): Element? {
  *
  * @return Returns the newly created [Element].
  */
+@InternalApi
 internal fun Node.appendElement(elementTagName: String, namespace: FeedNamespace? = null, init: Element.() -> Unit = {}): Element {
     val tagName = if (namespace != null) "${namespace.prefix}:$elementTagName" else elementTagName
     val element = getDocument().createElementNS(namespace?.uri, tagName)
@@ -94,6 +98,7 @@ private fun Node.getDocument(): Document = when {
  *
  * @return Returns the newly created [Attr].
  */
+@InternalApi
 internal fun Element.setAttributeWithNS(attributeName: String, namespace: FeedNamespace? = null, init: Attr.() -> Unit = {}): Attr {
     val name = if (namespace != null) "${namespace.prefix}:$attributeName" else attributeName
     val attr = ownerDocument.createAttributeNS(namespace?.uri, name)
@@ -109,6 +114,7 @@ internal fun Element.setAttributeWithNS(attributeName: String, namespace: FeedNa
  * @param value The value to use
  * @param namespace The namespace to use, if any
  */
+@InternalApi
 internal fun Node.appendYesElementIfTrue(tagName: String, value: Boolean, namespace: FeedNamespace? = null): Element? {
     val stringValue = value.asBooleanString(BooleanStringStyle.YES_NULL)
         ?: return null
@@ -126,6 +132,7 @@ internal fun Node.appendYesElementIfTrue(tagName: String, value: Boolean, namesp
  * @param value The value to use
  * @param namespace The namespace to use, if any
  */
+@InternalApi
 internal fun Node.appendTrueFalseElement(tagName: String, value: Boolean, namespace: FeedNamespace? = null) =
     appendElement(tagName, namespace) {
         textContent = value.asBooleanString(BooleanStringStyle.TRUE_FALSE)
@@ -138,6 +145,7 @@ internal fun Node.appendTrueFalseElement(tagName: String, value: Boolean, namesp
  * @param value The value to use
  * @param namespace The namespace to use, if any
  */
+@InternalApi
 internal fun Node.appendYesNoElement(tagName: String, value: Boolean, namespace: FeedNamespace? = null) =
     appendElement(tagName, namespace) {
         textContent = value.asBooleanString(BooleanStringStyle.YES_NO)
@@ -150,6 +158,7 @@ internal fun Node.appendYesNoElement(tagName: String, value: Boolean, namespace:
  * @param person The person instance to use
  * @param namespace The namespace to use, if any
  */
+@InternalApi
 internal fun Node.appendPersonElement(tagName: String, person: Person, namespace: FeedNamespace? = null) {
     if (person.name.isBlank()) return
 
@@ -172,6 +181,7 @@ internal fun Node.appendPersonElement(tagName: String, person: Person, namespace
  * @param categories The [categories][ITunesStyleCategory] to append.
  * @param namespace The namespace to use, if any.
  */
+@InternalApi
 internal fun Node.appendITunesStyleCategoryElements(categories: List<ITunesStyleCategory>, namespace: FeedNamespace? = null) {
     for (category in categories) {
         if (category.name.isBlank()) continue
@@ -193,6 +203,7 @@ internal fun Node.appendITunesStyleCategoryElements(categories: List<ITunesStyle
  * @param categories The [categories][RssCategory] to append.
  * @param namespace The namespace to use, if any.
  */
+@InternalApi
 internal fun Node.appendRssCategoryElements(categories: List<RssCategory>, namespace: FeedNamespace? = null) {
     for (category in categories) {
         if (category.name.isBlank()) continue

--- a/src/main/kotlin/io/hemin/wien/dom/NodeListWrapper.kt
+++ b/src/main/kotlin/io/hemin/wien/dom/NodeListWrapper.kt
@@ -1,5 +1,6 @@
 package io.hemin.wien.dom
 
+import io.hemin.wien.util.InternalApi
 import org.w3c.dom.Node
 import org.w3c.dom.NodeList
 
@@ -8,6 +9,7 @@ import org.w3c.dom.NodeList
  *
  * @property nodes The [NodeList] to provide a [List] API for.
  */
+@InternalApi
 internal class NodeListWrapper(private val nodes: NodeList) : AbstractList<Node>(), RandomAccess {
 
     /** Returns the number of elements in this nodes. */

--- a/src/main/kotlin/io/hemin/wien/model/Atom.kt
+++ b/src/main/kotlin/io/hemin/wien/model/Atom.kt
@@ -10,12 +10,14 @@ import io.hemin.wien.builder.validating.ValidatingAtomBuilder
  * @property contributors List of data from the `<atom:contributor>` elements as [Person] instances.
  * @property links List of data from the `<atom:link>` elements as [Link] instances.
  */
-data class Atom(
+public data class Atom(
     val authors: List<Person>,
     val contributors: List<Person>,
     val links: List<Link>
 ) {
-    companion object Factory : BuilderFactory<Atom, AtomBuilder> {
+
+    public companion object Factory : BuilderFactory<Atom, AtomBuilder> {
+
         /** Returns a builder implementation for building [Atom] model instances. */
         @JvmStatic
         override fun builder(): AtomBuilder = ValidatingAtomBuilder()

--- a/src/main/kotlin/io/hemin/wien/model/Episode.kt
+++ b/src/main/kotlin/io/hemin/wien/model/Episode.kt
@@ -188,7 +188,7 @@ public data class Episode(
             /** Type describing a trailer episode. */
             TRAILER("trailer");
 
-            public companion object {
+            public companion object Factory {
 
                 /**
                  * Factory method for the instance of the Enum matching the [type] parameter.
@@ -345,7 +345,7 @@ public data class Episode(
                 /** SRT, with full timing information. */
                 SRT("application/srt");
 
-                public companion object {
+                public companion object Factory {
 
                     public fun from(rawType: String): Type? = values().find { it.rawType == rawType }
                 }

--- a/src/main/kotlin/io/hemin/wien/model/Episode.kt
+++ b/src/main/kotlin/io/hemin/wien/model/Episode.kt
@@ -54,7 +54,7 @@ import java.util.Locale
  * @property podcast The data from the Podcast namespace, or null if no data from this namespace was found.
  */
 @Suppress("unused")
-data class Episode(
+public data class Episode(
     val title: String,
     val link: String? = null,
     val description: String? = null,
@@ -74,7 +74,8 @@ data class Episode(
     val podcast: Podcast? = null
 ) {
 
-    companion object Factory : BuilderFactory<Episode, EpisodeBuilder> {
+    public companion object Factory : BuilderFactory<Episode, EpisodeBuilder> {
+
         /** Returns a builder implementation for building [Episode] model instances. */
         @JvmStatic
         override fun builder(): EpisodeBuilder = ValidatingEpisodeBuilder()
@@ -87,12 +88,14 @@ data class Episode(
      * @property length The `length` attribute textContent of the RSS `<enclosure>` element. The media length in seconds.
      * @property type The `type` attribute textContent of the RSS `<enclosure>` element.
      */
-    data class Enclosure(
+    public data class Enclosure(
         val url: String,
         val length: Long,
         val type: String
     ) {
-        companion object Factory : BuilderFactory<Enclosure, EpisodeEnclosureBuilder> {
+
+        public companion object Factory : BuilderFactory<Enclosure, EpisodeEnclosureBuilder> {
+
             /** Returns a builder implementation for building [Enclosure] model instances. */
             @JvmStatic
             override fun builder(): EpisodeEnclosureBuilder = ValidatingEpisodeEnclosureBuilder()
@@ -105,11 +108,13 @@ data class Episode(
      * @property guid The text content of the element.
      * @property isPermalink The boolean interpretation of the `isPermalink` attribute.
      */
-    data class Guid(
+    public data class Guid(
         val guid: String,
         val isPermalink: Boolean? = null
     ) {
-        companion object Factory : BuilderFactory<Guid, EpisodeGuidBuilder> {
+
+        public companion object Factory : BuilderFactory<Guid, EpisodeGuidBuilder> {
+
             /** Returns a builder implementation for building [Guid] model instances. */
             @JvmStatic
             override fun builder(): EpisodeGuidBuilder = ValidatingEpisodeGuidBuilder()
@@ -121,10 +126,12 @@ data class Episode(
      *
      * @property encoded The text content of the `<content:encoded>` element.
      */
-    data class Content(
+    public data class Content(
         val encoded: String
     ) {
-        companion object Factory : BuilderFactory<Content, EpisodeContentBuilder> {
+
+        public companion object Factory : BuilderFactory<Content, EpisodeContentBuilder> {
+
             /** Returns a builder implementation for building [Content] model instances. */
             @JvmStatic
             override fun builder(): EpisodeContentBuilder = ValidatingEpisodeContentBuilder()
@@ -143,7 +150,7 @@ data class Episode(
      * @property episode The numeric value of the `<itunes:episode>` field's text content.
      * @property episodeType The `<itunes:episodeType>` field text content.
      */
-    data class ITunes(
+    public data class ITunes(
         override val title: String? = null,
         val duration: String? = null,
         override val image: HrefOnlyImage? = null,
@@ -157,7 +164,8 @@ data class Episode(
         override val summary: String? = null
     ) : ITunesBase {
 
-        companion object Factory : BuilderFactory<ITunes, EpisodeITunesBuilder> {
+        public companion object Factory : BuilderFactory<ITunes, EpisodeITunesBuilder> {
+
             /** Returns a builder implementation for building [ITunes] model instances. */
             @JvmStatic
             override fun builder(): EpisodeITunesBuilder = ValidatingEpisodeITunesBuilder()
@@ -169,7 +177,7 @@ data class Episode(
          *
          * @property type The string representation of the enum instance.
          */
-        enum class EpisodeType(val type: String) {
+        public enum class EpisodeType(public val type: String) {
 
             /** Type describing a bonus episode. */
             BONUS("bonus"),
@@ -180,15 +188,16 @@ data class Episode(
             /** Type describing a trailer episode. */
             TRAILER("trailer");
 
-            companion object {
+            public companion object {
+
                 /**
                  * Factory method for the instance of the Enum matching the [type] parameter.
                  *
                  * @param type The string representation of the Enum instance.
                  * @return The Enum instance matching [type], or null if not matching instance exists.
                  */
-                fun of(type: String?): EpisodeType? = type?.let {
-                    values().find { t -> t.type == it.toLowerCase() }
+                public fun from(type: String?): EpisodeType? = type?.let {
+                    values().find { value -> value.type == it.toLowerCase() }
                 }
             }
         }
@@ -202,13 +211,15 @@ data class Episode(
      * @property block The logical value of the `<googleplay:block>` field's text content.
      * @property image The data from the `<googleplay:image>` element as an [HrefOnlyImage].
      */
-    data class GooglePlay(
+    public data class GooglePlay(
         override val description: String? = null,
         override val explicit: Boolean? = null,
         override val block: Boolean,
         override val image: HrefOnlyImage? = null
     ) : GooglePlayBase {
-        companion object Factory : BuilderFactory<GooglePlay, EpisodeGooglePlayBuilder> {
+
+        public companion object Factory : BuilderFactory<GooglePlay, EpisodeGooglePlayBuilder> {
+
             /** Returns a builder implementation for building [GooglePlay] model instances. */
             @JvmStatic
             override fun builder(): EpisodeGooglePlayBuilder = ValidatingEpisodeGooglePlayBuilder()
@@ -221,11 +232,12 @@ data class Episode(
      *
      * @property simpleChapters List of data from the `<psc:chapter>` elements as [SimpleChapter] instances.
      */
-    data class Podlove(
+    public data class Podlove(
         val simpleChapters: List<SimpleChapter>
     ) {
 
-        companion object Factory : BuilderFactory<Podlove, EpisodePodloveBuilder> {
+        public companion object Factory : BuilderFactory<Podlove, EpisodePodloveBuilder> {
+
             /** Returns a builder implementation for building [Podlove] model instances. */
             @JvmStatic
             override fun builder(): EpisodePodloveBuilder = ValidatingEpisodePodloveBuilder()
@@ -240,13 +252,15 @@ data class Episode(
          * @property href The value of the chapter's `href` attribute.
          * @property image The value of the chapter's `image` attribute.
          */
-        data class SimpleChapter(
+        public data class SimpleChapter(
             val start: String,
             val title: String,
             val href: String? = null,
             val image: String? = null
         ) {
-            companion object Factory : BuilderFactory<SimpleChapter, EpisodePodloveSimpleChapterBuilder> {
+
+            public companion object Factory : BuilderFactory<SimpleChapter, EpisodePodloveSimpleChapterBuilder> {
+
                 /** Returns a builder implementation for building [SimpleChapter] model instances. */
                 @JvmStatic
                 override fun builder(): EpisodePodloveSimpleChapterBuilder = ValidatingEpisodePodloveSimpleChapterBuilder()
@@ -259,10 +273,12 @@ data class Episode(
      *
      * @property guid The GUID attribute for the RSS enclosure element.
      */
-    data class Bitlove(
+    public data class Bitlove(
         val guid: String
     ) {
-        companion object Factory : BuilderFactory<Bitlove, EpisodeBitloveBuilder> {
+
+        public companion object Factory : BuilderFactory<Bitlove, EpisodeBitloveBuilder> {
+
             /** Returns a builder implementation for building [Bitlove] model instances. */
             @JvmStatic
             override fun builder(): EpisodeBitloveBuilder = ValidatingEpisodeBitloveBuilder()
@@ -276,13 +292,14 @@ data class Episode(
      * @property soundbites The soundbites information for the episode.
      * @property chapters The chapters information for the episode.
      */
-    data class Podcast(
+    public data class Podcast(
         val transcripts: List<Transcript> = emptyList(),
         val soundbites: List<Soundbite> = emptyList(),
         val chapters: Chapters? = null
     ) {
 
-        companion object Factory : BuilderFactory<Podcast, EpisodePodcastBuilder> {
+        public companion object Factory : BuilderFactory<Podcast, EpisodePodcastBuilder> {
+
             /** Returns a builder implementation for building [Podcast] model instances. */
             @JvmStatic
             override fun builder(): EpisodePodcastBuilder = ValidatingEpisodePodcastBuilder()
@@ -296,14 +313,15 @@ data class Episode(
          * @param language The transcript language.
          * @param rel When present and equals to `captions`, the transcript is considered to be a CC, regardless of its [type].
          */
-        data class Transcript(
+        public data class Transcript(
             val url: String,
             val type: Type,
             val language: Locale? = null,
             val rel: String? = null
         ) {
 
-            companion object Factory : BuilderFactory<Transcript, EpisodePodcastTranscriptBuilder> {
+            public companion object Factory : BuilderFactory<Transcript, EpisodePodcastTranscriptBuilder> {
+
                 /** Returns a builder implementation for building [Transcript] model instances. */
                 @JvmStatic
                 override fun builder(): EpisodePodcastTranscriptBuilder = ValidatingEpisodePodcastTranscriptBuilder()
@@ -313,7 +331,8 @@ data class Episode(
              * Supported transcript types. See the
              * [reference docs](https://github.com/Podcastindex-org/podcast-namespace/blob/main/transcripts/transcripts.md).
              */
-            enum class Type(val rawType: String) {
+            public enum class Type(public val rawType: String) {
+
                 /** Plain text, with no timing information. */
                 PLAIN_TEXT("text/plain"),
 
@@ -326,9 +345,9 @@ data class Episode(
                 /** SRT, with full timing information. */
                 SRT("application/srt");
 
-                companion object {
+                public companion object {
 
-                    fun from(rawType: String): Type? = values().find { it.rawType == rawType }
+                    public fun from(rawType: String): Type? = values().find { it.rawType == rawType }
                 }
             }
         }
@@ -340,11 +359,13 @@ data class Episode(
          * @param url The URL for the chapters information.
          * @param type The MIME type of the chapters file. JSON (`application/json+chapters`) is the preferred format.
          */
-        data class Chapters(
+        public data class Chapters(
             val url: String,
             val type: String
         ) {
-            companion object Factory : BuilderFactory<Chapters, EpisodePodcastChaptersBuilder> {
+
+            public companion object Factory : BuilderFactory<Chapters, EpisodePodcastChaptersBuilder> {
+
                 /** Returns a builder implementation for building [Chapters] model instances. */
                 @JvmStatic
                 override fun builder(): EpisodePodcastChaptersBuilder = ValidatingEpisodePodcastChaptersBuilder()
@@ -358,12 +379,14 @@ data class Episode(
          * @param duration The duration of the timestamp (recommended between 15 and 120 seconds).
          * @param title A custom title for the soundbite. When null, the [Episode.title] is used.
          */
-        data class Soundbite(
+        public data class Soundbite(
             val startTime: Duration,
             val duration: Duration,
             val title: String? = null
         ) {
-            companion object Factory : BuilderFactory<Soundbite, EpisodePodcastSoundbiteBuilder> {
+
+            public companion object Factory : BuilderFactory<Soundbite, EpisodePodcastSoundbiteBuilder> {
+
                 /** Returns a builder implementation for building [Soundbite] model instances. */
                 @JvmStatic
                 override fun builder(): EpisodePodcastSoundbiteBuilder = ValidatingEpisodePodcastSoundbiteBuilder()

--- a/src/main/kotlin/io/hemin/wien/model/HrefOnlyImage.kt
+++ b/src/main/kotlin/io/hemin/wien/model/HrefOnlyImage.kt
@@ -8,8 +8,10 @@ import io.hemin.wien.builder.validating.ValidatingHrefOnlyImageBuilder
  *
  * @property href The value of the `href` attribute. Represents the image URL.
  */
-data class HrefOnlyImage(val href: String) {
-    companion object Factory : BuilderFactory<HrefOnlyImage, HrefOnlyImageBuilder> {
+public data class HrefOnlyImage(val href: String) {
+
+    public companion object Factory : BuilderFactory<HrefOnlyImage, HrefOnlyImageBuilder> {
+
         /** Returns a builder implementation for building [HrefOnlyImage] model instances. */
         @JvmStatic
         override fun builder(): HrefOnlyImageBuilder = ValidatingHrefOnlyImageBuilder()

--- a/src/main/kotlin/io/hemin/wien/model/ITunesStyleCategory.kt
+++ b/src/main/kotlin/io/hemin/wien/model/ITunesStyleCategory.kt
@@ -9,9 +9,10 @@ import io.hemin.wien.builder.validating.ValidatingITunesStyleCategoryBuilder
  *
  * @param name The name of the category.
  */
-sealed class ITunesStyleCategory(open val name: String) {
+public sealed class ITunesStyleCategory(public open val name: String) {
 
-    companion object Factory : BuilderFactory<ITunesStyleCategory, ITunesStyleCategoryBuilder> {
+    public companion object Factory : BuilderFactory<ITunesStyleCategory, ITunesStyleCategoryBuilder> {
+
         /** Returns a builder implementation for building [ITunesStyleCategory] model instances. */
         @JvmStatic
         override fun builder(): ITunesStyleCategoryBuilder = ValidatingITunesStyleCategoryBuilder()
@@ -24,7 +25,7 @@ sealed class ITunesStyleCategory(open val name: String) {
      * <itunes:category text="News" />
      * ```
      */
-    data class Simple(override val name: String) : ITunesStyleCategory(name)
+    public data class Simple(override val name: String) : ITunesStyleCategory(name)
 
     /**
      * An iTunes-style category that contains a nested subcategory:
@@ -37,5 +38,5 @@ sealed class ITunesStyleCategory(open val name: String) {
      *
      * @param subcategory The nested [Simple] subcategory.
      */
-    data class Nested(override val name: String, val subcategory: Simple) : ITunesStyleCategory(name)
+    public data class Nested(override val name: String, val subcategory: Simple) : ITunesStyleCategory(name)
 }

--- a/src/main/kotlin/io/hemin/wien/model/Link.kt
+++ b/src/main/kotlin/io/hemin/wien/model/Link.kt
@@ -14,7 +14,7 @@ import io.hemin.wien.builder.validating.ValidatingLinkBuilder
  * @property title The title of the link.
  * @property type The type of the link.
  */
-data class Link(
+public data class Link(
     val href: String,
     val hrefLang: String? = null,
     val hrefResolved: String? = null,
@@ -23,7 +23,9 @@ data class Link(
     val title: String? = null,
     val type: String? = null
 ) {
-    companion object Factory : BuilderFactory<Link, LinkBuilder> {
+
+    public companion object Factory : BuilderFactory<Link, LinkBuilder> {
+
         /** Returns a builder implementation for building [Link] model instances. */
         @JvmStatic
         override fun builder(): LinkBuilder = ValidatingLinkBuilder()

--- a/src/main/kotlin/io/hemin/wien/model/Person.kt
+++ b/src/main/kotlin/io/hemin/wien/model/Person.kt
@@ -10,12 +10,14 @@ import io.hemin.wien.builder.validating.ValidatingPersonBuilder
  * @property email The email of the person.
  * @property uri The uri of the person.
  */
-data class Person(
+public data class Person(
     val name: String,
     val email: String? = null,
     val uri: String? = null
 ) {
-    companion object Factory : BuilderFactory<Person, PersonBuilder> {
+
+    public companion object Factory : BuilderFactory<Person, PersonBuilder> {
+
         /** Returns a builder implementation for building [Person] model instances. */
         @JvmStatic
         override fun builder(): PersonBuilder = ValidatingPersonBuilder()

--- a/src/main/kotlin/io/hemin/wien/model/Podcast.kt
+++ b/src/main/kotlin/io/hemin/wien/model/Podcast.kt
@@ -128,7 +128,7 @@ public data class Podcast(
             /** Type describing a serial show. */
             SERIAL("serial");
 
-            public companion object {
+            public companion object Factory {
 
                 /**
                  * Factory method for the instance of the Enum matching the [type] parameter.

--- a/src/main/kotlin/io/hemin/wien/model/Podcast.kt
+++ b/src/main/kotlin/io/hemin/wien/model/Podcast.kt
@@ -43,7 +43,7 @@ import java.time.temporal.TemporalAccessor
  * @property categories The RSS feed categories, if any.
  * @property podcast The data from the Podcast namespace, or null if no data from this namespace was found.
  */
-data class Podcast(
+public data class Podcast(
     val title: String,
     val link: String,
     val description: String,
@@ -67,7 +67,8 @@ data class Podcast(
     val podcast: Podcast? = null
 ) {
 
-    companion object Factory : BuilderFactory<io.hemin.wien.model.Podcast, PodcastBuilder> {
+    public companion object Factory : BuilderFactory<io.hemin.wien.model.Podcast, PodcastBuilder> {
+
         /** Returns a builder implementation for building [io.hemin.wien.model.Podcast] model instances. */
         @JvmStatic
         override fun builder(): PodcastBuilder = ValidatingPodcastBuilder()
@@ -90,7 +91,7 @@ data class Podcast(
      * @property owner The `<itunes:title>` field text content.
      * @property owner The `<itunes:new-feed-url>` field text content.
      */
-    data class ITunes(
+    public data class ITunes(
         override val subtitle: String? = null,
         override val summary: String? = null,
         override val image: HrefOnlyImage?,
@@ -106,7 +107,8 @@ data class Podcast(
         val newFeedUrl: String? = null
     ) : ITunesBase {
 
-        companion object Factory : BuilderFactory<ITunes, PodcastITunesBuilder> {
+        public companion object Factory : BuilderFactory<ITunes, PodcastITunesBuilder> {
+
             /** Returns a builder implementation for building [ITunes] model instances. */
             @JvmStatic
             override fun builder(): PodcastITunesBuilder = ValidatingPodcastITunesBuilder()
@@ -118,7 +120,7 @@ data class Podcast(
          *
          * @property type The string representation of the Enum instance.
          */
-        enum class ShowType(val type: String) {
+        public enum class ShowType(public val type: String) {
 
             /** Type describing an episodic show. */
             EPISODIC("episodic"),
@@ -126,14 +128,15 @@ data class Podcast(
             /** Type describing a serial show. */
             SERIAL("serial");
 
-            companion object {
+            public companion object {
+
                 /**
                  * Factory method for the instance of the Enum matching the [type] parameter.
                  *
                  * @param type The string representation of the Enum instance.
                  * @return The Enum instance matching [type], or null if not matching instance exists.
                  */
-                fun of(type: String?): ShowType? = type?.let {
+                public fun from(type: String?): ShowType? = type?.let {
                     values().find { t -> t.type == it.toLowerCase() }
                 }
             }
@@ -151,7 +154,7 @@ data class Podcast(
      * @property block The logical value of the `<googleplay:block>` field's text content.
      * @property image The data from the `<googleplay:image>` element as an [HrefOnlyImage].
      */
-    data class GooglePlay(
+    public data class GooglePlay(
         val author: String? = null,
         val owner: String? = null,
         val categories: List<ITunesStyleCategory>,
@@ -160,7 +163,9 @@ data class Podcast(
         override val block: Boolean,
         override val image: HrefOnlyImage? = null
     ) : GooglePlayBase {
-        companion object Factory : BuilderFactory<GooglePlay, PodcastGooglePlayBuilder> {
+
+        public companion object Factory : BuilderFactory<GooglePlay, PodcastGooglePlayBuilder> {
+
             /** Returns a builder implementation for building [GooglePlay] model instances. */
             @JvmStatic
             override fun builder(): PodcastGooglePlayBuilder = ValidatingPodcastGooglePlayBuilder()
@@ -172,10 +177,12 @@ data class Podcast(
      *
      * @property verify The Podcast's verification token.
      */
-    data class Fyyd(
+    public data class Fyyd(
         val verify: String
     ) {
-        companion object Factory : BuilderFactory<Fyyd, PodcastFyydBuilder> {
+
+        public companion object Factory : BuilderFactory<Fyyd, PodcastFyydBuilder> {
+
             /** Returns a builder implementation for building [Fyyd] model instances. */
             @JvmStatic
             override fun builder(): PodcastFyydBuilder = ValidatingPodcastFyydBuilder()
@@ -191,14 +198,16 @@ data class Podcast(
      * @property cssFile The feed's custom CSS file.
      * @property link An alternative link to podcast or RSS clients.
      */
-    data class Feedpress(
+    public data class Feedpress(
         val newsletterId: String? = null,
         val locale: String? = null,
         val podcastId: String? = null,
         val cssFile: String? = null,
         val link: String? = null
     ) {
-        companion object Factory : BuilderFactory<Feedpress, PodcastFeedpressBuilder> {
+
+        public companion object Factory : BuilderFactory<Feedpress, PodcastFeedpressBuilder> {
+
             /** Returns a builder implementation for building [Feedpress] model instances. */
             @JvmStatic
             override fun builder(): PodcastFeedpressBuilder = ValidatingPodcastFeedpressBuilder()
@@ -211,12 +220,13 @@ data class Podcast(
      * @property locked The lock status of the podcast.
      * @property funding The funding information for the podcast.
      */
-    data class Podcast(
+    public data class Podcast(
         val locked: Locked? = null,
         val funding: List<Funding> = emptyList()
     ) {
 
-        companion object Factory : BuilderFactory<Podcast, PodcastPodcastBuilder> {
+        public companion object Factory : BuilderFactory<Podcast, PodcastPodcastBuilder> {
+
             /** Returns a builder implementation for building [Podcast] model instances. */
             @JvmStatic
             override fun builder(): PodcastPodcastBuilder = ValidatingPodcastPodcastBuilder()
@@ -229,11 +239,13 @@ data class Podcast(
          * @param owner An email address that can be used to verify ownership when moving hosting platforms.
          * @param locked When `true`, the podcast cannot be transferred to a new hosting platform.
          */
-        data class Locked(
+        public data class Locked(
             val owner: String,
             val locked: Boolean
         ) {
-            companion object Factory : BuilderFactory<Locked, PodcastPodcastLockedBuilder> {
+
+            public companion object Factory : BuilderFactory<Locked, PodcastPodcastLockedBuilder> {
+
                 /** Returns a builder implementation for building [Locked] model instances. */
                 @JvmStatic
                 override fun builder(): PodcastPodcastLockedBuilder = ValidatingPodcastPodcastLockedBuilder()
@@ -246,11 +258,13 @@ data class Podcast(
          * @param url The URL where listeners can find funding information for the podcast.
          * @param message The recommended CTA text to show users for the funding link.
          */
-        data class Funding(
+        public data class Funding(
             val url: String,
             val message: String
         ) {
-            companion object Factory : BuilderFactory<Funding, PodcastPodcastFundingBuilder> {
+
+            public companion object Factory : BuilderFactory<Funding, PodcastPodcastFundingBuilder> {
+
                 /** Returns a builder implementation for building [Funding] model instances. */
                 @JvmStatic
                 override fun builder(): PodcastPodcastFundingBuilder = ValidatingPodcastPodcastFundingBuilder()

--- a/src/main/kotlin/io/hemin/wien/model/RssCategory.kt
+++ b/src/main/kotlin/io/hemin/wien/model/RssCategory.kt
@@ -13,8 +13,10 @@ import io.hemin.wien.builder.validating.ValidatingRssCategoryBuilder
  * @param name The name of the category.
  * @param domain A name or URL identifying a categorization taxonomy.
  */
-data class RssCategory(val name: String, val domain: String? = null) {
-    companion object Factory : BuilderFactory<RssCategory, RssCategoryBuilder> {
+public data class RssCategory(val name: String, val domain: String? = null) {
+
+    public companion object Factory : BuilderFactory<RssCategory, RssCategoryBuilder> {
+
         /** Returns a builder implementation for building [RssCategory] model instances. */
         @JvmStatic
         override fun builder(): RssCategoryBuilder = ValidatingRssCategoryBuilder()

--- a/src/main/kotlin/io/hemin/wien/model/RssImage.kt
+++ b/src/main/kotlin/io/hemin/wien/model/RssImage.kt
@@ -27,7 +27,7 @@ import io.hemin.wien.builder.validating.ValidatingRssImageBuilder
  * @property height The numeric value of an RSS `<height>` element inside an `<image>` element.
  * @property description The value of an RSS `<description>` element inside an `<image>`.
  */
-data class RssImage(
+public data class RssImage(
     val url: String,
     val title: String,
     val link: String,
@@ -35,7 +35,9 @@ data class RssImage(
     val height: Int? = null,
     val description: String? = null
 ) {
-    companion object Factory : BuilderFactory<RssImage, RssImageBuilder> {
+
+    public companion object Factory : BuilderFactory<RssImage, RssImageBuilder> {
+
         /** Returns a builder implementation for building [RssImage] model instances. */
         @JvmStatic
         override fun builder(): RssImageBuilder = ValidatingRssImageBuilder()

--- a/src/main/kotlin/io/hemin/wien/parser/DateParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/DateParser.kt
@@ -1,5 +1,6 @@
 package io.hemin.wien.parser
 
+import io.hemin.wien.util.InternalApi
 import java.time.LocalDateTime
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
@@ -15,6 +16,7 @@ import java.util.Locale
  * Various formats are supported. This class attempts to find the correct
  * format to produce the intended date object.
  */
+@InternalApi
 internal object DateParser {
 
     private val dayOfWeek = mapOf(

--- a/src/main/kotlin/io/hemin/wien/parser/NamespaceParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/NamespaceParser.kt
@@ -5,9 +5,11 @@ import io.hemin.wien.builder.podcast.PodcastBuilder
 import io.hemin.wien.dom.isDirectChildOf
 import io.hemin.wien.util.FeedNamespace
 import io.hemin.wien.util.FeedNamespace.Companion.matches
+import io.hemin.wien.util.InternalApi
 import org.w3c.dom.Node
 
 /** Base class for XML namespace parser implementations. */
+@InternalApi
 internal abstract class NamespaceParser {
 
     /** The URI of the namespace processed by this parser. */

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/AtomParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/AtomParser.kt
@@ -10,6 +10,7 @@ import io.hemin.wien.dom.getAttributeValueByName
 import io.hemin.wien.dom.toPersonBuilder
 import io.hemin.wien.parser.NamespaceParser
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.InternalApi
 import org.w3c.dom.Node
 
 /**
@@ -17,6 +18,7 @@ import org.w3c.dom.Node
  *
  * The namespace URI is: `http://www.w3.org/2005/Atom`
  */
+@InternalApi
 internal object AtomParser : NamespaceParser() {
 
     override val namespace = FeedNamespace.ATOM

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/BitloveParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/BitloveParser.kt
@@ -6,6 +6,7 @@ import io.hemin.wien.dom.getAttributeValueByName
 import io.hemin.wien.dom.isDirectChildOf
 import io.hemin.wien.parser.NamespaceParser
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.InternalApi
 import org.w3c.dom.Node
 
 /**
@@ -13,6 +14,7 @@ import org.w3c.dom.Node
  *
  * The namespace URI is: `http://bitlove.org`
  */
+@InternalApi
 internal object BitloveParser : NamespaceParser() {
 
     override val namespace = FeedNamespace.BITLOVE

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/ContentParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/ContentParser.kt
@@ -5,6 +5,7 @@ import io.hemin.wien.builder.podcast.PodcastBuilder
 import io.hemin.wien.dom.textOrNull
 import io.hemin.wien.parser.NamespaceParser
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.InternalApi
 import org.w3c.dom.Node
 
 /**
@@ -12,6 +13,7 @@ import org.w3c.dom.Node
  *
  * The namespace URI is: `http://purl.org/rss/1.0/modules/content/`
  */
+@InternalApi
 internal object ContentParser : NamespaceParser() {
 
     override val namespace = FeedNamespace.CONTENT

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/FeedpressParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/FeedpressParser.kt
@@ -5,6 +5,7 @@ import io.hemin.wien.builder.podcast.PodcastBuilder
 import io.hemin.wien.dom.textOrNull
 import io.hemin.wien.parser.NamespaceParser
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.InternalApi
 import org.w3c.dom.Node
 
 /**
@@ -12,6 +13,7 @@ import org.w3c.dom.Node
  *
  * The namespace URI is: `https://feed.press/xmlns`
  */
+@InternalApi
 internal object FeedpressParser : NamespaceParser() {
 
     override val namespace = FeedNamespace.FEEDPRESS

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/FyydParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/FyydParser.kt
@@ -5,6 +5,7 @@ import io.hemin.wien.builder.podcast.PodcastBuilder
 import io.hemin.wien.dom.textOrNull
 import io.hemin.wien.parser.NamespaceParser
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.InternalApi
 import org.w3c.dom.Node
 
 /**
@@ -12,6 +13,7 @@ import org.w3c.dom.Node
  *
  * The namespace URI is: `https://fyyd.de/fyyd-ns/`
  */
+@InternalApi
 internal object FyydParser : NamespaceParser() {
 
     override val namespace = FeedNamespace.FYYD

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/GooglePlayParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/GooglePlayParser.kt
@@ -8,6 +8,7 @@ import io.hemin.wien.dom.toHrefOnlyImageBuilder
 import io.hemin.wien.dom.toITunesCategoryBuilder
 import io.hemin.wien.parser.NamespaceParser
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.InternalApi
 import org.w3c.dom.Node
 
 /**
@@ -15,6 +16,7 @@ import org.w3c.dom.Node
  *
  * The namespace URI is: `http://www.google.com/schemas/play-podcasts/1.0`
  */
+@InternalApi
 internal object GooglePlayParser : NamespaceParser() {
 
     override val namespace = FeedNamespace.GOOGLE_PLAY

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/ITunesParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/ITunesParser.kt
@@ -11,6 +11,7 @@ import io.hemin.wien.dom.toITunesCategoryBuilder
 import io.hemin.wien.dom.toPersonBuilder
 import io.hemin.wien.parser.NamespaceParser
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.InternalApi
 import org.w3c.dom.Node
 
 /**
@@ -18,6 +19,7 @@ import org.w3c.dom.Node
  *
  * The namespace URI is: `http://www.itunes.com/dtds/podcast-1.0.dtd`
  */
+@InternalApi
 internal object ITunesParser : NamespaceParser() {
 
     override val namespace = FeedNamespace.ITUNES

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/PodcastNamespaceParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/PodcastNamespaceParser.kt
@@ -12,6 +12,7 @@ import io.hemin.wien.dom.textAsBooleanOrNull
 import io.hemin.wien.model.Episode
 import io.hemin.wien.parser.NamespaceParser
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.InternalApi
 import io.hemin.wien.util.isNullOrNegative
 import io.hemin.wien.util.isNullOrNotPositive
 import io.hemin.wien.util.trimmedOrNullIfBlank
@@ -20,6 +21,12 @@ import java.time.Duration
 import java.time.format.DateTimeParseException
 import java.util.Locale
 
+/**
+ * Parser implementation for the PodcastIndex namespace.
+ *
+ * The namespace URI is: `https://podcastindex.org/namespace/1.0`
+ */
+@InternalApi
 internal object PodcastNamespaceParser : NamespaceParser() {
 
     override val namespace: FeedNamespace = FeedNamespace.PODCAST

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/PodloveSimpleChapterParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/PodloveSimpleChapterParser.kt
@@ -7,6 +7,7 @@ import io.hemin.wien.dom.asListOfNodes
 import io.hemin.wien.dom.getAttributeValueByName
 import io.hemin.wien.parser.NamespaceParser
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.InternalApi
 import org.w3c.dom.Node
 
 /**
@@ -14,6 +15,7 @@ import org.w3c.dom.Node
  *
  * The namespace URI is: `http://podlove.org/simple-chapters`
  */
+@InternalApi
 internal object PodloveSimpleChapterParser : NamespaceParser() {
 
     override val namespace = FeedNamespace.PODLOVE_SIMPLE_CHAPTER

--- a/src/main/kotlin/io/hemin/wien/parser/namespace/RssParser.kt
+++ b/src/main/kotlin/io/hemin/wien/parser/namespace/RssParser.kt
@@ -13,6 +13,7 @@ import io.hemin.wien.dom.toRssCategoryBuilder
 import io.hemin.wien.dom.toRssImageBuilder
 import io.hemin.wien.parser.NamespaceParser
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.InternalApi
 import org.w3c.dom.Element
 import org.w3c.dom.Node
 
@@ -23,6 +24,7 @@ import org.w3c.dom.Node
  *
  * The RSS specification is described []here][http://www.rssboard.org/rss-2-0].
  */
+@InternalApi
 internal object RssParser : NamespaceParser() {
 
     override val namespace: FeedNamespace? = null

--- a/src/main/kotlin/io/hemin/wien/util/BooleanStringStyle.kt
+++ b/src/main/kotlin/io/hemin/wien/util/BooleanStringStyle.kt
@@ -3,6 +3,7 @@ package io.hemin.wien.util
 /**
  * Indicates how a boolean value should be written as a string.
  */
+@InternalApi
 internal enum class BooleanStringStyle(val trueValue: String, val falseValue: String?) {
     /** A true value will be written as `true`, a false value as `false`. */
     TRUE_FALSE("true", "false"),
@@ -17,5 +18,6 @@ internal enum class BooleanStringStyle(val trueValue: String, val falseValue: St
     YES_NO("yes", "no")
 }
 
+@InternalApi
 internal fun Boolean.asBooleanString(style: BooleanStringStyle) =
     if (this) style.trueValue else style.falseValue

--- a/src/main/kotlin/io/hemin/wien/util/BuilderExtensions.kt
+++ b/src/main/kotlin/io/hemin/wien/util/BuilderExtensions.kt
@@ -3,18 +3,22 @@ package io.hemin.wien.util
 import io.hemin.wien.builder.Builder
 
 /** Check if all argument elements are not null */
+@InternalApi
 internal fun allNotNull(vararg elements: Any?): Boolean = elements.all { p -> p != null }
 
 /** Check if at least one argument element is not null */
+@InternalApi
 internal fun anyNotNull(vararg elements: Any?): Boolean = elements.any { p -> p != null }
 
 /** Check if all argument elements are null */
+@InternalApi
 internal fun allNull(vararg elements: Any?): Boolean = elements.all { p -> p == null }
 
 /**
  * Calls [callback] when [model] is not null
  * @return The [this] context from which [whenNotNull] was called.
  */
+@InternalApi
 internal fun <T : Any, R : Builder<T>> R.whenNotNull(model: T?, callback: (T) -> Unit): R {
     model?.let(callback)
     return this

--- a/src/main/kotlin/io/hemin/wien/util/CollectionsExtensions.kt
+++ b/src/main/kotlin/io/hemin/wien/util/CollectionsExtensions.kt
@@ -15,34 +15,34 @@ import io.hemin.wien.model.RssCategory
 
 /** Transforms this list into a list of [RssCategoryBuilder] */
 @JvmName("asRssCategoryBuilders")
-internal fun List<RssCategory>.asBuilders(): List<RssCategoryBuilder> = this.map(RssCategory.builder()::from)
+public fun List<RssCategory>.asBuilders(): List<RssCategoryBuilder> = map(RssCategory.builder()::from)
 
 /** Transforms this list into a list of [ITunesStyleCategoryBuilder] */
 @JvmName("asItunesCategoryBuilders")
-internal fun List<ITunesStyleCategory>.asBuilders(): List<ITunesStyleCategoryBuilder> = this.map(ITunesStyleCategory.builder()::from)
+public fun List<ITunesStyleCategory>.asBuilders(): List<ITunesStyleCategoryBuilder> = map(ITunesStyleCategory.builder()::from)
 
 /** Transforms this list into a list of [EpisodeEnclosureBuilder] */
 @JvmName("asEnclosureBuilders")
-internal fun List<Episode.Enclosure>.asBuilders(): List<EpisodeEnclosureBuilder> = this.map(Episode.Enclosure.builder()::from)
+public fun List<Episode.Enclosure>.asBuilders(): List<EpisodeEnclosureBuilder> = map(Episode.Enclosure.builder()::from)
 
 /** Transforms this list into a list of [EpisodePodcastSoundbiteBuilder] */
 @JvmName("asSoundbiteBuilders")
-internal fun List<Episode.Podcast.Soundbite>.asBuilders(): List<EpisodePodcastSoundbiteBuilder> = this.map(Episode.Podcast.Soundbite.builder()::from)
+public fun List<Episode.Podcast.Soundbite>.asBuilders(): List<EpisodePodcastSoundbiteBuilder> = map(Episode.Podcast.Soundbite.builder()::from)
 
 /** Transforms this list into a list of [EpisodePodcastTranscriptBuilder] */
 @JvmName("asTranscriptBuilders")
-internal fun List<Episode.Podcast.Transcript>.asBuilders(): List<EpisodePodcastTranscriptBuilder> =
-    this.map(Episode.Podcast.Transcript.builder()::from)
+public fun List<Episode.Podcast.Transcript>.asBuilders(): List<EpisodePodcastTranscriptBuilder> =
+    map(Episode.Podcast.Transcript.builder()::from)
 
 /** Transforms this list into a list of [PodcastPodcastFundingBuilder] */
 @JvmName("asFundingBuilders")
-internal fun List<Podcast.Podcast.Funding>.asBuilders(): List<PodcastPodcastFundingBuilder> = this.map(Podcast.Podcast.Funding.builder()::from)
+public fun List<Podcast.Podcast.Funding>.asBuilders(): List<PodcastPodcastFundingBuilder> = map(Podcast.Podcast.Funding.builder()::from)
 
 /** Transforms this list into a list of [EpisodePodloveSimpleChapterBuilder] */
 @JvmName("asSimpleChapterBuilders")
-internal fun List<Episode.Podlove.SimpleChapter>.asBuilders(): List<EpisodePodloveSimpleChapterBuilder> =
-    this.map(Episode.Podlove.SimpleChapter.builder()::from)
+public fun List<Episode.Podlove.SimpleChapter>.asBuilders(): List<EpisodePodloveSimpleChapterBuilder> =
+    map(Episode.Podlove.SimpleChapter.builder()::from)
 
 /** Transforms this list into a list of [EpisodeBuilder] */
 @JvmName("asEpisodeBuilders")
-internal fun List<Episode>.asBuilders(): List<EpisodeBuilder> = this.map(Episode.builder()::from)
+public fun List<Episode>.asBuilders(): List<EpisodeBuilder> = map(Episode.builder()::from)

--- a/src/main/kotlin/io/hemin/wien/util/CollectionsExtensions.kt
+++ b/src/main/kotlin/io/hemin/wien/util/CollectionsExtensions.kt
@@ -14,35 +14,43 @@ import io.hemin.wien.model.Podcast
 import io.hemin.wien.model.RssCategory
 
 /** Transforms this list into a list of [RssCategoryBuilder] */
+@InternalApi
 @JvmName("asRssCategoryBuilders")
-public fun List<RssCategory>.asBuilders(): List<RssCategoryBuilder> = map(RssCategory.builder()::from)
+internal fun List<RssCategory>.asBuilders(): List<RssCategoryBuilder> = map(RssCategory.builder()::from)
 
 /** Transforms this list into a list of [ITunesStyleCategoryBuilder] */
+@InternalApi
 @JvmName("asItunesCategoryBuilders")
-public fun List<ITunesStyleCategory>.asBuilders(): List<ITunesStyleCategoryBuilder> = map(ITunesStyleCategory.builder()::from)
+internal fun List<ITunesStyleCategory>.asBuilders(): List<ITunesStyleCategoryBuilder> = map(ITunesStyleCategory.builder()::from)
 
 /** Transforms this list into a list of [EpisodeEnclosureBuilder] */
+@InternalApi
 @JvmName("asEnclosureBuilders")
-public fun List<Episode.Enclosure>.asBuilders(): List<EpisodeEnclosureBuilder> = map(Episode.Enclosure.builder()::from)
+internal fun List<Episode.Enclosure>.asBuilders(): List<EpisodeEnclosureBuilder> = map(Episode.Enclosure.builder()::from)
 
 /** Transforms this list into a list of [EpisodePodcastSoundbiteBuilder] */
+@InternalApi
 @JvmName("asSoundbiteBuilders")
-public fun List<Episode.Podcast.Soundbite>.asBuilders(): List<EpisodePodcastSoundbiteBuilder> = map(Episode.Podcast.Soundbite.builder()::from)
+internal fun List<Episode.Podcast.Soundbite>.asBuilders(): List<EpisodePodcastSoundbiteBuilder> = map(Episode.Podcast.Soundbite.builder()::from)
 
 /** Transforms this list into a list of [EpisodePodcastTranscriptBuilder] */
+@InternalApi
 @JvmName("asTranscriptBuilders")
-public fun List<Episode.Podcast.Transcript>.asBuilders(): List<EpisodePodcastTranscriptBuilder> =
+internal fun List<Episode.Podcast.Transcript>.asBuilders(): List<EpisodePodcastTranscriptBuilder> =
     map(Episode.Podcast.Transcript.builder()::from)
 
 /** Transforms this list into a list of [PodcastPodcastFundingBuilder] */
+@InternalApi
 @JvmName("asFundingBuilders")
-public fun List<Podcast.Podcast.Funding>.asBuilders(): List<PodcastPodcastFundingBuilder> = map(Podcast.Podcast.Funding.builder()::from)
+internal fun List<Podcast.Podcast.Funding>.asBuilders(): List<PodcastPodcastFundingBuilder> = map(Podcast.Podcast.Funding.builder()::from)
 
 /** Transforms this list into a list of [EpisodePodloveSimpleChapterBuilder] */
+@InternalApi
 @JvmName("asSimpleChapterBuilders")
-public fun List<Episode.Podlove.SimpleChapter>.asBuilders(): List<EpisodePodloveSimpleChapterBuilder> =
+internal fun List<Episode.Podlove.SimpleChapter>.asBuilders(): List<EpisodePodloveSimpleChapterBuilder> =
     map(Episode.Podlove.SimpleChapter.builder()::from)
 
 /** Transforms this list into a list of [EpisodeBuilder] */
+@InternalApi
 @JvmName("asEpisodeBuilders")
-public fun List<Episode>.asBuilders(): List<EpisodeBuilder> = map(Episode.builder()::from)
+internal fun List<Episode>.asBuilders(): List<EpisodeBuilder> = map(Episode.builder()::from)

--- a/src/main/kotlin/io/hemin/wien/util/DateTimeExtensions.kt
+++ b/src/main/kotlin/io/hemin/wien/util/DateTimeExtensions.kt
@@ -8,4 +8,5 @@ import java.time.temporal.TemporalAccessor
  *
  * @return The string representing the value in the chosen style.
  */
+@InternalApi
 internal fun TemporalAccessor.asDateString() = DateFormatter.formatAsRfc2822(this)

--- a/src/main/kotlin/io/hemin/wien/util/DurationExtensions.kt
+++ b/src/main/kotlin/io/hemin/wien/util/DurationExtensions.kt
@@ -3,7 +3,9 @@ package io.hemin.wien.util
 import java.time.Duration
 
 /** Returns `true` when this duration is either `null` or negative. */
+@InternalApi
 internal fun Duration?.isNullOrNegative(): Boolean = this == null || this.isNegative
 
 /** Returns `true` when this duration is either `null` or zero or negative. */
+@InternalApi
 internal fun Duration?.isNullOrNotPositive(): Boolean = this == null || this.isZero || this.isNegative

--- a/src/main/kotlin/io/hemin/wien/util/FeedNamespace.kt
+++ b/src/main/kotlin/io/hemin/wien/util/FeedNamespace.kt
@@ -1,5 +1,6 @@
 package io.hemin.wien.util
 
+@InternalApi
 internal enum class FeedNamespace(
     val prefix: String,
     val uri: String,

--- a/src/main/kotlin/io/hemin/wien/util/InternalApi.kt
+++ b/src/main/kotlin/io/hemin/wien/util/InternalApi.kt
@@ -1,0 +1,7 @@
+package io.hemin.wien.util
+
+@RequiresOptIn(
+    level = RequiresOptIn.Level.ERROR,
+    message = "This API is meant to be internal, please do not use it. Or, use it, but don't complain when it breaks :)"
+)
+public annotation class InternalApi

--- a/src/main/kotlin/io/hemin/wien/util/StringExtensions.kt
+++ b/src/main/kotlin/io/hemin/wien/util/StringExtensions.kt
@@ -1,11 +1,12 @@
 package io.hemin.wien.util
 
 /** Returns the trimmed string, or null if it was blank to begin with. */
+@InternalApi
 internal fun String?.trimmedOrNullIfBlank(): String? {
     if (this == null) return null
-    val trimmed = trim()
-    return if (trimmed.isNotEmpty()) trimmed else null
+    return trim().ifEmpty { null }
 }
 
 /** Returns `true` when this string is neither `null` nor blank. */
+@InternalApi
 internal fun String?.isNeitherNullNorBlank(): Boolean = this != null && isNotBlank()

--- a/src/main/kotlin/io/hemin/wien/writer/DateFormatter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/DateFormatter.kt
@@ -1,8 +1,10 @@
 package io.hemin.wien.writer
 
+import io.hemin.wien.util.InternalApi
 import java.time.format.DateTimeFormatter
 import java.time.temporal.TemporalAccessor
 
+@InternalApi
 internal object DateFormatter {
 
     private val formatter = DateTimeFormatter.RFC_1123_DATE_TIME

--- a/src/main/kotlin/io/hemin/wien/writer/NamespaceWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/NamespaceWriter.kt
@@ -3,10 +3,12 @@ package io.hemin.wien.writer
 import io.hemin.wien.model.Episode
 import io.hemin.wien.model.Podcast
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.InternalApi
 import org.w3c.dom.Element
 import org.w3c.dom.Node
 
 /** Base class for XML namespace writer implementations. */
+@InternalApi
 internal abstract class NamespaceWriter {
 
     /** The URI of the namespace written to by this writer. */

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/AtomWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/AtomWriter.kt
@@ -7,6 +7,7 @@ import io.hemin.wien.model.Link
 import io.hemin.wien.model.Person
 import io.hemin.wien.model.Podcast
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.InternalApi
 import io.hemin.wien.util.isNeitherNullNorBlank
 import io.hemin.wien.writer.NamespaceWriter
 import org.w3c.dom.Element
@@ -16,6 +17,7 @@ import org.w3c.dom.Element
  *
  * The namespace URI is: `http://www.w3.org/2005/Atom`
  */
+@InternalApi
 internal object AtomWriter : NamespaceWriter() {
 
     override val namespace = FeedNamespace.ATOM

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/BitloveWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/BitloveWriter.kt
@@ -5,6 +5,7 @@ import io.hemin.wien.dom.setAttributeWithNS
 import io.hemin.wien.model.Episode
 import io.hemin.wien.model.Podcast
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.InternalApi
 import io.hemin.wien.writer.NamespaceWriter
 import org.w3c.dom.Element
 
@@ -13,6 +14,7 @@ import org.w3c.dom.Element
  *
  * The namespace URI is: `http://bitlove.org`
  */
+@InternalApi
 internal object BitloveWriter : NamespaceWriter() {
 
     override val namespace = FeedNamespace.BITLOVE

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/ContentWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/ContentWriter.kt
@@ -4,6 +4,7 @@ import io.hemin.wien.dom.appendElement
 import io.hemin.wien.model.Episode
 import io.hemin.wien.model.Podcast
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.InternalApi
 import io.hemin.wien.writer.NamespaceWriter
 import org.w3c.dom.Element
 
@@ -12,6 +13,7 @@ import org.w3c.dom.Element
  *
  * The namespace URI is: `http://purl.org/rss/1.0/modules/content/`
  */
+@InternalApi
 internal object ContentWriter : NamespaceWriter() {
 
     override val namespace = FeedNamespace.CONTENT

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/FeedpressWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/FeedpressWriter.kt
@@ -4,6 +4,7 @@ import io.hemin.wien.dom.appendElement
 import io.hemin.wien.model.Episode
 import io.hemin.wien.model.Podcast
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.InternalApi
 import io.hemin.wien.util.isNeitherNullNorBlank
 import io.hemin.wien.writer.NamespaceWriter
 import org.w3c.dom.Element
@@ -13,6 +14,7 @@ import org.w3c.dom.Element
  *
  * The namespace URI is: `https://feed.press/xmlns`
  */
+@InternalApi
 internal object FeedpressWriter : NamespaceWriter() {
 
     override val namespace = FeedNamespace.FEEDPRESS

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/FyydWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/FyydWriter.kt
@@ -4,6 +4,7 @@ import io.hemin.wien.dom.appendElement
 import io.hemin.wien.model.Episode
 import io.hemin.wien.model.Podcast
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.InternalApi
 import io.hemin.wien.writer.NamespaceWriter
 import org.w3c.dom.Element
 
@@ -12,6 +13,7 @@ import org.w3c.dom.Element
  *
  * The namespace URI is: `https://fyyd.de/fyyd-ns/`
  */
+@InternalApi
 internal object FyydWriter : NamespaceWriter() {
 
     override val namespace = FeedNamespace.FYYD

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/GooglePlayWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/GooglePlayWriter.kt
@@ -9,6 +9,7 @@ import io.hemin.wien.model.Episode
 import io.hemin.wien.model.GooglePlayBase
 import io.hemin.wien.model.Podcast
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.InternalApi
 import io.hemin.wien.util.isNeitherNullNorBlank
 import io.hemin.wien.writer.NamespaceWriter
 import org.w3c.dom.Element
@@ -18,6 +19,7 @@ import org.w3c.dom.Element
  *
  * The namespace URI is: `http://www.google.com/schemas/play-podcasts/1.0`
  */
+@InternalApi
 internal object GooglePlayWriter : NamespaceWriter() {
 
     override val namespace = FeedNamespace.GOOGLE_PLAY

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/ITunesWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/ITunesWriter.kt
@@ -10,6 +10,7 @@ import io.hemin.wien.model.Episode
 import io.hemin.wien.model.ITunesBase
 import io.hemin.wien.model.Podcast
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.InternalApi
 import io.hemin.wien.util.isNeitherNullNorBlank
 import io.hemin.wien.writer.NamespaceWriter
 import org.w3c.dom.Element
@@ -19,6 +20,7 @@ import org.w3c.dom.Element
  *
  * The namespace URI is: `http://www.itunes.com/dtds/podcast-1.0.dtd`
  */
+@InternalApi
 internal object ITunesWriter : NamespaceWriter() {
 
     override val namespace = FeedNamespace.ITUNES

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/PodcastNamespaceWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/PodcastNamespaceWriter.kt
@@ -5,6 +5,7 @@ import io.hemin.wien.model.Episode
 import io.hemin.wien.model.Podcast
 import io.hemin.wien.util.BooleanStringStyle
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.InternalApi
 import io.hemin.wien.util.asBooleanString
 import io.hemin.wien.writer.NamespaceWriter
 import org.w3c.dom.Element
@@ -17,6 +18,7 @@ import java.time.Duration
  * but `https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md`
  * should also be accepted as equivalent. TODO allow both NS
  */
+@InternalApi
 internal object PodcastNamespaceWriter : NamespaceWriter() {
 
     override val namespace = FeedNamespace.PODCAST

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/PodloveSimpleChapterWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/PodloveSimpleChapterWriter.kt
@@ -4,6 +4,7 @@ import io.hemin.wien.dom.appendElement
 import io.hemin.wien.model.Episode
 import io.hemin.wien.model.Podcast
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.InternalApi
 import io.hemin.wien.util.isNeitherNullNorBlank
 import io.hemin.wien.writer.NamespaceWriter
 import org.w3c.dom.Element
@@ -13,6 +14,7 @@ import org.w3c.dom.Element
  *
  * The namespace URI is: `http://podlove.org/simple-chapters`
  */
+@InternalApi
 internal object PodloveSimpleChapterWriter : NamespaceWriter() {
 
     override val namespace = FeedNamespace.PODLOVE_SIMPLE_CHAPTER

--- a/src/main/kotlin/io/hemin/wien/writer/namespace/RssWriter.kt
+++ b/src/main/kotlin/io/hemin/wien/writer/namespace/RssWriter.kt
@@ -7,6 +7,7 @@ import io.hemin.wien.model.Episode
 import io.hemin.wien.model.Podcast
 import io.hemin.wien.util.BooleanStringStyle
 import io.hemin.wien.util.FeedNamespace
+import io.hemin.wien.util.InternalApi
 import io.hemin.wien.util.asBooleanString
 import io.hemin.wien.util.asDateString
 import io.hemin.wien.util.isNeitherNullNorBlank
@@ -20,6 +21,7 @@ import org.w3c.dom.Element
  *
  * `http://www.rssboard.org/rss-2-0`
  */
+@InternalApi
 internal object RssWriter : NamespaceWriter() {
 
     /** Standard RSS 2.0 elements do not have a namespace. This value is therefore null. */

--- a/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodeITunesBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/episode/FakeEpisodeITunesBuilder.kt
@@ -33,7 +33,7 @@ internal class FakeEpisodeITunesBuilder : FakeBuilder<Episode.ITunes>(), Episode
 
     override fun episode(episode: Int?): EpisodeITunesBuilder = apply { this.episode = episode }
 
-    override fun episodeType(episodeType: String?): EpisodeITunesBuilder = apply { this.episodeType = Episode.ITunes.EpisodeType.of(episodeType) }
+    override fun episodeType(episodeType: String?): EpisodeITunesBuilder = apply { this.episodeType = Episode.ITunes.EpisodeType.from(episodeType) }
 
     override fun author(author: String?): EpisodeITunesBuilder = apply { this.author = author }
 

--- a/src/test/kotlin/io/hemin/wien/builder/fake/podcast/FakePodcastITunesBuilder.kt
+++ b/src/test/kotlin/io/hemin/wien/builder/fake/podcast/FakePodcastITunesBuilder.kt
@@ -44,7 +44,7 @@ internal class FakePodcastITunesBuilder : FakeBuilder<Podcast.ITunes>(), Podcast
 
     override fun complete(complete: Boolean): PodcastITunesBuilder = apply { this.complete = complete }
 
-    override fun type(type: String?): PodcastITunesBuilder = apply { this.type = Podcast.ITunes.ShowType.of(type) }
+    override fun type(type: String?): PodcastITunesBuilder = apply { this.type = Podcast.ITunes.ShowType.from(type) }
 
     override fun ownerBuilder(ownerBuilder: PersonBuilder?): PodcastITunesBuilder = apply { this.ownerBuilder = ownerBuilder }
 


### PR DESCRIPTION
This PR:
 1. Updates Kotlin to 1.4.30 and Gradle to 6.8.2
 2. Enables [explicit API mode](https://kotlinlang.org/docs/reference/whatsnew14.html#explicit-api-mode-for-library-authors) and adds explicit visibility modifier everywhere
 3. Adds an `@InternalApi` annotation that will cause errors in clients that attempt to use `internal` APIs (should work in Java, too), in the same way that Coroutines handle this.
 4. Tweaks the IDE code style to match actual code style in the project
 5. Applies some minor code changes (add KDoc, reformat, increase visibility)

Note: this PR is only supposed to be merged _after_ #38 is merged. The diff will be a bit smaller once that's done.